### PR TITLE
Use custom Result alias

### DIFF
--- a/src/cmd_create.rs
+++ b/src/cmd_create.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use std::{fs::OpenOptions, path::PathBuf};
 
-pub fn cmd_basic(password: &str, iterations: u32, output: PathBuf, force: bool) -> Result<()> {
+pub fn cmd_basic(password: &str, iterations: u32, output: PathBuf, force: bool) -> Result {
     let keypair = Keypair::gen_keypair();
     let wallet = Wallet::Basic(basic::Wallet::Decrypted {
         keypair,
@@ -32,7 +32,7 @@ pub fn cmd_sharded(
     iterations: u32,
     output: PathBuf,
     force: bool,
-) -> Result<()> {
+) -> Result {
     let keypair = Keypair::gen_keypair();
 
     let wallet = Wallet::Sharded(sharded::Wallet::Decrypted {

--- a/src/cmd_verify.rs
+++ b/src/cmd_verify.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use std::{fs, path::PathBuf};
 
-pub fn cmd_verify(files: Vec<PathBuf>, password: &str) -> Result<()> {
+pub fn cmd_verify(files: Vec<PathBuf>, password: &str) -> Result {
     let first_file = files.first().expect("At least one file expected");
     let is_sharded = {
         let mut reader = fs::File::open(first_file)?;
@@ -50,7 +50,7 @@ fn print_wallet(
     sharded: bool,
     files: Vec<PathBuf>,
     verify: Option<Result<Wallet>>,
-) -> Result<()> {
+) -> Result {
     let file_names: Vec<String> = files.iter().map(|pb| pb.display().to_string()).collect();
     println!("Address: {}", public_key.to_b58()?);
     println!("Sharded: {}", sharded);
@@ -58,7 +58,7 @@ fn print_wallet(
     if let Some(result) = verify {
         let msg = match result {
             Ok(_) => "true".to_string(),
-            Err(m) => m.to_string()
+            Err(m) => m.to_string(),
         };
         println!("Verify: {}", msg);
     };

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -61,7 +61,7 @@ impl fmt::Debug for Keypair {
 }
 
 impl ReadWrite for Keypair {
-    fn write(&self, writer: &mut dyn io::Write) -> Result<()> {
+    fn write(&self, writer: &mut dyn io::Write) -> Result {
         writer.write_all(&[KEYTYPE_ED25519])?;
         writer.write_all(&self.secret.0)?;
         writer.write_all(&self.public.0)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,9 @@ mod result;
 mod traits;
 mod wallet;
 
-use std::error::Error;
+use result::Result;
 use std::path::PathBuf;
 use std::process;
-use std::result::Result;
 use structopt::StructOpt;
 
 /// Create and manage Helium wallets
@@ -88,7 +87,7 @@ fn get_password(confirm: bool) -> std::io::Result<String> {
     builder.interact()
 }
 
-fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
+fn run(cli: Cli) -> Result {
     match cli {
         Cli::Info { files } => cmd_info::cmd_info(files),
         Cli::Verify { files } => {

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,1 +1,1 @@
-pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,7 +10,7 @@ pub trait ReadWrite {
     fn read(reader: &mut dyn Read) -> Result<Self>
     where
         Self: std::marker::Sized;
-    fn write(&self, writer: &mut dyn Write) -> Result<()>;
+    fn write(&self, writer: &mut dyn Write) -> Result;
 }
 
 pub trait B58 {
@@ -24,9 +24,8 @@ pub trait Empty {
     fn empty() -> Self;
 }
 
-
 impl ReadWrite for ed25519::PublicKey {
-    fn write(&self, writer: &mut dyn io::Write) -> Result<()> {
+    fn write(&self, writer: &mut dyn io::Write) -> Result {
         writer.write_all(&[KEYTYPE_ED25519])?;
         writer.write_all(&self.0)?;
         Ok(())

--- a/src/wallet/basic_wallet.rs
+++ b/src/wallet/basic_wallet.rs
@@ -58,7 +58,7 @@ impl ReadWrite for Wallet {
         Ok(wallet)
     }
 
-    fn write(&self, writer: &mut dyn io::Write) -> Result<()> {
+    fn write(&self, writer: &mut dyn io::Write) -> Result {
         match self {
             Wallet::Decrypted { .. } => Err("not an encrypted wallet".into()),
             Wallet::Encrypted {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -51,7 +51,7 @@ impl ReadWrite for Wallet {
         }
     }
 
-    fn write(&self, writer: &mut dyn io::Write) -> Result<()> {
+    fn write(&self, writer: &mut dyn io::Write) -> Result {
         match self {
             Wallet::Basic(wallet) => {
                 writer.write_u16::<LittleEndian>(0x0001)?;
@@ -218,7 +218,7 @@ pub fn stretch_password(
     iterations: u32,
     salt: &mut Salt,
     key: &mut AESKey,
-) -> Result<()> {
+) -> Result {
     randombytes::randombytes_into(salt);
     re_stretch_password(password, iterations, *salt, key)
 }
@@ -228,7 +228,7 @@ pub fn re_stretch_password(
     iterations: u32,
     salt: Salt,
     key: &mut AESKey,
-) -> Result<()> {
+) -> Result {
     pbkdf2::pbkdf2::<Hmac<Sha256>>(password, &salt, iterations as usize, &mut key[..]);
     Ok(())
 }
@@ -240,7 +240,7 @@ pub fn encrypt_keypair(
     pubkey_bin: &mut PubKeyBin,
     encrypted: &mut Vec<u8>,
     tag: &mut Tag,
-) -> Result<()> {
+) -> Result {
     randombytes::randombytes_into(iv);
 
     let mut pubkey_writer: &mut [u8] = pubkey_bin;

--- a/src/wallet/sharded_wallet.rs
+++ b/src/wallet/sharded_wallet.rs
@@ -77,7 +77,7 @@ impl ReadWrite for Wallet {
         Ok(wallet)
     }
 
-    fn write(&self, writer: &mut dyn io::Write) -> Result<()> {
+    fn write(&self, writer: &mut dyn io::Write) -> Result {
         match self {
             Wallet::Decrypted { .. } => Err("not an encrypted wallet".into()),
             Wallet::Encrypted {


### PR DESCRIPTION
Convert explicit uses of `Result<T, Box<dyn std::error::Error>>` to the already aliased `Result<T = ()>`.