### PR TITLE
Remove redundant flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,6 @@ version = "0.1.0"
 authors = ["Marc Nijdam <marc@helium.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[profile.release]
-debug = false
-
 [dependencies]
 byteorder = "1.3.2"
 structopt = "0.3.2"


### PR DESCRIPTION
`debug = false` is the default for release builds.