### PR TITLE
Replace custom Empty trait with Default

### DIFF
--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -1,6 +1,6 @@
 use crate::{
     result::Result,
-    traits::{Empty, ReadWrite, B58},
+    traits::{ReadWrite, B58},
 };
 use byteorder::ReadBytesExt;
 use sodiumoxide::crypto::sign::ed25519;
@@ -11,7 +11,15 @@ pub const KEYTYPE_ED25519: u8 = 1;
 
 pub use ed25519::PublicKey;
 pub use ed25519::SecretKey;
-pub type PubKeyBin = [u8; 33];
+
+// Newtype to allow us to `impl Default` on a 33 element array.
+pub struct PubKeyBin(pub(crate) [u8; 33]);
+
+impl Default for PubKeyBin {
+    fn default() -> Self {
+        PubKeyBin([0; 33])
+    }
+}
 
 pub struct Keypair {
     pub public: PublicKey,
@@ -24,12 +32,6 @@ fn init() {
             panic!("Failed to intialize sodium {:?}", e)
         }
     })
-}
-
-impl Empty for PubKeyBin {
-    fn empty() -> Self {
-        [0; 33]
-    }
 }
 
 impl Keypair {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -20,10 +20,6 @@ pub trait B58 {
         Self: std::marker::Sized;
 }
 
-pub trait Empty {
-    fn empty() -> Self;
-}
-
 impl ReadWrite for ed25519::PublicKey {
     fn write(&self, writer: &mut dyn io::Write) -> Result {
         writer.write_all(&[KEYTYPE_ED25519])?;

--- a/src/wallet/basic_wallet.rs
+++ b/src/wallet/basic_wallet.rs
@@ -1,7 +1,7 @@
 use crate::{
     keypair::{Keypair, PubKeyBin, PublicKey},
     result::Result,
-    traits::{Empty, ReadWrite, B58},
+    traits::{ReadWrite, B58},
     wallet::{self, AESKey, Salt, Tag, IV},
 };
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -89,7 +89,7 @@ impl Wallet {
                 iterations,
                 keypair,
             } => {
-                let mut pubkey_bin = PubKeyBin::empty();;
+                let mut pubkey_bin = PubKeyBin::default();
                 let mut iv = IV::default();
                 let mut tag = Tag::default();
                 let mut encrypted = Vec::new();

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -243,14 +243,14 @@ pub fn encrypt_keypair(
 ) -> Result {
     randombytes::randombytes_into(iv);
 
-    let mut pubkey_writer: &mut [u8] = pubkey_bin;
+    let mut pubkey_writer: &mut [u8] = &mut pubkey_bin.0;
     keypair.public.write(&mut pubkey_writer)?;
 
     use aead::generic_array::GenericArray;
     let aead = Aes256Gcm::new(*GenericArray::from_slice(key));
 
     keypair.write(encrypted)?;
-    match aead.encrypt_in_place_detached(iv.as_ref().into(), pubkey_bin, encrypted) {
+    match aead.encrypt_in_place_detached(iv.as_ref().into(), &pubkey_bin.0, encrypted) {
         Err(_) => Err("Failed to encrypt wallet".into()),
         Ok(gtag) => {
             tag.copy_from_slice(&gtag);

--- a/src/wallet/sharded_wallet.rs
+++ b/src/wallet/sharded_wallet.rs
@@ -1,7 +1,7 @@
 use crate::{
     keypair::{Keypair, PubKeyBin, PublicKey},
     result::Result,
-    traits::{Empty, ReadWrite, B58},
+    traits::{ReadWrite, B58},
     wallet::{self, AESKey, Salt, Tag, IV},
 };
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -116,7 +116,7 @@ impl Wallet {
                 key_share_count,
                 recovery_threshold,
             } => {
-                let mut pubkey_bin = PubKeyBin::empty();;
+                let mut pubkey_bin = PubKeyBin::default();
                 let mut iv = IV::default();
                 let mut tag = Tag::default();
                 let mut encrypted = Vec::new();


### PR DESCRIPTION
This PR wraps `PubKeyBin` as a newtype, allowing us to remove the custom `Empty` trait, and use `Default` instead.
