### PR TITLE
Remove unnecessary `clone()`s

### DIFF
--- a/src/cmd_create.rs
+++ b/src/cmd_create.rs
@@ -19,7 +19,7 @@ pub fn cmd_basic(password: &str, iterations: u32, output: PathBuf, force: bool) 
         .write(true)
         .create(true)
         .create_new(!force)
-        .open(output.clone())?;
+        .open(&output)?;
 
     enc_wallet[0].write(&mut writer)?;
     crate::cmd_verify::cmd_verify(vec![output], password)

--- a/src/cmd_verify.rs
+++ b/src/cmd_verify.rs
@@ -30,14 +30,14 @@ pub fn cmd_verify(files: Vec<PathBuf>, password: &str) -> Result {
         )?;
         Ok(())
     } else {
-        for file in files.iter() {
+        for file in files {
             let mut reader = fs::File::open(&file)?;
             let enc_wallet = Wallet::read(&mut reader)?;
             let result = wallet::Wallet::decrypt_basic(password.as_bytes(), &enc_wallet);
             print_wallet(
                 enc_wallet.public_key(),
                 is_sharded,
-                vec![file.clone()],
+                vec![file],
                 Some(result),
             )?;
         }


### PR DESCRIPTION
These clones are not in a hot-path here, so they're not a big deal, but we should try avoid `.clone()`s when possible.