### PR TITLE
Refactor Wallets with Trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,13 +67,13 @@ name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -146,7 +146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -160,19 +160,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "console"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clicolors-control 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -201,7 +201,7 @@ name = "dialoguer"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "console 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -230,7 +230,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -245,11 +245,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -266,7 +266,7 @@ name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ dependencies = [
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shamirsecretsharing 0.1.4 (git+https://github.com/dsprenkels/sss-rs)",
  "sodiumoxide 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -302,7 +302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.62"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -321,10 +321,10 @@ name = "libsodium-sys"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -366,14 +366,14 @@ name = "proc-macro-error"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -384,7 +384,7 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -392,8 +392,8 @@ name = "rand"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -413,7 +413,7 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -457,7 +457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -476,8 +476,8 @@ name = "shamirsecretsharing"
 version = "0.1.4"
 source = "git+https://github.com/dsprenkels/sss-rs#0516716f0f87b4d0522d61df78b0d35275ca7694"
 dependencies = [
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -485,9 +485,9 @@ name = "sodiumoxide"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -497,23 +497,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "structopt"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "structopt-derive"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -528,10 +528,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -547,7 +547,7 @@ version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -558,7 +558,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -570,7 +570,7 @@ name = "termios"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -588,7 +588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -649,7 +649,7 @@ name = "xattr"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -666,7 +666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
-"checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
+"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
@@ -674,11 +674,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-"checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
+"checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
-"checksum console 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62828f51cfa18f8c31d3d55a43c6ce6af3f87f754cba9fbba7ff38089b9f5612"
+"checksum console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f5d540c2d34ac9dd0deb5f3b5f54c36c79efa78f6b3ad19106a554d07a7b5d9f"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum dialoguer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "116f66c4e7b19af0d52857aa4ff710cc3b4781d9c16616e31540bc55ec57ba8c"
@@ -687,21 +687,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd7380b54ced79dda72ecc35cc4fbbd1da6bba54afaa37e96fd1c2a308cd469"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
+"checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum ghash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b78de4273e3a6ccb458928e416527eb3e379e967be0da491b40183041e660809"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
+"checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
 "checksum libsodium-sys 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1c344ff12b90ef8fa1f0fffacd348c1fd041db331841fec9eab23fdb991f5e73"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
-"checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
+"checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum polyval 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26b1ba4ccd4520b84b1c39cd7b4ca1ce3378053c5a012ff262e7131ec7f08226"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
-"checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
+"checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
 "checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
@@ -712,23 +712,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
-"checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
+"checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum shamirsecretsharing 0.1.4 (git+https://github.com/dsprenkels/sss-rs)" = "<none>"
 "checksum sodiumoxide 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585232e78a4fc18133eef9946d3080befdf68b906c51b621531c37e91787fa2b"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe8d3289b63ef2f196d89e7701f986583c0895e764b78f052a55b9b5d34d84a"
-"checksum structopt-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f3add731f5b4fb85931d362a3c92deb1ad7113649a8d51701fb257673705f122"
+"checksum structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4f66a4c0ddf7aee4677995697366de0749b0139057342eccbb609b12d0affc"
+"checksum structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fe0c13e476b4e21ff7f5c4ace3818b6d7bdc16897c31c73862471bc1663acae"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab3af2eb31c42e8f0ccf43548232556c42737e01a96db6e1777b0be108e79799"
-"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
+"checksum syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
-"checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
+"checksum unicode-segmentation 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49f5526225fd8b77342d5986ab5f6055552e9c0776193b5b63fd53b46debfad7"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum universal-hash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df0c900f2f9b4116803415878ff48b63da9edb268668e08cf9292d7503114a01"

--- a/src/cmd_create.rs
+++ b/src/cmd_create.rs
@@ -3,13 +3,13 @@ use crate::{
     keypair::Keypair,
     result::Result,
     traits::ReadWrite,
-    wallet::{basic, sharded, Wallet},
+    wallet::{basic::BasicWallet, sharded::ShardedWallet, Wallet},
 };
 use std::{fs::OpenOptions, path::PathBuf};
 
 pub fn cmd_basic(password: &str, iterations: u32, output: PathBuf, force: bool) -> Result {
     let keypair = Keypair::gen_keypair();
-    let wallet = Wallet::Basic(basic::Wallet::Decrypted {
+    let wallet = Wallet::Basic(BasicWallet::Decrypted {
         keypair,
         iterations,
     });
@@ -35,7 +35,7 @@ pub fn cmd_sharded(
 ) -> Result {
     let keypair = Keypair::gen_keypair();
 
-    let wallet = Wallet::Sharded(sharded::Wallet::Decrypted {
+    let wallet = Wallet::Sharded(ShardedWallet::Decrypted {
         iterations,
         keypair,
         key_share_count,

--- a/src/cmd_info.rs
+++ b/src/cmd_info.rs
@@ -1,16 +1,24 @@
 use crate::{
     traits::{ReadWrite, B58},
-    wallet::Wallet,
+    wallet::{Wallet, WalletReadWrite},
 };
 use std::{error::Error, fs, path::PathBuf, result::Result};
 
 pub fn cmd_info(files: Vec<PathBuf>) -> Result<(), Box<dyn Error>> {
     for file in files {
         let mut reader = fs::File::open(&file)?;
-        let enc_wallet = Wallet::read(&mut reader)?;
-        println!("Address: {}", enc_wallet.public_key().to_b58()?);
-        println!("Sharded: {}", enc_wallet.is_sharded());
-        println!("File: {}", file.display());
+        let enc_wallet = WalletReadWrite::read(&mut reader)?;
+        match enc_wallet {
+            WalletReadWrite::Basic(wallet) => {
+                println!("Address: {}", wallet.public_key().to_b58()?);
+                println!("File: {}", file.display());
+            }
+            WalletReadWrite::Sharded(wallet) => {
+                println!("Address: {}", wallet.public_key().to_b58()?);
+                println!("Shards: {}", wallet.num_shards());
+                println!("File: {}", file.display());
+            }
+        }
     }
     Ok(())
 }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1,15 +1,15 @@
 use crate::{
-    keypair::{self, Keypair, PubKeyBin, PublicKey},
+    keypair::{self, Keypair, PublicKey},
     result::Result,
     traits::ReadWrite,
 };
 use aead::NewAead;
 use aes_gcm::Aes256Gcm;
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{LittleEndian, ReadBytesExt};
 use hmac::{Hmac, Mac};
 use pbkdf2;
 use sha2::Sha256;
-use shamirsecretsharing::hazmat::{combine_keyshares, create_keyshares};
+use shamirsecretsharing::hazmat::combine_keyshares;
 use sodiumoxide::randombytes;
 use std::io::{self, Cursor};
 
@@ -19,7 +19,8 @@ pub type IV = [u8; 12];
 pub type AESKey = [u8; 32];
 pub type SSSKey = [u8; 32];
 
-type HmacSha256 = Hmac<Sha256>;
+const WALLET_TYPE_BYTES_BASIC: u16 = 0x0001;
+const WALLET_TYPE_BYTES_SHARDED: u16 = 0x0101;
 
 mod basic_wallet;
 use basic_wallet::BasicWallet;
@@ -32,22 +33,22 @@ pub mod sharded {
     pub use crate::wallet::sharded_wallet::*;
 }
 
-pub enum Wallet {
+pub enum WalletReadWrite {
     Basic(BasicWallet),
     Sharded(ShardedWallet),
 }
 
-impl ReadWrite for Wallet {
-    fn read(reader: &mut dyn io::Read) -> Result<Wallet> {
+impl ReadWrite for WalletReadWrite {
+    fn read(reader: &mut dyn io::Read) -> Result<WalletReadWrite> {
         let kind = reader.read_u16::<LittleEndian>()?;
         match kind {
-            0x0001 => {
+            WALLET_TYPE_BYTES_BASIC => {
                 let wallet = BasicWallet::read(reader)?;
-                Ok(Wallet::Basic(wallet))
+                Ok(WalletReadWrite::Basic(wallet))
             }
-            0x0101 => {
+            WALLET_TYPE_BYTES_SHARDED => {
                 let wallet = ShardedWallet::read(reader)?;
-                Ok(Wallet::Sharded(wallet))
+                Ok(WalletReadWrite::Sharded(wallet))
             }
             _ => Err(format!("Invalid wallet type {}", kind).into()),
         }
@@ -55,164 +56,72 @@ impl ReadWrite for Wallet {
 
     fn write(&self, writer: &mut dyn io::Write) -> Result {
         match self {
-            Wallet::Basic(wallet) => {
-                writer.write_u16::<LittleEndian>(0x0001)?;
-                wallet.write(writer)
-            }
-            Wallet::Sharded(wallet) => {
-                writer.write_u16::<LittleEndian>(0x0101)?;
-                wallet.write(writer)
-            }
+            WalletReadWrite::Basic(wallet) => wallet.write(writer),
+            WalletReadWrite::Sharded(wallet) => wallet.write(writer),
         }
     }
 }
 
-impl Wallet {
-    pub fn is_sharded(&self) -> bool {
-        match self {
-            Wallet::Sharded(_) => true,
-            _ => false,
+pub trait Wallet {
+    fn public_key(&self) -> &keypair::PublicKey;
+    fn decrypt(&mut self, password: &[u8; 32]) -> Result<()>;
+    fn encrypt(&mut self, password: &AESKey, salt: Salt) -> Result<()>;
+    fn derive_aes_key(&self, password: &[u8], out_salt: Option<&mut Salt>) -> Result<AESKey>;
+}
+
+pub fn decrypt_basic(password: &[u8], mut wallet: BasicWallet) -> Result<BasicWallet> {
+    let aes_key = wallet.derive_aes_key(password, None)?;
+    wallet.decrypt(&aes_key)?;
+    Ok(wallet)
+}
+
+pub fn decrypt_sharded(password: &[u8], mut shards: Vec<ShardedWallet>) -> Result<ShardedWallet> {
+    let first_wallet = shards.first().expect("No wallet shards provided");
+    let (k, n, aes_key) = match first_wallet {
+        ShardedWallet::Encrypted {
+            recovery_threshold,
+            key_share_count,
+            iterations,
+            salt,
+            ..
+        } => {
+            let mut aes_key = AESKey::default();
+            re_stretch_password(password, *iterations, *salt, &mut aes_key)?;
+            (*recovery_threshold, *key_share_count, aes_key)
         }
-    }
-
-    pub fn public_key(&self) -> &keypair::PublicKey {
-        match self {
-            Wallet::Basic(wallet) => wallet.public_key(),
-            Wallet::Sharded(wallet) => wallet.public_key(),
-        }
-    }
-
-    pub fn encrypt(&self, password: &[u8]) -> Result<Vec<Wallet>> {
-        match self {
-            Wallet::Basic(wallet) => match wallet {
-                BasicWallet::Encrypted { .. } => Err("Wallet already encrypted".into()),
-                BasicWallet::Decrypted { .. } => {
-                    let mut salt = Salt::default();
-                    let aes_key = self.derive_aes_key(password, Some(&mut salt))?;
-                    let enc_wallet = wallet.encrypt(&aes_key, salt)?;
-                    Ok(vec![Wallet::Basic(enc_wallet)])
-                }
-            },
-            Wallet::Sharded(sh) => match sh {
-                ShardedWallet::Encrypted { .. } => Err("Wallet already encrypted".into()),
-                ShardedWallet::Decrypted {
-                    recovery_threshold,
-                    key_share_count,
-                    ..
-                } => {
-                    let mut salt = Salt::default();
-                    let aes_key = self.derive_aes_key(password, Some(&mut salt))?;
-
-                    let mut sss_key = SSSKey::default();
-                    randombytes::randombytes_into(&mut sss_key);
-                    let final_key = derive_sharded_aes_key(&sss_key, &aes_key)?;
-
-                    let key_shares =
-                        create_keyshares(&sss_key, *key_share_count, *recovery_threshold)?;
-
-                    let enc_wallet = sh.encrypt(&final_key, salt)?;
-
-                    let mut wallets = Vec::with_capacity(key_shares.len());
-                    for key_share in key_shares {
-                        let wallet_share = Wallet::Sharded(enc_wallet.with_key_share(&key_share)?);
-                        wallets.push(wallet_share);
-                    }
-                    Ok(wallets)
-                }
-            },
-        }
-    }
-
-    pub fn decrypt(&self, password: &AESKey) -> Result<Wallet> {
-        match self {
-            Wallet::Basic(wallet) => {
-                let dec_wallet = wallet.decrypt(password)?;
-                Ok(Wallet::Basic(dec_wallet))
-            }
-            Wallet::Sharded(wallet) => {
-                let dec_wallet = wallet.decrypt(password)?;
-                Ok(Wallet::Sharded(dec_wallet))
-            }
-        }
-    }
-
-    fn derive_aes_key(&self, password: &[u8], out_salt: Option<&mut Salt>) -> Result<AESKey> {
-        let mut aes_key = AESKey::default();
-        match self {
-            Wallet::Basic(BasicWallet::Encrypted {
-                salt, iterations, ..
-            }) => re_stretch_password(password, *iterations, *salt, &mut aes_key)?,
-            Wallet::Basic(BasicWallet::Decrypted { iterations, .. }) => {
-                stretch_password(password, *iterations, out_salt.unwrap(), &mut aes_key)?
-            }
-            Wallet::Sharded(ShardedWallet::Encrypted {
-                salt, iterations, ..
-            }) => re_stretch_password(password, *iterations, *salt, &mut aes_key)?,
-            Wallet::Sharded(ShardedWallet::Decrypted { iterations, .. }) => {
-                stretch_password(password, *iterations, out_salt.unwrap(), &mut aes_key)?
-            }
-        };
-        Ok(aes_key)
-    }
-
-    pub fn decrypt_basic(password: &[u8], wallet: &Wallet) -> Result<Wallet> {
-        let aes_key = wallet.derive_aes_key(password, None)?;
-        wallet.decrypt(&aes_key)
-    }
-
-    pub fn decrypt_sharded(password: &[u8], shards: &[Wallet]) -> Result<Wallet> {
-        let first_wallet = shards.first().expect("No wallet shards provided");
-        let (k, n, aes_key) = match first_wallet {
-            Wallet::Sharded(ShardedWallet::Encrypted {
+        _ => return Err("Not an encrypted wallet".into()),
+    };
+    if shards.len() < k as usize {
+        return Err("Not enough shards to recover the key".into());
+    };
+    // Check if shards are all encrypted and congruent
+    let mut key_shares = Vec::new();
+    for shard in shards.iter() {
+        match shard {
+            ShardedWallet::Encrypted {
                 recovery_threshold,
                 key_share_count,
+                key_share,
                 ..
-            }) => {
-                let aes_key = first_wallet.derive_aes_key(password, None)?;
-                (*recovery_threshold, *key_share_count, aes_key)
-            }
-            _ => return Err("Not a sharded wallet".into()),
-        };
-        if shards.len() < k as usize {
-            return Err("Not enough shards to recover the key".into());
-        };
-        // Check if shards are all encrypted and congruent
-        let mut key_shares = Vec::new();
-        for shard in shards {
-            match shard {
-                Wallet::Sharded(ShardedWallet::Encrypted {
-                    recovery_threshold,
-                    key_share_count,
-                    key_share,
-                    ..
-                }) => {
-                    if *recovery_threshold != k || *key_share_count != n {
-                        return Err("Shards not congruent".into());
-                    }
-                    key_shares.push(key_share.to_vec());
+            } => {
+                if *recovery_threshold != k || *key_share_count != n {
+                    return Err("Shards not congruent".into());
                 }
-                _ => return Err("Not a sharded wallet".into()),
+                key_shares.push(key_share.to_vec());
             }
+            _ => return Err("Not an encrypted wallet".into()),
         }
-
-        let mut sss_key = SSSKey::default();
-        match combine_keyshares(&key_shares) {
-            Ok(k) => sss_key.copy_from_slice(&k),
-            Err(_) => return Err("Failed to combine keyshares".into()),
-        };
-        let final_key = derive_sharded_aes_key(&sss_key, &aes_key)?;
-
-        first_wallet.decrypt(&final_key)
     }
-}
 
-fn derive_sharded_aes_key(sss_key: &SSSKey, aes_key: &AESKey) -> Result<AESKey> {
-    let mut hmac = match HmacSha256::new_varkey(sss_key) {
-        Err(_) => return Err("Failed to initialize hmac".into()),
-        Ok(m) => m,
+    let mut sss_key = SSSKey::default();
+    match combine_keyshares(&key_shares) {
+        Ok(k) => sss_key.copy_from_slice(&k),
+        Err(_) => return Err("Failed to combine keyshares".into()),
     };
-    hmac.input(aes_key);
-    Ok(hmac.result().code().into())
+    let final_key = sharded_wallet::derive_sharded_aes_key(&sss_key, &aes_key)?;
+
+    shards[0].decrypt(&final_key)?;
+    Ok(shards.remove(0))
 }
 
 pub fn stretch_password(
@@ -235,28 +144,24 @@ pub fn re_stretch_password(
     Ok(())
 }
 
-pub fn encrypt_keypair(
-    keypair: &keypair::Keypair,
-    key: &AESKey,
-    iv: &mut IV,
-    pubkey_bin: &mut PubKeyBin,
-    encrypted: &mut Vec<u8>,
-    tag: &mut Tag,
-) -> Result {
-    randombytes::randombytes_into(iv);
-
-    let mut pubkey_writer: &mut [u8] = &mut pubkey_bin.0;
+pub fn encrypt_keypair(keypair: &keypair::Keypair, key: &AESKey) -> Result<(IV, Tag, Vec<u8>)> {
+    let mut pubkey_bin = [0; 33];
+    let mut iv = IV::default();
+    let mut tag = Tag::default();
+    let mut encrypted = Vec::new();
+    randombytes::randombytes_into(&mut iv);
+    let mut pubkey_writer: &mut [u8] = &mut pubkey_bin;
     keypair.public.write(&mut pubkey_writer)?;
 
     use aead::generic_array::GenericArray;
     let aead = Aes256Gcm::new(*GenericArray::from_slice(key));
 
-    keypair.write(encrypted)?;
-    match aead.encrypt_in_place_detached(iv.as_ref().into(), &pubkey_bin.0, encrypted) {
+    keypair.write(&mut encrypted)?;
+    match aead.encrypt_in_place_detached(iv.as_ref().into(), &mut pubkey_bin, &mut encrypted) {
         Err(_) => Err("Failed to encrypt wallet".into()),
         Ok(gtag) => {
             tag.copy_from_slice(&gtag);
-            Ok(())
+            Ok((iv, tag, encrypted))
         }
     }
 }


### PR DESCRIPTION
Not sure if this really "adds" anything other than avoiding the following match pattern:
``` rust
pub fn encrypt(&self, password: &[u8]) -> Result<Vec<Wallet>> {
        match self {
            Wallet::Basic(wallet) => match wallet {
                basic::Wallet::Encrypted
                basic::Wallet::Decrypted
            }
            Wallet::Sharded(sh) => match sh {
                sharded::Wallet::Encrypted 
                sharded::Wallet::Decrypted
            }
}
```
And instead implements a Trait for each Wallet type.

One thing I would consider as a next step would be to make Encrypted and Decrypted wallets different types, and thus break out the Trait Wallet into Encrypted and Decrypted Wallet. This would let the compiler avoid the following run-time paths:
``` rust
(1)
fn decrypt(&mut self, password: &[u8; 32]) -> Result<()> {
        match self {
            ShardedWallet::Decrypted { .. } => Err("not an encrypted wallet".into()),
...

(2)
    fn encrypt(&mut self, password: &AESKey, salt: Salt) -> Result<()> {
        match self {
            ShardedWallet::Encrypted { .. } => Err("not an decrypted wallet".into()),
...
```
