### PR TITLE
Add create and redeem HTLC commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,7 @@ dependencies = [
  "dialoguer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "helium-api 0.2.0 (git+https://github.com/helium/helium-api-rs?tag=0.2.0)",
  "helium-proto 0.1.0 (git+https://github.com/helium/proto)",
+ "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -653,6 +654,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hmac"
@@ -2173,6 +2179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum helium-api 0.2.0 (git+https://github.com/helium/helium-api-rs?tag=0.2.0)" = "<none>"
 "checksum helium-proto 0.1.0 (git+https://github.com/helium/proto)" = "<none>"
 "checksum hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
+"checksum hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 "checksum http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ structopt = "0.3.2"
 dialoguer = "0.4.0"
 bs58 = {version = "0.3.0", features=["check"]}
 sodiumoxide = "0.2.5"
+hex = "0.4.2"
 hmac = "0.7.1"
 sha2 = "0.8.0"
 pbkdf2 = {version = "0.3.0", default-features=false }

--- a/src/cmd_hotspots.rs
+++ b/src/cmd_hotspots.rs
@@ -29,9 +29,9 @@ fn print_results(results: Vec<(String, Result<Vec<Hotspot>>)>) {
                     table.add_row(row![
                         hotspot.address,
                         hotspot.name.unwrap_or_else(|| "unknown".to_string()),
-                        hotspot.location.unwrap_or_else(|| "uknown".to_string()),
-                        hotspot.geocode.short_city.unwrap_or_else(|| "uknown".to_string()),
-                        hotspot.geocode.short_state.unwrap_or_else(|| "uknown".to_string()),
+                        hotspot.location.unwrap_or_else(|| "uknnown".to_string()),
+                        hotspot.geocode.short_city.unwrap_or_else(|| "unknown".to_string()),
+                        hotspot.geocode.short_state.unwrap_or_else(|| "unknown".to_string()),
                         hotspot.score
                     ]);
                 }

--- a/src/cmd_hotspots.rs
+++ b/src/cmd_hotspots.rs
@@ -15,7 +15,9 @@ pub fn cmd_hotspots(url: String, addresses: Vec<String>) -> Result {
 fn print_results(results: Vec<(String, Result<Vec<Hotspot>>)>) {
     let mut table = Table::new();
     table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
-    table.set_titles(row!["Address", "Name", "Location", "City", "State", "Score"]);
+    table.set_titles(row![
+        "Address", "Name", "Location", "City", "State", "Score"
+    ]);
 
     for (address, result) in results {
         #[allow(clippy::unused_unit)]
@@ -30,8 +32,14 @@ fn print_results(results: Vec<(String, Result<Vec<Hotspot>>)>) {
                         hotspot.address,
                         hotspot.name.unwrap_or_else(|| "unknown".to_string()),
                         hotspot.location.unwrap_or_else(|| "uknnown".to_string()),
-                        hotspot.geocode.short_city.unwrap_or_else(|| "unknown".to_string()),
-                        hotspot.geocode.short_state.unwrap_or_else(|| "unknown".to_string()),
+                        hotspot
+                            .geocode
+                            .short_city
+                            .unwrap_or_else(|| "unknown".to_string()),
+                        hotspot
+                            .geocode
+                            .short_state
+                            .unwrap_or_else(|| "unknown".to_string()),
                         hotspot.score
                     ]);
                 }

--- a/src/cmd_htlc.rs
+++ b/src/cmd_htlc.rs
@@ -1,5 +1,5 @@
 use crate::{
-    keypair::{PubKeyBin, Keypair},
+    keypair::{Keypair, PubKeyBin},
     result::Result,
     traits::{Sign, B58},
     wallet::Wallet,
@@ -12,7 +12,7 @@ pub fn cmd_create(
     url: String,
     wallet: &Wallet,
     password: &str,
-    payee: String,    
+    payee: String,
     hashlock: String,
     timelock: u64,
     amount: u64,
@@ -96,7 +96,7 @@ pub fn cmd_redeem(
     txn.sign(&keypair)?;
     let wrapped_txn = Txn::RedeemHtlc(txn.clone());
 
-    let status = client.submit_txn(wrapped_txn)?;   
+    let status = client.submit_txn(wrapped_txn)?;
 
     if hash {
         println!("{}", status.hash);

--- a/src/cmd_htlc.rs
+++ b/src/cmd_htlc.rs
@@ -1,0 +1,120 @@
+use crate::{
+    keypair::{PubKeyBin, Keypair},
+    result::Result,
+    traits::{Sign, B58},
+    wallet::Wallet,
+};
+use helium_api::{Client, PendingTxnStatus};
+use helium_proto::{BlockchainTxnCreateHtlcV1, BlockchainTxnRedeemHtlcV1, Txn};
+use prettytable::Table;
+
+pub fn cmd_create(
+    url: String,
+    wallet: &Wallet,
+    password: &str,
+    payee: String,    
+    hashlock: String,
+    timelock: u64,
+    amount: u64,
+    commit: bool,
+    hash: bool,
+) -> Result {
+    let client = Client::new_with_base_url(url);
+
+    let keypair = wallet.to_keypair(password.as_bytes())?;
+    let account = client.get_account(&keypair.public.to_b58()?)?;
+    let address = Keypair::gen_keypair().pubkey_bin();
+
+    let mut txn = BlockchainTxnCreateHtlcV1 {
+        amount,
+        fee: 0,
+        payee: PubKeyBin::from_b58(payee)?.to_vec(),
+        payer: keypair.pubkey_bin().to_vec(),
+        address: address.to_vec(),
+        hashlock: hex::decode(hashlock).unwrap(),
+        timelock,
+        nonce: account.speculative_nonce + 1,
+        signature: Vec::new(),
+    };
+    txn.sign(&keypair)?;
+    let wrapped_txn = Txn::CreateHtlc(txn.clone());
+
+    let status = if commit {
+        Some(client.submit_txn(wrapped_txn)?)
+    } else {
+        None
+    };
+
+    if hash {
+        println!("{}", status.map_or("none".to_string(), |s| s.hash));
+    } else {
+        print_create_txn(&txn, &status);
+    }
+
+    Ok(())
+}
+
+fn print_create_txn(txn: &BlockchainTxnCreateHtlcV1, status: &Option<PendingTxnStatus>) {
+    let mut table = Table::new();
+    table.add_row(row!["Address", "Payee", "Amount", "Hashlock", "Timelock"]);
+    table.add_row(row![
+        PubKeyBin::from_vec(&txn.address).to_b58().unwrap(),
+        PubKeyBin::from_vec(&txn.payee).to_b58().unwrap(),
+        txn.amount,
+        hex::encode(&txn.hashlock),
+        txn.timelock
+    ]);
+    table.printstd();
+
+    if status.is_some() {
+        ptable!(
+            ["Nonce", "Hash"],
+            [txn.nonce, status.as_ref().map_or("none", |s| &s.hash)]
+        );
+    }
+}
+
+pub fn cmd_redeem(
+    url: String,
+    wallet: &Wallet,
+    password: &str,
+    address: String,
+    preimage: String,
+    hash: bool,
+) -> Result {
+    let client = Client::new_with_base_url(url);
+
+    let keypair = wallet.to_keypair(password.as_bytes())?;
+
+    let mut txn = BlockchainTxnRedeemHtlcV1 {
+        fee: 0,
+        payee: keypair.pubkey_bin().to_vec(),
+        address: PubKeyBin::from_b58(address)?.to_vec(),
+        preimage: preimage.into_bytes(),
+        signature: Vec::new(),
+    };
+    txn.sign(&keypair)?;
+    let wrapped_txn = Txn::RedeemHtlc(txn.clone());
+
+    let status = client.submit_txn(wrapped_txn)?;   
+
+    if hash {
+        println!("{}", status.hash);
+    } else {
+        print_redeem_txn(&txn, &status);
+    }
+
+    Ok(())
+}
+
+fn print_redeem_txn(txn: &BlockchainTxnRedeemHtlcV1, status: &PendingTxnStatus) {
+    let mut table = Table::new();
+    table.add_row(row!["Payee", "Address", "Preimage", "Hash"]);
+    table.add_row(row![
+        PubKeyBin::from_vec(&txn.payee).to_b58().unwrap(),
+        PubKeyBin::from_vec(&txn.address).to_b58().unwrap(),
+        std::str::from_utf8(&txn.preimage).unwrap(),
+        status.hash
+    ]);
+    table.printstd();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,9 @@ extern crate lazy_static;
 mod cmd_balance;
 mod cmd_create;
 mod cmd_hotspots;
+mod cmd_htlc;
 mod cmd_info;
 mod cmd_pay;
-mod cmd_htlc;
 mod cmd_verify;
 mod keypair;
 mod mnemonic;
@@ -18,9 +18,9 @@ mod wallet;
 
 use crate::{result::Result, traits::ReadWrite, wallet::Wallet};
 use cmd_pay::Payee;
+use helium_api::Hnt;
 use std::{env, fs, path::PathBuf, process};
 use structopt::StructOpt;
-use helium_api::Hnt;
 
 /// Create and manage Helium wallets
 #[derive(Debug, StructOpt)]
@@ -141,7 +141,7 @@ pub enum CreateCmd {
 #[derive(Debug, StructOpt)]
 /// Create or Redeem from an HTLC address
 pub enum HtlcCmd {
-    /// Creates a new HTLC address with a specified hashlock and timelock (in block height), and transfers a value of tokens to it. 
+    /// Creates a new HTLC address with a specified hashlock and timelock (in block height), and transfers a value of tokens to it.
     /// The transaction is not submitted to the system unless the '--commit' option is given.
     Create {
         /// Wallet to use as the payer
@@ -300,7 +300,17 @@ fn run(cli: Cli) -> Result {
         }) => {
             let pass = get_password(false)?;
             let wallet = load_wallet(files)?;
-            cmd_htlc::cmd_create(api_url(), &wallet, &pass, payee, hashlock, timelock, hnt.to_bones(), commit, hash)
+            cmd_htlc::cmd_create(
+                api_url(),
+                &wallet,
+                &pass,
+                payee,
+                hashlock,
+                timelock,
+                hnt.to_bones(),
+                commit,
+                hash,
+            )
         }
         Cli::Htlc(HtlcCmd::Redeem {
             address,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod cmd_create;
 mod cmd_hotspots;
 mod cmd_info;
 mod cmd_pay;
+mod cmd_htlc;
 mod cmd_verify;
 mod keypair;
 mod mnemonic;
@@ -19,6 +20,7 @@ use crate::{result::Result, traits::ReadWrite, wallet::Wallet};
 use cmd_pay::Payee;
 use std::{env, fs, path::PathBuf, process};
 use structopt::StructOpt;
+use helium_api::Hnt;
 
 /// Create and manage Helium wallets
 #[derive(Debug, StructOpt)]
@@ -83,6 +85,8 @@ enum Cli {
         #[structopt(long)]
         hash: bool,
     },
+    /// Create or Redeem from an HTLC address
+    Htlc(HtlcCmd),
 }
 
 #[derive(Debug, StructOpt)]
@@ -131,6 +135,58 @@ pub enum CreateCmd {
         #[structopt(long)]
         /// Use seed words to create the wallet
         seed: bool,
+    },
+}
+
+#[derive(Debug, StructOpt)]
+/// Create or Redeem from an HTLC address
+pub enum HtlcCmd {
+    /// Creates a new HTLC address with a specified hashlock and timelock (in block height), and transfers a value of tokens to it. 
+    /// The transaction is not submitted to the system unless the '--commit' option is given.
+    Create {
+        /// Wallet to use as the payer
+        #[structopt(short = "f", long = "file", default_value = "wallet.key")]
+        files: Vec<PathBuf>,
+
+        /// The address of the intended payee for this HTLC
+        payee: String,
+
+        /// Number of hnt to send
+        #[structopt(long)]
+        hnt: Hnt,
+
+        /// A hex encoded SHA256 digest of a secret value (called a preimage) that locks this contract
+        #[structopt(short = "h", long = "hashlock")]
+        hashlock: String,
+
+        /// A specific blockheight after which the payer (you) can redeem their tokens
+        #[structopt(short = "t", long = "timelock")]
+        timelock: u64,
+
+        /// Commit the payment to the API
+        #[structopt(long)]
+        commit: bool,
+
+        /// Only output the submitted transaction hash.
+        #[structopt(long)]
+        hash: bool,
+    },
+    /// Redeem the balance from an HTLC address with the specified preimage for the hashlock
+    Redeem {
+        /// Wallet to use as the payer
+        #[structopt(short = "f", long = "file", default_value = "wallet.key")]
+        files: Vec<PathBuf>,
+
+        /// Address of the HTLC contract to redeem from
+        address: String,
+
+        /// The preimage used to create the hashlock for this contract address
+        #[structopt(short = "p", long = "preimage")]
+        preimage: String,
+
+        /// Only output the submitted transaction hash.
+        #[structopt(long)]
+        hash: bool,
     },
 }
 
@@ -232,6 +288,29 @@ fn run(cli: Cli) -> Result {
             let pass = get_password(false)?;
             let wallet = load_wallet(files)?;
             cmd_pay::cmd_pay(api_url(), &wallet, &pass, payees, commit, hash)
+        }
+        Cli::Htlc(HtlcCmd::Create {
+            payee,
+            hashlock,
+            timelock,
+            hnt,
+            files,
+            commit,
+            hash,
+        }) => {
+            let pass = get_password(false)?;
+            let wallet = load_wallet(files)?;
+            cmd_htlc::cmd_create(api_url(), &wallet, &pass, payee, hashlock, timelock, hnt.to_bones(), commit, hash)
+        }
+        Cli::Htlc(HtlcCmd::Redeem {
+            address,
+            preimage,
+            files,
+            hash,
+        }) => {
+            let pass = get_password(false)?;
+            let wallet = load_wallet(files)?;
+            cmd_htlc::cmd_redeem(api_url(), &wallet, &pass, address, preimage, hash)
         }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,7 @@
 use crate::keypair::{Keypair, PubKeyBin, PublicKey, KEYTYPE_ED25519};
 use crate::result::Result;
 use bs58;
-use helium_proto::{BlockchainTxnPaymentV1, BlockchainTxnPaymentV2, Message};
+use helium_proto::{BlockchainTxnPaymentV1, BlockchainTxnPaymentV2, BlockchainTxnCreateHtlcV1, BlockchainTxnRedeemHtlcV1, Message};
 use io::{Read, Write};
 use std::io;
 
@@ -97,6 +97,24 @@ impl Sign for BlockchainTxnPaymentV1 {
 }
 
 impl Sign for BlockchainTxnPaymentV2 {
+    fn sign(&mut self, keypair: &Keypair) -> Result {
+        let mut buf = vec![];
+        self.encode(&mut buf)?;
+        self.signature = keypair.sign(&buf);
+        Ok(())
+    }
+}
+
+impl Sign for BlockchainTxnCreateHtlcV1 {
+    fn sign(&mut self, keypair: &Keypair) -> Result {
+        let mut buf = vec![];
+        self.encode(&mut buf)?;
+        self.signature = keypair.sign(&buf);
+        Ok(())
+    }
+}
+
+impl Sign for BlockchainTxnRedeemHtlcV1 {
     fn sign(&mut self, keypair: &Keypair) -> Result {
         let mut buf = vec![];
         self.encode(&mut buf)?;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,10 @@
 use crate::keypair::{Keypair, PubKeyBin, PublicKey, KEYTYPE_ED25519};
 use crate::result::Result;
 use bs58;
-use helium_proto::{BlockchainTxnPaymentV1, BlockchainTxnPaymentV2, BlockchainTxnCreateHtlcV1, BlockchainTxnRedeemHtlcV1, Message};
+use helium_proto::{
+    BlockchainTxnCreateHtlcV1, BlockchainTxnPaymentV1, BlockchainTxnPaymentV2,
+    BlockchainTxnRedeemHtlcV1, Message,
+};
 use io::{Read, Write};
 use std::io;
 


### PR DESCRIPTION
Adds two commands:

`htlc create` to create an HTLC with a hashlock and timelock value
`htlc redeem` to redeem from an HTLC address with the correct preimage