### PR TITLE
Enable lint and format checks on CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,14 @@ matrix:
   - name: Linux Binary
     env: TARGET=x86_64-unknown-linux-musl
     rust: stable
-    before_script: rustup target add $TARGET
-    script: cargo build --release --target $TARGET --locked --features vendored
+    before_script:
+      - rustup target add $TARGET
+      - rustup component add rustfmt
+      - rustup component add clippy
+    script:
+      - cargo fmt -- --check
+      - cargo build --release --target $TARGET --locked --features vendored
+      - cargo clippy -- --deny=clippy::all
     addons:
       apt:
         packages:
@@ -46,6 +52,12 @@ matrix:
     env: MACOSX_DEPLOYMENT_TARGET=10.7 TARGET=x86_64-apple-darwin
     os: osx
     rust: stable
-    script: cargo build --release --target $TARGET --locked
+    before_script:
+      - rustup component add rustfmt
+      - rustup component add clippy
+    script:
+      - cargo fmt -- --check
+      - cargo build --release --target $TARGET --locked
+      - cargo clippy -- --deny=clippy::all
     install: true
     <<: *DEPLOY_TO_GITHUB

--- a/src/cmd_htlc.rs
+++ b/src/cmd_htlc.rs
@@ -8,6 +8,7 @@ use helium_api::{Client, PendingTxnStatus};
 use helium_proto::{BlockchainTxnCreateHtlcV1, BlockchainTxnRedeemHtlcV1, Txn};
 use prettytable::Table;
 
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_create(
     url: String,
     wallet: &Wallet,


### PR DESCRIPTION
This PR adds two new CI build steps: rustfmt and clippy. They ensure the codebase is formatted and lint-free before merging PRs. 

The order that the new steps are run is intentional so they run from fastest to slowest:

1. format
1. build
1. clippy