### PR TITLE
improved pwhash support

### DIFF
--- a/src/cmd/htlc.rs
+++ b/src/cmd/htlc.rs
@@ -77,7 +77,7 @@ impl Create {
         let wallet = load_wallet(opts.files)?;
         let client = Client::new_with_base_url(api_url());
 
-        let keypair = wallet.to_keypair(password.as_bytes())?;
+        let keypair = wallet.decrypt(password.as_bytes())?;
         let account = client.get_account(&keypair.public.to_b58()?)?;
         let address = Keypair::gen_keypair().pubkey_bin();
 
@@ -150,7 +150,7 @@ impl Redeem {
     pub fn run(&self, opts: Opts) -> Result {
         let password = get_password(false)?;
         let wallet = load_wallet(opts.files)?;
-        let keypair = wallet.to_keypair(password.as_bytes())?;
+        let keypair = wallet.decrypt(password.as_bytes())?;
         let client = Client::new_with_base_url(api_url());
 
         let mut txn = BlockchainTxnRedeemHtlcV1 {

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -34,14 +34,15 @@ fn print_wallet(wallet: &Wallet, format: OutputFormat) -> Result {
     match format {
         OutputFormat::Table => {
             let mut table = Table::new();
-            table.add_row(row!["Address", "Sharded"]);
-            table.add_row(row![address, wallet.is_sharded()]);
+            table.add_row(row!["Address", "Sharded", "PWHash"]);
+            table.add_row(row![address, wallet.is_sharded(), wallet.pwhash()]);
             table.printstd();
         }
         OutputFormat::Json => {
             let table = json!({
                 "address": address,
-                "sharded": wallet.is_sharded()
+                "sharded": wallet.is_sharded(),
+                "pwhash": wallet.pwhash().to_string(),
             });
             println!("{}", serde_json::to_string_pretty(&table)?);
         }

--- a/src/cmd/onboard.rs
+++ b/src/cmd/onboard.rs
@@ -33,7 +33,7 @@ impl Cmd {
     pub fn run(&self, opts: Opts) -> Result {
         let password = get_password(false)?;
         let wallet = load_wallet(opts.files)?;
-        let keypair = wallet.to_keypair(password.as_bytes())?;
+        let keypair = wallet.decrypt(password.as_bytes())?;
         // let staking_address = get_staking_address()?;
         // Now decode the given transaction
         let mut envelope = BlockchainTxn::from_b64(&self.read_txn()?)?;

--- a/src/cmd/oracle.rs
+++ b/src/cmd/oracle.rs
@@ -47,7 +47,7 @@ impl Report {
     pub fn run(&self, opts: Opts) -> Result {
         let password = get_password(false)?;
         let wallet = load_wallet(opts.files)?;
-        let keypair = wallet.to_keypair(password.as_bytes())?;
+        let keypair = wallet.decrypt(password.as_bytes())?;
 
         let client = Client::new_with_base_url(api_url());
 

--- a/src/cmd/oui.rs
+++ b/src/cmd/oui.rs
@@ -82,7 +82,7 @@ impl Create {
     pub fn run(&self, opts: Opts) -> Result {
         let password = get_password(false)?;
         let wallet = load_wallet(opts.files)?;
-        let keypair = wallet.to_keypair(password.as_bytes())?;
+        let keypair = wallet.decrypt(password.as_bytes())?;
 
         let api_client = Client::new_with_base_url(api_url());
         let staking_client = staking::Client::default();

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -31,7 +31,7 @@ impl Cmd {
 
         let client = Client::new_with_base_url(api_url());
 
-        let keypair = wallet.to_keypair(password.as_bytes())?;
+        let keypair = wallet.decrypt(password.as_bytes())?;
         let account = client.get_account(&keypair.public.to_b58()?)?;
 
         let payments: Result<Vec<Payment>> = self

--- a/src/cmd/verify.rs
+++ b/src/cmd/verify.rs
@@ -15,7 +15,7 @@ impl Cmd {
     pub fn run(&self, opts: Opts) -> Result {
         let password = get_password(false)?;
         let wallet = load_wallet(opts.files)?;
-        let result = wallet.to_keypair(password.as_bytes());
+        let result = wallet.decrypt(password.as_bytes());
         print_result(&wallet, result.is_ok(), opts.format)
     }
 }
@@ -26,8 +26,8 @@ pub fn print_result(wallet: &Wallet, result: bool, format: OutputFormat) -> Resu
         OutputFormat::Table => {
             let mut table = Table::new();
             table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
-            table.set_titles(row!["Address", "Sharded", "Verify"]);
-            table.add_row(row![address, wallet.is_sharded(), result]);
+            table.set_titles(row!["Address", "Sharded", "Verify", "PWHash"]);
+            table.add_row(row![address, wallet.is_sharded(), result, wallet.pwhash()]);
             table.printstd();
             Ok(())
         }
@@ -35,7 +35,8 @@ pub fn print_result(wallet: &Wallet, result: bool, format: OutputFormat) -> Resu
             let table = json!({
                 "address": address,
                 "sharded": wallet.is_sharded(),
-                "verify": result
+                "verify": result,
+                "pwhash": wallet.pwhash().to_string()
             });
             println!("{}", serde_json::to_string_pretty(&table)?);
             Ok(())

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,220 @@
+use crate::{pwhash::PWHash, result::Result};
+use byteorder::{ReadBytesExt, WriteBytesExt};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use shamirsecretsharing::hazmat::{combine_keyshares, create_keyshares};
+use sodiumoxide::randombytes;
+use std::{fmt, io};
+
+#[derive(Clone)]
+pub enum Format {
+    Basic(Basic),
+    Sharded(Sharded),
+}
+
+impl Format {
+    pub fn derive_key(&mut self, password: &[u8], key: &mut [u8]) -> Result {
+        match self {
+            Format::Basic(derive) => derive.derive_key(password, key),
+            Format::Sharded(derive) => derive.derive_key(password, key),
+        }
+    }
+
+    pub fn mut_pwhash(&mut self) -> &mut PWHash {
+        match self {
+            Format::Basic(derive) => derive.mut_pwhash(),
+            Format::Sharded(derive) => derive.mut_pwhash(),
+        }
+    }
+
+    pub fn pwhash(&self) -> &PWHash {
+        match self {
+            Format::Basic(derive) => derive.pwhash(),
+            Format::Sharded(derive) => derive.pwhash(),
+        }
+    }
+
+    pub fn read(&mut self, reader: &mut dyn io::Read) -> Result {
+        match self {
+            Format::Basic(derive) => derive.read(reader),
+            Format::Sharded(derive) => derive.read(reader),
+        }
+    }
+
+    pub fn write(&self, writer: &mut dyn io::Write) -> Result {
+        match self {
+            Format::Basic(derive) => derive.write(writer),
+            Format::Sharded(derive) => derive.write(writer),
+        }
+    }
+
+    pub fn basic(pwhash: PWHash) -> Self {
+        Format::Basic(Basic { pwhash })
+    }
+
+    pub fn sharded(key_share_count: u8, recovery_threshold: u8, pwhash: PWHash) -> Self {
+        Format::Sharded(Sharded {
+            key_share_count,
+            recovery_threshold,
+            key_shares: Vec::new(),
+            pwhash,
+        })
+    }
+
+    pub fn sharded_default(pwhash: PWHash) -> Self {
+        Self::sharded(5, 3, pwhash)
+    }
+}
+
+#[derive(Clone)]
+pub struct Basic {
+    pub pwhash: PWHash,
+}
+
+impl Basic {
+    pub fn derive_key(&mut self, password: &[u8], key: &mut [u8]) -> Result {
+        self.pwhash.pwhash(password, key)
+    }
+
+    pub fn mut_pwhash(&mut self) -> &mut PWHash {
+        &mut self.pwhash
+    }
+
+    pub fn pwhash(&self) -> &PWHash {
+        &self.pwhash
+    }
+
+    pub fn read(&mut self, _reader: &mut dyn io::Read) -> Result {
+        Ok(())
+    }
+
+    pub fn write(&self, _writer: &mut dyn io::Write) -> Result {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct KeyShare(pub(crate) [u8; 33]);
+
+impl Default for KeyShare {
+    fn default() -> Self {
+        KeyShare([0; 33])
+    }
+}
+
+impl fmt::Debug for KeyShare {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("KeyShare").field(&&self.0[..]).finish()
+    }
+}
+
+impl KeyShare {
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+
+    pub fn from_slice(slice: &[u8]) -> KeyShare {
+        let mut share = [0u8; 33];
+        share.copy_from_slice(slice);
+        KeyShare(share)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Sharded {
+    pub key_share_count: u8,
+    pub recovery_threshold: u8,
+    pub key_shares: Vec<KeyShare>,
+    pub pwhash: PWHash,
+}
+
+impl Sharded {
+    pub fn derive_key(&mut self, password: &[u8], key: &mut [u8]) -> Result {
+        self.pwhash.pwhash(password, key)?;
+
+        let mut sss_key: [u8; 32] = [0; 32];
+
+        if self.key_shares.is_empty() {
+            // Generate the keyhares when we have none
+            randombytes::randombytes_into(&mut sss_key);
+            let key_share_vecs =
+                create_keyshares(&sss_key, self.key_share_count, self.recovery_threshold)?;
+            let mut key_shares = vec![];
+            for share_vec in key_share_vecs {
+                key_shares.push(KeyShare::from_slice(&share_vec));
+            }
+            self.key_shares = key_shares;
+        } else if self.key_shares.len() < self.recovery_threshold as usize {
+            // Otherwise validate that we can reconstruct the key
+            return Err("not enouth keyshares to recover key".into());
+        } else {
+            // Reconstruct shared key
+            let key_share_vecs: Vec<Vec<u8>> =
+                self.key_shares.iter().map(|sh| sh.to_vec()).collect();
+            match combine_keyshares(&key_share_vecs) {
+                Ok(k) => sss_key.copy_from_slice(&k),
+                Err(_) => return Err("Failed to combine keyshares".into()),
+            }
+        }
+
+        // Now go derive the encryption key from the sharded key
+        // source and the stretched key
+        let mut hmac = match Hmac::<Sha256>::new_varkey(&sss_key) {
+            Err(_) => return Err("Failed to initialize hmac".into()),
+            Ok(m) => m,
+        };
+        hmac.input(key);
+        let code: [u8; 32] = hmac.result().code().into();
+        key.copy_from_slice(&code);
+        Ok(())
+    }
+
+    pub fn mut_pwhash(&mut self) -> &mut PWHash {
+        &mut self.pwhash
+    }
+
+    pub fn pwhash(&self) -> &PWHash {
+        &self.pwhash
+    }
+
+    pub fn shards(&self) -> Vec<Self> {
+        let mut shards = vec![];
+        for share in &self.key_shares {
+            shards.push(Self {
+                key_shares: vec![share.clone()],
+                ..*self
+            })
+        }
+        shards
+    }
+
+    pub fn absorb(&mut self, other: &Self) -> Result {
+        if self.key_share_count != other.key_share_count
+            || self.recovery_threshold != other.recovery_threshold
+        {
+            return Err("Shards are not congruent".into());
+        }
+
+        self.key_shares.extend_from_slice(&other.key_shares);
+        Ok(())
+    }
+
+    pub fn read(&mut self, reader: &mut dyn io::Read) -> Result {
+        self.key_share_count = reader.read_u8()?;
+        self.recovery_threshold = reader.read_u8()?;
+        let mut key_share = KeyShare::default();
+        reader.read_exact(&mut key_share.0)?;
+        self.key_shares.push(key_share);
+        Ok(())
+    }
+
+    pub fn write(&self, writer: &mut dyn io::Write) -> Result {
+        if self.key_shares.len() != 1 {
+            return Err("Invalid number of ksy shares in shard".into());
+        }
+        writer.write_u8(self.key_share_count)?;
+        writer.write_u8(self.recovery_threshold)?;
+        writer.write_all(&self.key_shares[0].0)?;
+        Ok(())
+    }
+}

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -230,7 +230,7 @@ mod tests {
     fn roundtrip_b58_public_key() {
         let pk = Keypair::gen_keypair().public;
         let encoded = pk.to_b58().expect("Failed to encode public key");
-        let decoded = PublicKey::from_b58(encoded).expect("Failed to decode public key");
+        let decoded = PublicKey::from_b58(&encoded).expect("Failed to decode public key");
         assert_eq!(pk, decoded);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,10 @@ extern crate lazy_static;
 extern crate serde_json;
 
 pub mod cmd;
+pub mod format;
 pub mod keypair;
 pub mod mnemonic;
+pub mod pwhash;
 pub mod result;
 pub mod staking;
 pub mod traits;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use helium_wallet::{
-    cmd::{balance, create, hotspots, htlc, info, onboard, oracle, oui, pay, verify, Opts},
+    cmd::{
+        balance, create, hotspots, htlc, info, onboard, oracle, oui, pay, upgrade, verify, Opts,
+    },
     result::Result,
 };
 use std::process;
@@ -21,6 +23,7 @@ pub enum Cmd {
     Balance(balance::Cmd),
     Hotspots(hotspots::Cmd),
     Create(create::Cmd),
+    Upgrade(upgrade::Cmd),
     Pay(pay::Cmd),
     Htlc(htlc::Cmd),
     Oui(oui::Cmd),
@@ -43,6 +46,7 @@ fn run(cli: Cli) -> Result {
         Cmd::Balance(cmd) => cmd.run(cli.opts),
         Cmd::Hotspots(cmd) => cmd.run(cli.opts),
         Cmd::Create(cmd) => cmd.run(cli.opts),
+        Cmd::Upgrade(cmd) => cmd.run(cli.opts),
         Cmd::Pay(cmd) => cmd.run(cli.opts),
         Cmd::Htlc(cmd) => cmd.run(cli.opts),
         Cmd::Oui(cmd) => cmd.run(cli.opts),

--- a/src/pwhash.rs
+++ b/src/pwhash.rs
@@ -1,0 +1,136 @@
+use crate::result::Result;
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use hmac::Hmac;
+use sha2::Sha256;
+use sodiumoxide::{crypto::pwhash::argon2id13, randombytes};
+use std::{convert::TryInto, fmt, io};
+
+#[derive(Clone, Copy, Debug)]
+pub enum PWHash {
+    PBKDF2(PBKDF2),
+    Argon2id13(Argon2id13),
+}
+
+impl PWHash {
+    pub fn pwhash(&self, password: &[u8], hash: &mut [u8]) -> Result {
+        match self {
+            PWHash::PBKDF2(hasher) => hasher.pwhash(password, hash),
+            PWHash::Argon2id13(hasher) => hasher.pwhash(password, hash),
+        }
+    }
+
+    pub fn read(&mut self, reader: &mut dyn io::Read) -> Result {
+        match self {
+            PWHash::PBKDF2(hasher) => hasher.read(reader),
+            PWHash::Argon2id13(hasher) => hasher.read(reader),
+        }
+    }
+
+    pub fn write(&self, writer: &mut dyn io::Write) -> Result {
+        match self {
+            PWHash::PBKDF2(hasher) => hasher.write(writer),
+            PWHash::Argon2id13(hasher) => hasher.write(writer),
+        }
+    }
+
+    pub fn pbkdf2_default() -> Self {
+        PWHash::PBKDF2(PBKDF2::with_iterations(PBKDF2_DEFAULT_ITERATIONS))
+    }
+
+    pub fn pbkdf2(iterations: u32) -> Self {
+        PWHash::PBKDF2(PBKDF2::with_iterations(iterations))
+    }
+
+    pub fn argon2id13_default() -> Self {
+        PWHash::Argon2id13(Argon2id13::default())
+    }
+}
+
+impl fmt::Display for PWHash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PWHash::PBKDF2(_) => f.write_str("PBKDF2"),
+            PWHash::Argon2id13(_) => f.write_str("Argon2id13"),
+        }
+    }
+}
+
+pub const PBKDF2_DEFAULT_ITERATIONS: u32 = 1_000_000;
+
+#[derive(Clone, Copy, Debug)]
+pub struct PBKDF2 {
+    salt: [u8; 8],
+    iterations: u32,
+}
+
+impl PBKDF2 {
+    pub fn with_iterations(iterations: u32) -> Self {
+        let mut salt: [u8; 8] = [0; 8];
+        randombytes::randombytes_into(&mut salt);
+        Self { salt, iterations }
+    }
+
+    pub fn pwhash(&self, password: &[u8], hash: &mut [u8]) -> Result {
+        pbkdf2::pbkdf2::<Hmac<Sha256>>(password, &self.salt, self.iterations as usize, hash);
+        Ok(())
+    }
+
+    pub fn read(&mut self, reader: &mut dyn io::Read) -> Result {
+        reader.read_exact(&mut self.salt)?;
+        self.iterations = reader.read_u32::<LittleEndian>()?;
+        Ok(())
+    }
+
+    pub fn write(&self, writer: &mut dyn io::Write) -> Result {
+        writer.write_all(&self.salt)?;
+        writer.write_u32::<LittleEndian>(self.iterations)?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Argon2id13 {
+    salt: argon2id13::Salt,
+    mem_limit: argon2id13::MemLimit,
+    ops_limit: argon2id13::OpsLimit,
+}
+
+impl Default for Argon2id13 {
+    fn default() -> Self {
+        Self::with_limits(
+            argon2id13::OPSLIMIT_SENSITIVE,
+            argon2id13::MEMLIMIT_SENSITIVE,
+        )
+    }
+}
+
+impl Argon2id13 {
+    pub fn with_limits(ops_limit: argon2id13::OpsLimit, mem_limit: argon2id13::MemLimit) -> Self {
+        Self {
+            salt: argon2id13::gen_salt(),
+            mem_limit,
+            ops_limit,
+        }
+    }
+
+    pub fn pwhash(&self, password: &[u8], hash: &mut [u8]) -> Result {
+        match argon2id13::derive_key(hash, password, &self.salt, self.ops_limit, self.mem_limit) {
+            Ok(_) => Ok(()),
+            Err(_) => Err("Failed to hash password".into()),
+        }
+    }
+
+    pub fn read(&mut self, reader: &mut dyn io::Read) -> Result {
+        reader.read_exact(&mut self.salt.0)?;
+        self.mem_limit = argon2id13::MemLimit(reader.read_u32::<LittleEndian>()?.try_into()?);
+        self.ops_limit = argon2id13::OpsLimit(reader.read_u32::<LittleEndian>()?.try_into()?);
+        Ok(())
+    }
+
+    pub fn write(&self, writer: &mut dyn io::Write) -> Result {
+        writer.write_all(&self.salt.0)?;
+        writer.write_u32::<LittleEndian>(self.mem_limit.0.try_into()?)?;
+        writer.write_u32::<LittleEndian>(self.ops_limit.0.try_into()?)?;
+        Ok(())
+    }
+}

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,435 +1,193 @@
 use crate::{
-    keypair::{self, Keypair, PubKeyBin},
+    format::{self, Format},
+    keypair::{Keypair, PubKeyBin},
+    pwhash::PWHash,
     result::Result,
     traits::{ReadWrite, B58},
 };
 use aead::NewAead;
 use aes_gcm::Aes256Gcm;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use hmac::{Hmac, Mac};
-use sha2::Sha256;
-use shamirsecretsharing::hazmat::{combine_keyshares, create_keyshares};
 use sodiumoxide::randombytes;
-use std::{
-    boxed::Box,
-    fmt,
-    io::{self, Cursor},
-};
+use std::io::{self, Cursor};
 
-pub type Salt = [u8; 8];
 pub type Tag = [u8; 16];
 pub type IV = [u8; 12];
 pub type AESKey = [u8; 32];
-pub type SSSKey = [u8; 32];
 
-#[derive(Clone)]
-pub struct KeyShare(pub(crate) [u8; 33]);
+const WALLET_KIND_BASIC_V1: u16 = 0x0001;
+const WALLET_KIND_BASIC_V2: u16 = 0x0002;
 
-type HmacSha256 = Hmac<Sha256>;
+const WALLET_KIND_SHARDED_V1: u16 = 0x0101;
+const WALLET_KIND_SHARDED_V2: u16 = 0x0102;
 
-const WALLET_KIND_BASIC: u16 = 0x0001;
-const WALLET_KIND_SHARDED: u16 = 0x0101;
-const WALLET_DEFAULT_ITERATIONS: u32 = 1_000_000;
-
-impl Default for KeyShare {
-    fn default() -> Self {
-        KeyShare([0; 33])
-    }
-}
-
-impl KeyShare {
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.0.to_vec()
-    }
-
-    pub fn from_slice(slice: &[u8]) -> KeyShare {
-        let mut share = [0u8; 33];
-        share.copy_from_slice(slice);
-        KeyShare(share)
-    }
-}
-
-impl fmt::Debug for KeyShare {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("KeyShare").field(&&self.0[..]).finish()
-    }
-}
+const PWHASH_KIND_PBKDF2: u8 = 0;
+const PWHASH_KIND_ARGON2ID13: u8 = 1;
 
 pub struct Wallet {
     pub pubkey_bin: PubKeyBin,
-    pub iterations: u32,
     pub iv: IV,
-    pub salt: Salt,
     pub tag: Tag,
     pub encrypted: Vec<u8>,
-    pub format: Box<dyn WalletFormat>,
-}
-
-pub trait WalletFormat {
-    fn wallet_for_keypair(
-        &mut self,
-        keypair: &Keypair,
-        password: &[u8],
-        iterations: u32,
-    ) -> Result<Wallet>;
-    fn keypair_for_wallet(&self, wallet: &Wallet, password: &[u8]) -> Result<Keypair>;
-    fn as_sharded_format(&self) -> Result<ShardedFormat>;
-    fn absorb_key_shares(&mut self, other: &ShardedFormat) -> Result;
-    fn read_wallet(&self, reader: &mut dyn io::Read) -> Result<Wallet>;
-    fn write_wallet(&self, wallet: &Wallet, writer: &mut dyn io::Write) -> Result;
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct BasicFormat {}
-
-#[derive(Clone, Debug)]
-pub struct ShardedFormat {
-    pub key_share_count: u8,
-    pub recovery_threshold: u8,
-    pub key_shares: Vec<KeyShare>,
-}
-
-impl Default for ShardedFormat {
-    fn default() -> Self {
-        Self {
-            key_share_count: 5,
-            recovery_threshold: 3,
-            key_shares: Vec::new(),
-        }
-    }
-}
-
-impl WalletFormat for BasicFormat {
-    fn wallet_for_keypair(
-        &mut self,
-        keypair: &Keypair,
-        password: &[u8],
-        iterations: u32,
-    ) -> Result<Wallet> {
-        let mut salt = Salt::default();
-        let mut encryption_key = AESKey::default();
-        stretch_password(password, iterations, &mut salt, &mut encryption_key)?;
-
-        let mut wallet = Wallet {
-            salt,
-            iterations,
-            pubkey_bin: PubKeyBin::default(),
-            encrypted: Vec::new(),
-            iv: IV::default(),
-            tag: Tag::default(),
-            format: Box::new(self.to_owned()),
-        };
-        encrypt_keypair(
-            keypair,
-            &encryption_key,
-            &mut wallet.iv,
-            &mut wallet.pubkey_bin,
-            &mut wallet.encrypted,
-            &mut wallet.tag,
-        )?;
-        Ok(wallet)
-    }
-
-    fn keypair_for_wallet(&self, wallet: &Wallet, password: &[u8]) -> Result<Keypair> {
-        let mut encryption_key = AESKey::default();
-        re_stretch_password(
-            password,
-            wallet.iterations,
-            wallet.salt,
-            &mut encryption_key,
-        )?;
-        let keypair = decrypt_keypair(
-            &wallet.encrypted,
-            &encryption_key,
-            &wallet.pubkey_bin,
-            &wallet.iv,
-            &wallet.tag,
-        )?;
-        Ok(keypair)
-    }
-
-    fn as_sharded_format(&self) -> Result<ShardedFormat> {
-        Err("Not a sharded wallet".into())
-    }
-
-    fn absorb_key_shares(&mut self, _other: &ShardedFormat) -> Result {
-        Err("Basic wallet has no key shares".into())
-    }
-
-    fn read_wallet(&self, reader: &mut dyn io::Read) -> Result<Wallet> {
-        let mut wallet = Wallet {
-            salt: Salt::default(),
-            pubkey_bin: PubKeyBin::read(reader)?,
-            iterations: WALLET_DEFAULT_ITERATIONS,
-            encrypted: Vec::new(),
-            iv: IV::default(),
-            tag: Tag::default(),
-            format: Box::new(self.to_owned()),
-        };
-        reader.read_exact(&mut wallet.iv)?;
-        reader.read_exact(&mut wallet.salt)?;
-        wallet.iterations = reader.read_u32::<LittleEndian>()?;
-        reader.read_exact(&mut wallet.tag)?;
-        reader.read_to_end(&mut wallet.encrypted)?;
-        Ok(wallet)
-    }
-
-    fn write_wallet(&self, wallet: &Wallet, writer: &mut dyn io::Write) -> Result {
-        writer.write_u16::<LittleEndian>(WALLET_KIND_BASIC)?;
-        wallet.pubkey_bin.write(writer)?;
-        writer.write_all(&wallet.iv)?;
-        writer.write_all(&wallet.salt)?;
-        writer.write_u32::<LittleEndian>(wallet.iterations)?;
-        writer.write_all(&wallet.tag)?;
-        writer.write_all(&wallet.encrypted)?;
-        Ok(())
-    }
-}
-
-impl WalletFormat for ShardedFormat {
-    fn wallet_for_keypair(
-        &mut self,
-        keypair: &Keypair,
-        password: &[u8],
-        iterations: u32,
-    ) -> Result<Wallet> {
-        let mut salt = Salt::default();
-        let mut stretched_key = AESKey::default();
-        stretch_password(password, iterations, &mut salt, &mut stretched_key)?;
-
-        let mut sss_key = SSSKey::default();
-        randombytes::randombytes_into(&mut sss_key);
-
-        let key_share_vecs =
-            create_keyshares(&sss_key, self.key_share_count, self.recovery_threshold)?;
-        let mut key_shares = Vec::new();
-        for share_vec in key_share_vecs {
-            key_shares.push(KeyShare::from_slice(&share_vec));
-        }
-        self.key_shares = key_shares;
-
-        let encryption_key = derive_sharded_aes_key(&sss_key, &stretched_key)?;
-        let mut wallet = Wallet {
-            salt,
-            iterations,
-            pubkey_bin: PubKeyBin::default(),
-            encrypted: Vec::new(),
-            iv: IV::default(),
-            tag: Tag::default(),
-            format: Box::new(self.to_owned()),
-        };
-
-        encrypt_keypair(
-            keypair,
-            &encryption_key,
-            &mut wallet.iv,
-            &mut wallet.pubkey_bin,
-            &mut wallet.encrypted,
-            &mut wallet.tag,
-        )?;
-        Ok(wallet)
-    }
-
-    fn keypair_for_wallet(&self, wallet: &Wallet, password: &[u8]) -> Result<Keypair> {
-        let mut stretched_key = AESKey::default();
-        re_stretch_password(password, wallet.iterations, wallet.salt, &mut stretched_key)?;
-
-        if self.key_shares.len() < self.recovery_threshold as usize {
-            return Err("not enouth keyshares to recover key".into());
-        }
-
-        let mut sss_key = SSSKey::default();
-        let key_share_vecs: Vec<Vec<u8>> = self.key_shares.iter().map(|sh| sh.to_vec()).collect();
-        match combine_keyshares(&key_share_vecs) {
-            Ok(k) => sss_key.copy_from_slice(&k),
-            Err(_) => return Err("Failed to combine keyshares".into()),
-        };
-        let encryption_key = derive_sharded_aes_key(&sss_key, &stretched_key)?;
-
-        let keypair = decrypt_keypair(
-            &wallet.encrypted,
-            &encryption_key,
-            &wallet.pubkey_bin,
-            &wallet.iv,
-            &wallet.tag,
-        )?;
-        Ok(keypair)
-    }
-
-    fn as_sharded_format(&self) -> Result<ShardedFormat> {
-        Ok(self.clone())
-    }
-
-    fn absorb_key_shares(&mut self, other: &ShardedFormat) -> Result {
-        if self.key_share_count != other.key_share_count
-            || self.recovery_threshold != other.recovery_threshold
-        {
-            return Err("Shards are not congruent".into());
-        }
-        self.key_shares.extend(other.key_shares.iter().cloned());
-        Ok(())
-    }
-
-    fn read_wallet(&self, reader: &mut dyn io::Read) -> Result<Wallet> {
-        let mut format = ShardedFormat::default();
-        format.key_share_count = reader.read_u8()?;
-        format.recovery_threshold = reader.read_u8()?;
-        let mut key_share = KeyShare::default();
-        reader.read_exact(&mut key_share.0)?;
-        format.key_shares = vec![key_share];
-
-        let mut wallet = Wallet {
-            salt: Salt::default(),
-            iterations: WALLET_DEFAULT_ITERATIONS,
-            pubkey_bin: PubKeyBin::read(reader)?,
-            encrypted: Vec::new(),
-            iv: IV::default(),
-            tag: Tag::default(),
-            format: Box::new(format),
-        };
-
-        reader.read_exact(&mut wallet.iv)?;
-        reader.read_exact(&mut wallet.salt)?;
-        wallet.iterations = reader.read_u32::<LittleEndian>()?;
-        reader.read_exact(&mut wallet.tag)?;
-        reader.read_to_end(&mut wallet.encrypted)?;
-        Ok(wallet)
-    }
-
-    fn write_wallet(&self, wallet: &Wallet, writer: &mut dyn io::Write) -> Result {
-        writer.write_u16::<LittleEndian>(WALLET_KIND_SHARDED)?;
-        writer.write_u8(self.key_share_count)?;
-        writer.write_u8(self.recovery_threshold)?;
-        writer.write_all(&self.key_shares[0].0)?;
-
-        wallet.pubkey_bin.write(writer)?;
-        writer.write_all(&wallet.iv)?;
-        writer.write_all(&wallet.salt)?;
-        writer.write_u32::<LittleEndian>(wallet.iterations)?;
-        writer.write_all(&wallet.tag)?;
-        writer.write_all(&wallet.encrypted)?;
-        Ok(())
-    }
+    pub format: Format,
 }
 
 impl Wallet {
-    pub fn from_keypair(
-        keypair: &Keypair,
-        password: &[u8],
-        iterations: u32,
-        format: &mut dyn WalletFormat,
-    ) -> Result<Wallet> {
-        format.wallet_for_keypair(keypair, password, iterations)
+    pub fn encrypt(keypair: &Keypair, password: &[u8], fmt: Format) -> Result<Wallet> {
+        let mut encryption_key = AESKey::default();
+        let mut format = fmt;
+        format.derive_key(password, &mut encryption_key)?;
+
+        let mut iv = IV::default();
+        randombytes::randombytes_into(&mut iv);
+
+        let pubkey_bin = keypair.pubkey_bin();
+
+        use aead::generic_array::GenericArray;
+        let aead = Aes256Gcm::new(*GenericArray::from_slice(&encryption_key));
+
+        let mut encrypted = vec![];
+        keypair.write(&mut encrypted)?;
+
+        match aead.encrypt_in_place_detached(iv.as_ref().into(), &pubkey_bin.0, &mut encrypted) {
+            Err(_) => Err("Failed to encrypt wallet".into()),
+            Ok(gtag) => Ok(Wallet {
+                pubkey_bin,
+                iv,
+                tag: gtag.into(),
+                encrypted,
+                format,
+            }),
+        }
     }
 
-    pub fn to_keypair(&self, password: &[u8]) -> Result<Keypair> {
-        self.format.keypair_for_wallet(self, password)
+    pub fn decrypt(&self, password: &[u8]) -> Result<Keypair> {
+        let mut encryption_key = AESKey::default();
+        let mut format = self.format.clone();
+        format.derive_key(password, &mut encryption_key)?;
+
+        use aead::generic_array::GenericArray;
+        let aead = Aes256Gcm::new(*GenericArray::from_slice(&encryption_key));
+        let mut buffer = self.encrypted.to_owned();
+        match aead.decrypt_in_place_detached(
+            self.iv.as_ref().into(),
+            &self.pubkey_bin.0,
+            &mut buffer,
+            self.tag.as_ref().into(),
+        ) {
+            Err(_) => Err("Failed to decrypt wallet"),
+            _ => Ok(()),
+        }?;
+        let keypair = Keypair::read(&mut Cursor::new(buffer))?;
+        Ok(keypair)
     }
 
     pub fn address(&self) -> Result<String> {
         self.pubkey_bin.to_b58()
     }
 
+    pub fn pwhash(&self) -> &PWHash {
+        self.format.pwhash()
+    }
+
+    fn mut_sharded_format(&mut self) -> Result<&mut format::Sharded> {
+        match &mut self.format {
+            Format::Sharded(format) => Ok(format),
+            _ => Err("Wallet not sharded".into()),
+        }
+    }
+
+    fn sharded_format(&self) -> Result<&format::Sharded> {
+        match &self.format {
+            Format::Sharded(format) => Ok(format),
+            _ => Err("Wallet not sharded".into()),
+        }
+    }
+
     pub fn is_sharded(&self) -> bool {
-        self.format.as_sharded_format().is_ok()
+        self.sharded_format().is_ok()
     }
-}
 
-impl ReadWrite for Wallet {
-    fn read(reader: &mut dyn io::Read) -> Result<Wallet> {
-        let kind = reader.read_u16::<LittleEndian>()?;
+    pub fn shards(&self) -> Result<Vec<Wallet>> {
+        let format = self.sharded_format()?;
+        let mut wallets = vec![];
+        for shard in format.shards() {
+            wallets.push(Self {
+                format: Format::Sharded(shard),
+                encrypted: self.encrypted.clone(),
+                ..*self
+            })
+        }
+        Ok(wallets)
+    }
+
+    pub fn absorb_shard(&mut self, shard: &Wallet) -> Result {
+        let format = self.mut_sharded_format()?;
+        let other_format = shard.sharded_format()?;
+
+        format.absorb(&other_format)
+    }
+
+    fn read_pwhash(reader: &mut dyn io::Read) -> Result<PWHash> {
+        let kind = reader.read_u8()?;
         match kind {
-            WALLET_KIND_BASIC => BasicFormat::default().read_wallet(reader),
-            WALLET_KIND_SHARDED => ShardedFormat::default().read_wallet(reader),
-            _ => Err(format!("Invalid wallet kind {}", kind).into()),
+            PWHASH_KIND_PBKDF2 => Ok(PWHash::pbkdf2_default()),
+            PWHASH_KIND_ARGON2ID13 => Ok(PWHash::argon2id13_default()),
+            _ => Err(format!("Invalid pwhash kind {}", kind).into()),
         }
     }
 
-    fn write(&self, writer: &mut dyn io::Write) -> Result {
-        self.format.write_wallet(self, writer)
+    pub fn read(reader: &mut dyn io::Read) -> Result<Wallet> {
+        let kind = reader.read_u16::<LittleEndian>()?;
+        let mut format = match kind {
+            WALLET_KIND_BASIC_V1 => Format::basic(PWHash::pbkdf2_default()),
+            WALLET_KIND_BASIC_V2 => Format::basic(Self::read_pwhash(reader)?),
+            WALLET_KIND_SHARDED_V1 => Format::sharded_default(PWHash::pbkdf2_default()),
+            WALLET_KIND_SHARDED_V2 => Format::sharded_default(Self::read_pwhash(reader)?),
+            _ => return Err(format!("Invalid wallet kind {}", kind).into()),
+        };
+        format.read(reader)?;
+        let pubkey_bin = PubKeyBin::read(reader)?;
+        let mut iv = IV::default();
+        reader.read_exact(&mut iv)?;
+        format.mut_pwhash().read(reader)?;
+        let mut tag = Tag::default();
+        reader.read_exact(&mut tag)?;
+        let mut encrypted = vec![];
+        reader.read_to_end(&mut encrypted)?;
+
+        Ok(Wallet {
+            pubkey_bin,
+            iv,
+            tag,
+            format,
+            encrypted,
+        })
     }
-}
 
-fn derive_sharded_aes_key(sss_key: &SSSKey, aes_key: &AESKey) -> Result<AESKey> {
-    let mut hmac = match HmacSha256::new_varkey(sss_key) {
-        Err(_) => return Err("Failed to initialize hmac".into()),
-        Ok(m) => m,
-    };
-    hmac.input(aes_key);
-    Ok(hmac.result().code().into())
-}
-
-//
-// Utilities
-//
-
-pub fn stretch_password(
-    password: &[u8],
-    iterations: u32,
-    salt: &mut Salt,
-    key: &mut AESKey,
-) -> Result {
-    randombytes::randombytes_into(salt);
-    re_stretch_password(password, iterations, *salt, key)
-}
-
-pub fn re_stretch_password(
-    password: &[u8],
-    iterations: u32,
-    salt: Salt,
-    key: &mut AESKey,
-) -> Result {
-    pbkdf2::pbkdf2::<Hmac<Sha256>>(password, &salt, iterations as usize, &mut key[..]);
-    Ok(())
-}
-
-pub fn encrypt_keypair(
-    keypair: &keypair::Keypair,
-    key: &AESKey,
-    iv: &mut IV,
-    pubkey_bin: &mut PubKeyBin,
-    encrypted: &mut Vec<u8>,
-    tag: &mut Tag,
-) -> Result {
-    randombytes::randombytes_into(iv);
-
-    let mut pubkey_writer: &mut [u8] = &mut pubkey_bin.0;
-    keypair.public.write(&mut pubkey_writer)?;
-
-    use aead::generic_array::GenericArray;
-    let aead = Aes256Gcm::new(*GenericArray::from_slice(key));
-
-    keypair.write(encrypted)?;
-    match aead.encrypt_in_place_detached(iv.as_ref().into(), &pubkey_bin.0, encrypted) {
-        Err(_) => Err("Failed to encrypt wallet".into()),
-        Ok(gtag) => {
-            tag.copy_from_slice(&gtag);
-            Ok(())
+    fn write_pwhash(pwhash: &PWHash, writer: &mut dyn io::Write) -> Result {
+        match pwhash {
+            PWHash::PBKDF2(_) => writer.write_u8(PWHASH_KIND_PBKDF2)?,
+            PWHash::Argon2id13(_) => writer.write_u8(PWHASH_KIND_ARGON2ID13)?,
         }
+        Ok(())
     }
-}
 
-pub fn decrypt_keypair(
-    encrypted: &[u8],
-    key: &AESKey,
-    pubkey_bin: &PubKeyBin,
-    iv: &IV,
-    tag: &Tag,
-) -> Result<Keypair> {
-    use aead::generic_array::GenericArray;
-    let aead = Aes256Gcm::new(*GenericArray::from_slice(key));
-    let mut buffer = encrypted.to_owned();
-    match aead.decrypt_in_place_detached(
-        iv.as_ref().into(),
-        &pubkey_bin.0,
-        &mut buffer,
-        tag.as_ref().into(),
-    ) {
-        Err(_) => Err("Failed to decrypt wallet"),
-        _ => Ok(()),
-    }?;
-    let keypair = Keypair::read(&mut Cursor::new(buffer))?;
-    Ok(keypair)
+    pub fn write(&self, writer: &mut dyn io::Write) -> Result {
+        let kind = match self.format {
+            Format::Basic(_) => WALLET_KIND_BASIC_V2,
+            Format::Sharded(_) => WALLET_KIND_SHARDED_V2,
+        };
+        writer.write_u16::<LittleEndian>(kind)?;
+        Self::write_pwhash(self.format.pwhash(), writer)?;
+        self.format.write(writer)?;
+        self.pubkey_bin.write(writer)?;
+        writer.write_all(&self.iv)?;
+        self.format.pwhash().write(writer)?;
+        writer.write_all(&self.tag)?;
+        writer.write_all(&self.encrypted)?;
+        Ok(())
+    }
 }
 
 //
@@ -443,22 +201,29 @@ mod tests {
     #[test]
     fn rountrip_basic() {
         let from_keypair = Keypair::gen_keypair();
-        let mut format = BasicFormat::default();
+        let format = format::Basic {
+            pwhash: PWHash::argon2id13_default(),
+        };
         let password = b"passsword";
-        let wallet = Wallet::from_keypair(&from_keypair, password, 10, &mut format)
+        let wallet = Wallet::encrypt(&from_keypair, password, Format::Basic(format))
             .expect("wallet creation");
-        let to_keypair = wallet.to_keypair(password).expect("wallet to keypair");
+        let to_keypair = wallet.decrypt(password).expect("wallet to keypair");
         assert_eq!(from_keypair, to_keypair);
     }
 
     #[test]
     fn rountrip_sharded() {
         let from_keypair = Keypair::gen_keypair();
-        let mut format = ShardedFormat::default();
+        let format = format::Sharded {
+            key_share_count: 5,
+            recovery_threshold: 3,
+            pwhash: PWHash::argon2id13_default(),
+            key_shares: vec![],
+        };
         let password = b"passsword";
-        let wallet = Wallet::from_keypair(&from_keypair, password, 10, &mut format)
+        let wallet = Wallet::encrypt(&from_keypair, password, Format::Sharded(format))
             .expect("wallet creation");
-        let to_keypair = wallet.to_keypair(password).expect("wallet to keypair");
+        let to_keypair = wallet.decrypt(password).expect("wallet to keypair");
         assert_eq!(from_keypair, to_keypair);
     }
 }


### PR DESCRIPTION
This revs the wallet version for new wallets to use the argon2id13
password hashing support over pbkdf2.

An `upgrade` command is introduced to upgrade a given walle to the
newest version of a given format.