### PR TITLE
Fix accidental UTF-8 sequence in help message.

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -167,7 +167,7 @@ pub fn get_file_extension(filename: &PathBuf) -> String {
 
 pub fn print_footer(status: &Option<PendingTxnStatus>) -> Result {
     if status.is_none() {
-        println!("\nPreview mode: use —commit to submit the transaction to the network");
+        println!("\nPreview mode: use --commit to submit the transaction to the network");
     };
     Ok(())
 }


### PR DESCRIPTION
When previewing a payment the help text seeks to remind the user that the
transaction will not be committed unless the command is re-run with the
"--commit" flag. However, an overzealous code editor appears to have taken the
double hyphen and replaced it with a singular U+2014 (Em Dash) character in
the UTF-8 encoding. This is not helpful as it tends to render as a single
dash in the terminal (if it renders at all).

Replace the character with the proper double hyphen ASCII sequence.