### PR TITLE
Add request payment command

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -19,6 +19,7 @@ pub mod onboard;
 pub mod oracle;
 pub mod oui;
 pub mod pay;
+pub mod request;
 pub mod securities;
 pub mod upgrade;
 pub mod vars;

--- a/src/cmd/request.rs
+++ b/src/cmd/request.rs
@@ -1,0 +1,54 @@
+use crate::{
+    cmd::{load_wallet, print_json, Opts, OutputFormat},
+    result::Result,
+};
+use helium_api::Hnt;
+use qr2term::print_qr;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+/// Construct various request (like payment) in a QR code
+pub enum Cmd {
+    Payment(Payment),
+}
+
+#[derive(Debug, StructOpt)]
+/// Construct a payment request in a QR code
+pub struct Payment {
+    #[structopt(long)]
+    /// Amount of HNT to request
+    amount: Option<Hnt>,
+}
+
+impl Cmd {
+    pub fn run(&self, opts: Opts) -> Result {
+        match self {
+            Cmd::Payment(cmd) => cmd.run(opts),
+        }
+    }
+}
+
+impl Payment {
+    pub fn run(&self, opts: Opts) -> Result {
+        let wallet = load_wallet(opts.files)?;
+
+        let mut request = json!({
+            "type": "payment",
+            "address": wallet.address()?,
+        });
+        if self.amount.is_some() {
+            request["amount"] = self.amount.unwrap().to_string().into();
+        }
+        print_request(&request, opts.format)
+    }
+}
+
+fn print_request(request: &serde_json::Value, format: OutputFormat) -> Result {
+    match format {
+        OutputFormat::Json => print_json(request),
+        OutputFormat::Table => {
+            print_qr(&serde_json::to_string(&request)?)?;
+            Ok(())
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use helium_wallet::{
     cmd::{
-        balance, burn, create, hotspots, htlc, info, onboard, oracle, oui, pay, securities,
-        upgrade, vars, verify, Opts,
+        balance, burn, create, hotspots, htlc, info, onboard, oracle, oui, pay, request,
+        securities, upgrade, vars, verify, Opts,
     },
     result::Result,
 };
@@ -33,6 +33,7 @@ pub enum Cmd {
     Securities(securities::Cmd),
     Burn(burn::Cmd),
     Vars(vars::Cmd),
+    Request(request::Cmd),
 }
 
 fn main() {
@@ -59,5 +60,6 @@ fn run(cli: Cli) -> Result {
         Cmd::Securities(cmd) => cmd.run(cli.opts),
         Cmd::Burn(cmd) => cmd.run(cli.opts),
         Cmd::Vars(cmd) => cmd.run(cli.opts),
+        Cmd::Request(cmd) => cmd.run(cli.opts),
     }
 }


### PR DESCRIPTION
This adds a `request payment` command with optional `--amount`  which generates a handy QR terminal code to send to people or put on your website.

If you prefer an image to be output install a third party tool like `qrencode` which can be used as:

`helium-wallet --format json request payment --amount 10 | qrencode -o request_10.png `

If the amount option is omitted only the requesting address is put in the QR code leaving the amount to be filled in in the app
