### PR TITLE
Multisig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 perf.data*
 flamegraph.*
 *.png
+*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,12 +16,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
-name = "adler32"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
-
-[[package]]
 name = "aead"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,7 +44,7 @@ dependencies = [
  "aead",
  "aes",
  "ghash",
- "subtle 2.2.3",
+ "subtle 2.3.0",
  "zeroize",
 ]
 
@@ -95,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
 
 [[package]]
 name = "arc-swap"
@@ -124,15 +118,15 @@ checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.50"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
+checksum = "f813291114c186a042350e787af10c26534601062603d888be110f59f85ef8fa"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -150,6 +144,12 @@ checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -227,9 +227,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
+checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
 
 [[package]]
 name = "cfg-if"
@@ -245,9 +245,9 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "clap"
-version = "2.33.1"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",
@@ -354,7 +354,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static 1.4.0",
@@ -380,7 +380,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "cfg-if",
  "lazy_static 1.4.0",
 ]
@@ -459,9 +459,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "either"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encode_unicode"
@@ -471,18 +471,18 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
+checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "error-chain"
-version = "0.12.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "version_check",
 ]
@@ -516,18 +516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
-name = "filetime"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,9 +523,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
+checksum = "da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -590,9 +578,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures-cpupool"
@@ -615,13 +603,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -659,12 +647,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
-dependencies = [
- "autocfg 1.0.0",
-]
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
@@ -680,7 +665,7 @@ name = "helium-api"
 version = "1.1.2"
 source = "git+https://github.com/helium/helium-api-rs?tag=1.1.3#824ba6d2248033176c45be2942ee9dc73024a4de"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "helium-proto",
  "reqwest",
  "rust_decimal",
@@ -692,7 +677,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#5baedf16e08385684edd325c62cbf4b7490b033b"
+source = "git+https://github.com/helium/proto?branch=master#9d604b5908ab6084676d3b6e4819792b0c11bc0e"
 dependencies = [
  "bytes 0.4.12",
  "prost",
@@ -705,10 +690,10 @@ version = "1.3.8-dev"
 dependencies = [
  "aead",
  "aes-gcm",
- "base64",
+ "base64 0.13.0",
  "bs58",
  "byteorder",
- "bytes 0.4.12",
+ "bytes 0.5.6",
  "console",
  "dialoguer",
  "helium-api",
@@ -733,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
@@ -852,11 +837,11 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "hashbrown",
 ]
 
@@ -908,34 +893,19 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.73"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
-
-[[package]]
-name = "libflate"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
-dependencies = [
- "adler32",
- "crc32fast",
- "rle-decode-fast",
- "take_mut",
-]
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libsodium-sys"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c344ff12b90ef8fa1f0fffacd348c1fd041db331841fec9eab23fdb991f5e73"
+checksum = "a685b64f837b339074115f2e7f7b431ac73681d08d75b389db7498b8892b8a58"
 dependencies = [
  "cc",
  "libc",
- "libflate",
  "pkg-config",
- "tar",
- "vcpkg",
 ]
 
 [[package]]
@@ -985,11 +955,11 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1010,11 +980,12 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
+checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1050,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
+checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "native-tls"
@@ -1074,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
+checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1089,7 +1060,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1136,9 +1107,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.10.2+1.1.1g"
+version = "111.11.0+1.1.1h"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a287fdb22e32b5b60624d4a5a7a02dbe82777f730ec0dbc42a0554326fef5a70"
+checksum = "380fe324132bea01f45239fadfec9343adb044615f29930d039bec1ae7b9fa5b"
 dependencies = [
  "cc",
 ]
@@ -1149,7 +1120,7 @@ version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "cc",
  "libc",
  "openssl-src",
@@ -1203,7 +1174,7 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall",
- "smallvec 1.4.1",
+ "smallvec 1.4.2",
  "winapi 0.3.9",
 ]
 
@@ -1257,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "prettytable-rs"
@@ -1277,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -1290,22 +1261,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "syn-mid",
  "version_check",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -1597,7 +1566,7 @@ version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 dependencies = [
- "base64",
+ "base64 0.10.1",
  "bytes 0.4.12",
  "cookie",
  "cookie_store",
@@ -1626,16 +1595,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rle-decode-fast"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
-
-[[package]]
 name = "rust_decimal"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ba36e8c41bf675947e200af432325f332f60a0aea0ef2dc456636c2f6037d7"
+checksum = "c9e81662973c7a8d9663e64a0de4cd642b89a21d64966e3d99606efdc5fb0cc6"
 dependencies = [
  "num-traits",
  "serde",
@@ -1643,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
 
 [[package]]
 name = "rustc-serialize"
@@ -1724,18 +1687,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.114"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.114"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1744,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
+checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
 dependencies = [
  "itoa",
  "ryu",
@@ -1800,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
 dependencies = [
  "arc-swap",
  "libc",
@@ -1825,15 +1788,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "sodiumoxide"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585232e78a4fc18133eef9946d3080befdf68b906c51b621531c37e91787fa2b"
+checksum = "7038b67c941e23501573cb7242ffb08709abe9b11eb74bceff875bbda024a6a8"
 dependencies = [
  "libc",
  "libsodium-sys",
@@ -1857,9 +1820,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"
+checksum = "a7a7159e7d0dbcab6f9c980d7971ef50f3ff5753081461eeda120d5974a4ee95"
 dependencies = [
  "clap",
  "lazy_static 1.4.0",
@@ -1868,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.8"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
+checksum = "8fc47de4dfba76248d1e9169ccff240eea2a4dc1e34e309b95b2393109b4b383"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1887,30 +1850,19 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.35"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7f4c519df8c117855e19dd8cc851e89eb746fe7a73f0157e0d95fdec5369b0"
+checksum = "e03e57e4fcbfe7749842d53e24ccb9aa12b7252dbe5e91d2acad31834c8b8fdd"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1923,24 +1875,6 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
-]
-
-[[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-
-[[package]]
-name = "tar"
-version = "0.4.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a4c1d0bee3230179544336c15eefb563cf0302955d962e456542323e8c2e8a"
-dependencies = [
- "filetime",
- "libc",
- "redox_syscall",
- "xattr",
 ]
 
 [[package]]
@@ -2006,19 +1940,20 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
+checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
 name = "tokio"
@@ -2226,7 +2161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df0c900f2f9b4116803415878ff48b63da9edb268668e08cf9292d7503114a01"
 dependencies = [
  "generic-array",
- "subtle 2.2.3",
+ "subtle 2.3.0",
 ]
 
 [[package]]
@@ -2294,6 +2229,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "which"
@@ -2367,16 +2308,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "xattr"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "zeroize"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"

--- a/src/cmd/burn.rs
+++ b/src/cmd/burn.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     keypair::PubKeyBin,
     result::Result,
-    traits::{Sign, Signer, TxnEnvelope, TxnFee, B58, B64},
+    traits::{Sign, TxnEnvelope, TxnFee, B58, B64},
 };
 use helium_api::{BlockchainTxn, BlockchainTxnTokenBurnV1, Client, Hnt, PendingTxnStatus};
 use serde_json::json;
@@ -55,13 +55,13 @@ impl Cmd {
             signature: Vec::new(),
         };
         txn.fee = txn.txn_fee(&get_txn_fees(&client)?)?;
-        let envelope = txn.sign(&keypair, Signer::Payer)?.in_envelope();
+        txn.signature = txn.sign(&keypair)?;
+        let envelope = txn.in_envelope();
         let status = if self.commit {
             Some(client.submit_txn(&envelope)?)
         } else {
             None
         };
-
         print_txn(&txn, &envelope, &status, opts.format)
     }
 }

--- a/src/cmd/htlc.rs
+++ b/src/cmd/htlc.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     keypair::{Keypair, PubKeyBin},
     result::Result,
-    traits::{Sign, Signer, TxnEnvelope, TxnFee, B58, B64},
+    traits::{Sign, TxnEnvelope, TxnFee, B58, B64},
 };
 use helium_api::{
     BlockchainTxn, BlockchainTxnCreateHtlcV1, BlockchainTxnRedeemHtlcV1, Client, Hnt,
@@ -95,7 +95,8 @@ impl Create {
             signature: Vec::new(),
         };
         txn.fee = txn.txn_fee(&get_txn_fees(&client)?)?;
-        let envelope = txn.sign(&keypair, Signer::Owner)?.in_envelope();
+        txn.signature = txn.sign(&keypair)?;
+        let envelope = txn.in_envelope();
 
         let status = if self.commit {
             Some(client.submit_txn(&envelope)?)
@@ -158,8 +159,8 @@ impl Redeem {
             signature: Vec::new(),
         };
         txn.fee = txn.txn_fee(&get_txn_fees(&client)?)?;
-
-        let envelope = txn.sign(&keypair, Signer::Owner)?.in_envelope();
+        txn.signature = txn.sign(&keypair)?;
+        let envelope = txn.in_envelope();
 
         let status = if self.commit {
             Some(client.submit_txn(&envelope)?)

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -15,6 +15,7 @@ pub mod create;
 pub mod hotspots;
 pub mod htlc;
 pub mod info;
+pub mod multisig;
 pub mod onboard;
 pub mod oracle;
 pub mod oui;

--- a/src/cmd/multisig.rs
+++ b/src/cmd/multisig.rs
@@ -1,0 +1,229 @@
+use crate::{
+    cmd::{api_url, get_password, load_wallet, print_json, status_json, Opts},
+    keypair::Keypair,
+    result::Result,
+    traits::{Sign, ToJson, B64},
+};
+use helium_api::{BlockchainTxn, Client, PendingTxnStatus, Txn};
+use serde::{Deserialize, Serialize};
+use std::{fs::File, path::PathBuf};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+/// Commands multi signature transactions
+pub enum Cmd {
+    Inspect(Inspect),
+    Sign(Prove),
+    Combine(Combine),
+}
+
+#[derive(Debug, StructOpt)]
+/// Inspect a given transaction artifact file
+pub struct Inspect {
+    #[structopt(name = "ARTIFACT FILE")]
+    artifact: PathBuf,
+}
+
+#[derive(Debug, StructOpt)]
+/// Sign a given transaction artifact file.
+pub struct Prove {
+    #[structopt(name = "ARTIFACT FILE")]
+    artifact: PathBuf,
+
+    /// Sign as a new key
+    #[structopt(long = "key")]
+    key: bool,
+}
+
+#[derive(Debug, StructOpt)]
+/// Combine an artifact file with a number of proof files and optionally commit
+/// to the Helium API.
+pub struct Combine {
+    #[structopt(name = "ARTIFACT FILE")]
+    artifact: PathBuf,
+
+    /// Proof file(s) to use
+    #[structopt(long = "proof")]
+    proofs: Vec<PathBuf>,
+
+    /// Commit the combined transaction to the API
+    #[structopt(long)]
+    commit: bool,
+}
+
+impl Cmd {
+    pub fn run(&self, opts: Opts) -> Result {
+        match self {
+            Cmd::Inspect(cmd) => cmd.run(opts),
+            Cmd::Sign(cmd) => cmd.run(opts),
+            Cmd::Combine(cmd) => cmd.run(opts),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct Artifact {
+    txn: String,
+}
+
+enum ProofType {
+    KeyProof,
+    Proof,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Proofs {
+    proofs: Vec<String>,
+    key_proofs: Vec<String>,
+}
+
+impl Inspect {
+    pub fn run(&self, _opts: Opts) -> Result {
+        let txn = Artifact::load_txn(&self.artifact)?;
+        print_txn(&txn, &None)
+    }
+}
+
+impl Prove {
+    pub fn run(&self, opts: Opts) -> Result {
+        let password = get_password(false)?;
+        let wallet = load_wallet(opts.files)?;
+        let keypair = wallet.decrypt(password.as_bytes())?;
+
+        let txn = Artifact::load_txn(&self.artifact)?;
+        let mut proofs = Proofs::new();
+        let proof_type = if self.key {
+            ProofType::KeyProof
+        } else {
+            ProofType::Proof
+        };
+        proofs.add_proof(&keypair, &txn, proof_type)?;
+        print_json(&proofs)
+    }
+}
+
+impl Combine {
+    pub fn run(&self, _opts: Opts) -> Result {
+        let mut envelope = Artifact::load_txn(&self.artifact)?;
+        // Load proofs and key_proof maps from txn
+        let mut combined_proofs = Proofs::from_txn(&envelope)?;
+        for path in &self.proofs {
+            let proofs = Proofs::load(path)?;
+            combined_proofs.merge_proofs(&proofs)?;
+        }
+        combined_proofs.apply(&mut envelope)?;
+        let status = if self.commit {
+            let client = Client::new_with_base_url(api_url());
+            Some(client.submit_txn(&envelope)?)
+        } else {
+            None
+        };
+        print_txn(&envelope, &status)
+    }
+}
+
+fn print_txn(envelope: &BlockchainTxn, status: &Option<PendingTxnStatus>) -> Result {
+    let mut json = match &envelope.txn {
+        Some(Txn::Vars(t)) => t.to_json()?,
+        _ => return Err("Unsupported transaction for multisig".into()),
+    };
+    json["hash"] = status_json(status);
+    print_json(&json)
+}
+
+impl Proofs {
+    fn new() -> Self {
+        Proofs {
+            proofs: Vec::default(),
+            key_proofs: Vec::default(),
+        }
+    }
+
+    fn load(path: &PathBuf) -> Result<Self> {
+        let file = File::open(path)?;
+        let proofs: Proofs = serde_json::from_reader(&file)?;
+        Ok(proofs)
+    }
+
+    fn from_txn(envelope: &BlockchainTxn) -> Result<Self> {
+        let mut proofs = Self::new();
+        match &envelope.txn {
+            Some(Txn::Vars(t)) => {
+                for signature in &t.multi_key_proofs {
+                    proofs.key_proofs.push(signature.to_b64()?);
+                }
+                let multi_proofs = t.multi_proofs.clone().into_iter();
+                for signature in multi_proofs {
+                    proofs.proofs.push(signature.to_b64()?);
+                }
+            }
+            _ => return Err("Invalid transaction for proof".into()),
+        }
+        Ok(proofs)
+    }
+
+    fn apply(&self, envelope: &mut BlockchainTxn) -> Result {
+        match &mut envelope.txn {
+            Some(Txn::Vars(t)) => {
+                t.multi_key_proofs = Vec::with_capacity(self.key_proofs.len());
+                for signature in &self.key_proofs {
+                    t.multi_key_proofs.push(Vec::<u8>::from_b64(&signature)?);
+                }
+                t.multi_proofs = Vec::with_capacity(self.proofs.len());
+                for signature in &self.proofs {
+                    t.multi_proofs.push(Vec::<u8>::from_b64(&signature)?);
+                }
+            }
+            _ => return Err("Invalid transaction for proof".into()),
+        };
+        Ok(())
+    }
+
+    fn add_proof(
+        &mut self,
+        keypair: &Keypair,
+        envelope: &BlockchainTxn,
+        proof_type: ProofType,
+    ) -> Result {
+        match &envelope.txn {
+            Some(Txn::Vars(t)) => {
+                let signature = t.sign(&keypair)?.to_b64()?;
+                match proof_type {
+                    ProofType::KeyProof => self.key_proofs.push(signature),
+                    ProofType::Proof => self.proofs.push(signature),
+                };
+                self.dedup();
+            }
+            _ => return Err("Invalid transaction for proof".into()),
+        };
+        Ok(())
+    }
+
+    fn merge_proofs(&mut self, other: &Proofs) -> Result {
+        self.proofs.extend(other.proofs.clone());
+        self.key_proofs.extend(other.key_proofs.clone());
+        self.dedup();
+        Ok(())
+    }
+
+    fn dedup(&mut self) {
+        self.proofs.dedup_by(|a, b| a == b);
+        self.key_proofs.dedup_by(|a, b| a == b)
+    }
+}
+
+impl Artifact {
+    fn load_txn(path: &PathBuf) -> Result<BlockchainTxn> {
+        let file = File::open(path)?;
+        let artifact: Artifact = serde_json::from_reader(&file)?;
+        artifact.to_txn()
+    }
+
+    pub fn from_txn(txn: &BlockchainTxn) -> Result<Self> {
+        Ok(Self { txn: txn.to_b64()? })
+    }
+
+    pub fn to_txn(&self) -> Result<BlockchainTxn> {
+        Ok(BlockchainTxn::from_b64(&self.txn)?)
+    }
+}

--- a/src/cmd/onboard.rs
+++ b/src/cmd/onboard.rs
@@ -4,7 +4,7 @@ use crate::{
     },
     result::Result,
     staking,
-    traits::{Sign, Signer, TxnPayer, B64},
+    traits::{Sign, TxnPayer, B64},
 };
 use helium_api::{BlockchainTxn, PendingTxnStatus, Txn};
 use serde_json::json;
@@ -41,10 +41,10 @@ impl Cmd {
         let mut envelope = BlockchainTxn::from_b64(&self.read_txn()?)?;
         match &mut envelope.txn {
             Some(Txn::AddGateway(t)) => {
-                t.sign(&keypair, Signer::Owner)?;
+                t.owner_signature = t.sign(&keypair)?;
             }
             Some(Txn::AssertLocation(t)) => {
-                t.sign(&keypair, Signer::Owner)?;
+                t.owner_signature = t.sign(&keypair)?;
             }
             _ => return Err("Unsupported transaction for onboarding".into()),
         };

--- a/src/cmd/oracle.rs
+++ b/src/cmd/oracle.rs
@@ -4,7 +4,7 @@ use crate::{
         Opts, OutputFormat,
     },
     result::Result,
-    traits::{Sign, Signer, TxnEnvelope, B64},
+    traits::{Sign, TxnEnvelope, B64},
 };
 use helium_api::{BlockchainTxn, BlockchainTxnPriceOracleV1, Client, PendingTxnStatus};
 use rust_decimal::{prelude::*, Decimal};
@@ -60,8 +60,8 @@ impl Report {
             block_height: self.block.to_block(),
             signature: Vec::new(),
         };
-
-        let envelope = txn.sign(&keypair, Signer::Owner)?.in_envelope();
+        txn.signature = txn.sign(&keypair)?;
+        let envelope = txn.in_envelope();
         let status = if self.commit {
             Some(client.submit_txn(&envelope)?)
         } else {

--- a/src/cmd/oui.rs
+++ b/src/cmd/oui.rs
@@ -6,7 +6,7 @@ use crate::{
     keypair::PubKeyBin,
     result::Result,
     staking,
-    traits::{Sign, Signer, TxnEnvelope, TxnFee, TxnStakingFee, B64},
+    traits::{Sign, TxnEnvelope, TxnFee, TxnStakingFee, B64},
 };
 use helium_api::{BlockchainTxn, BlockchainTxnOuiV1, Client, PendingTxnStatus, Txn};
 use serde_json::json;
@@ -109,8 +109,8 @@ impl Create {
         };
         txn.fee = txn.txn_fee(&get_txn_fees(&api_client)?)?;
         txn.staking_fee = txn.txn_staking_fee(&get_txn_fees(&api_client)?)?;
-
-        let envelope = txn.sign(&keypair, Signer::Owner)?.in_envelope();
+        txn.owner_signature = txn.sign(&keypair)?;
+        let envelope = txn.in_envelope();
 
         match payer {
             key if key == Some(wallet_key) || key.is_none() => {

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     keypair::PubKeyBin,
     result::Result,
-    traits::{Sign, Signer, TxnEnvelope, TxnFee, B58, B64},
+    traits::{Sign, TxnEnvelope, TxnFee, B58, B64},
 };
 use helium_api::{BlockchainTxn, BlockchainTxnPaymentV2, Client, Hnt, Payment, PendingTxnStatus};
 use prettytable::Table;
@@ -55,7 +55,8 @@ impl Cmd {
             signature: Vec::new(),
         };
         txn.fee = txn.txn_fee(&get_txn_fees(&client)?)?;
-        let envelope = txn.sign(&keypair, Signer::Payer)?.in_envelope();
+        txn.signature = txn.sign(&keypair)?;
+        let envelope = txn.in_envelope();
         let status = if self.commit {
             Some(client.submit_txn(&envelope)?)
         } else {

--- a/src/cmd/securities.rs
+++ b/src/cmd/securities.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     keypair::PubKeyBin,
     result::Result,
-    traits::{Sign, Signer, TxnEnvelope, TxnFee, B58, B64},
+    traits::{Sign, TxnEnvelope, TxnFee, B58, B64},
 };
 use helium_api::{BlockchainTxn, BlockchainTxnSecurityExchangeV1, Client, PendingTxnStatus};
 use serde_json::json;
@@ -58,7 +58,8 @@ impl Transfer {
             signature: vec![],
         };
         txn.fee = txn.txn_fee(&get_txn_fees(&client)?)?;
-        let envelope = txn.sign(&keypair, Signer::Payer)?.in_envelope();
+        txn.signature = txn.sign(&keypair)?;
+        let envelope = txn.in_envelope();
         let status = if self.commit {
             Some(client.submit_txn(&envelope)?)
         } else {

--- a/src/cmd/vars.rs
+++ b/src/cmd/vars.rs
@@ -23,19 +23,19 @@ pub struct Current {}
 /// Create a chain variable transaction
 pub struct Create {
     /// Variables to set
-    #[structopt(long, name = "name=value")]
+    #[structopt(long)]
     set: Vec<VarSet>,
 
     /// Variables to unset
-    #[structopt(long, name = "name")]
+    #[structopt(long)]
     unset: Vec<String>,
 
     /// Variables to cancel
-    #[structopt(long, name = "name")]
+    #[structopt(long)]
     cancel: Vec<String>,
 
     /// Signing keys to set
-    #[structopt(long, name = "key")]
+    #[structopt(long)]
     key: Vec<PubKeyBin>,
 
     /// The nonce to use

--- a/src/cmd/vars.rs
+++ b/src/cmd/vars.rs
@@ -22,20 +22,20 @@ pub struct Current {}
 #[derive(Debug, StructOpt)]
 /// Create a chain variable transaction
 pub struct Create {
-    /// Variables to set
-    #[structopt(long)]
+    /// Set of Variables to set
+    #[structopt(long, name = "set_name=value")]
     set: Vec<VarSet>,
 
-    /// Variables to unset
-    #[structopt(long)]
+    /// Variable to unset
+    #[structopt(long, name = "unset_name")]
     unset: Vec<String>,
 
-    /// Variables to cancel
-    #[structopt(long)]
+    /// Variable to cancel
+    #[structopt(long, name = "cancel_name")]
     cancel: Vec<String>,
 
     /// Signing keys to set
-    #[structopt(long)]
+    #[structopt(long, name = "key")]
     key: Vec<PubKeyBin>,
 
     /// The nonce to use

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use helium_wallet::{
     cmd::{
-        balance, burn, create, hotspots, htlc, info, onboard, oracle, oui, pay, request,
+        balance, burn, create, hotspots, htlc, info, multisig, onboard, oracle, oui, pay, request,
         securities, upgrade, vars, verify, Opts,
     },
     result::Result,
@@ -32,8 +32,9 @@ pub enum Cmd {
     Oracle(oracle::Cmd),
     Securities(securities::Cmd),
     Burn(burn::Cmd),
-    Vars(vars::Cmd),
+    Multisig(multisig::Cmd),
     Request(request::Cmd),
+    Vars(vars::Cmd),
 }
 
 fn main() {
@@ -59,7 +60,8 @@ fn run(cli: Cli) -> Result {
         Cmd::Oracle(cmd) => cmd.run(cli.opts),
         Cmd::Securities(cmd) => cmd.run(cli.opts),
         Cmd::Burn(cmd) => cmd.run(cli.opts),
-        Cmd::Vars(cmd) => cmd.run(cli.opts),
+        Cmd::Multisig(cmd) => cmd.run(cli.opts),
         Cmd::Request(cmd) => cmd.run(cli.opts),
+        Cmd::Vars(cmd) => cmd.run(cli.opts),
     }
 }

--- a/src/traits/b58.rs
+++ b/src/traits/b58.rs
@@ -44,3 +44,13 @@ impl B58 for PubKeyBin {
         Ok(pubkey_bin)
     }
 }
+
+impl B58 for Vec<u8> {
+    fn to_b58(&self) -> Result<String> {
+        Ok(bs58::encode(self).with_check().into_string())
+    }
+
+    fn from_b58(b58: &str) -> Result<Self> {
+        Ok(bs58::decode(b58).with_check(Some(0)).into_vec()?)
+    }
+}

--- a/src/traits/b64.rs
+++ b/src/traits/b64.rs
@@ -3,34 +3,64 @@ use helium_api::{BlockchainTxn, Message};
 use std::convert::TryInto;
 
 pub trait B64 {
-    fn to_b64(&self) -> Result<String>;
+    fn to_b64(&self) -> Result<String> {
+        self.to_b64_config(base64::STANDARD)
+    }
+    fn to_b64_url(&self) -> Result<String> {
+        self.to_b64_config(base64::URL_SAFE_NO_PAD)
+    }
     fn from_b64(str: &str) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Self::from_b64_config(str, base64::STANDARD)
+    }
+    fn from_b64_url(str: &str) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Self::from_b64_config(str, base64::URL_SAFE_NO_PAD)
+    }
+
+    fn to_b64_config(&self, config: base64::Config) -> Result<String>;
+    fn from_b64_config(str: &str, config: base64::Config) -> Result<Self>
     where
         Self: std::marker::Sized;
 }
 
 impl B64 for BlockchainTxn {
-    fn to_b64(&self) -> Result<String> {
+    fn to_b64_config(&self, config: base64::Config) -> Result<String> {
         let mut buf = vec![];
         self.encode(&mut buf)?;
-        Ok(base64::encode(&buf))
+        Ok(base64::encode_config(&buf, config))
     }
 
-    fn from_b64(b64: &str) -> Result<Self> {
-        let decoded = base64::decode(b64)?;
+    fn from_b64_config(b64: &str, config: base64::Config) -> Result<Self> {
+        let decoded = base64::decode_config(b64, config)?;
         let envelope = BlockchainTxn::decode(&decoded[..])?;
         Ok(envelope)
     }
 }
 
 impl B64 for u64 {
-    fn to_b64(&self) -> Result<String> {
-        Ok(base64::encode(&self.to_le_bytes()))
+    fn to_b64_config(&self, config: base64::Config) -> Result<String> {
+        Ok(base64::encode_config(&self.to_le_bytes(), config))
     }
 
-    fn from_b64(b64: &str) -> Result<Self> {
-        let decoded = base64::decode(b64)?;
+    fn from_b64_config(b64: &str, config: base64::Config) -> Result<Self> {
+        let decoded = base64::decode_config(b64, config)?;
         let int_bytes = decoded.as_slice().try_into()?;
         Ok(Self::from_le_bytes(int_bytes))
+    }
+}
+
+impl B64 for Vec<u8> {
+    fn to_b64_config(&self, config: base64::Config) -> Result<String> {
+        Ok(base64::encode_config(&self, config))
+    }
+
+    fn from_b64_config(b64: &str, config: base64::Config) -> Result<Self> {
+        let decoded = base64::decode_config(b64, config)?;
+        Ok(decoded)
     }
 }

--- a/src/traits/json.rs
+++ b/src/traits/json.rs
@@ -1,0 +1,106 @@
+use crate::{
+    result::Result,
+    traits::{B58, B64},
+};
+use helium_api::{BlockchainTxnVarsV1, BlockchainVarV1};
+
+pub(crate) fn maybe_b58(data: &[u8]) -> Result<Option<String>> {
+    if data.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(data.to_vec().to_b58()?))
+    }
+}
+
+pub(crate) fn maybe_b64_url(data: &[u8]) -> Result<Option<String>> {
+    if data.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(data.to_vec().to_b64_url()?))
+    }
+}
+
+pub trait ToJson {
+    fn to_json(&self) -> Result<serde_json::Value>;
+}
+
+impl<T> ToJson for Vec<T>
+where
+    T: ToJson,
+{
+    fn to_json(&self) -> Result<serde_json::Value> {
+        let mut seq = Vec::with_capacity(self.len());
+        for entry in self {
+            seq.push(entry.to_json()?)
+        }
+        Ok(json!(seq))
+    }
+}
+
+fn vec_to_strings(vec: &[Vec<u8>]) -> Result<Vec<String>> {
+    let mut seq = Vec::with_capacity(vec.len());
+    for entry in vec {
+        seq.push(String::from_utf8(entry.to_vec())?);
+    }
+    Ok(seq)
+}
+
+fn vec_to_b58s(vec: &[Vec<u8>]) -> Result<Vec<String>> {
+    let mut seq = Vec::with_capacity(vec.len());
+    for entry in vec {
+        seq.push(entry.to_b58()?);
+    }
+    Ok(seq)
+}
+
+fn vec_to_b64_urls(vec: &[Vec<u8>]) -> Result<Vec<String>> {
+    let mut seq = Vec::with_capacity(vec.len());
+    for entry in vec {
+        seq.push(entry.to_b64_url()?);
+    }
+    Ok(seq)
+}
+
+impl ToJson for BlockchainTxnVarsV1 {
+    fn to_json(&self) -> Result<serde_json::Value> {
+        let map = json!({
+            "type": "vars_v1",
+            "version_predicate": self.version_predicate,
+            "nonce": self.nonce,
+            "proof": maybe_b64_url(&self.proof)?,
+            "master_key": maybe_b58(&self.master_key)?,
+            "key_proof": maybe_b64_url(&self.key_proof)?,
+            "vars": self.vars.to_json()?,
+            "unsets": vec_to_strings(&self.unsets)?,
+            "cancels": vec_to_strings(&self.cancels)?,
+            "multi_keys": vec_to_b58s(&self.multi_keys)?,
+            "multi_proofs": vec_to_b64_urls(&self.multi_proofs)?,
+            "multi_key_proofs": vec_to_b64_urls(&self.multi_key_proofs)?,
+        });
+        Ok(map)
+    }
+}
+
+impl ToJson for BlockchainVarV1 {
+    fn to_json(&self) -> Result<serde_json::Value> {
+        let value = match &self.r#type[..] {
+            "int" => {
+                let v: i64 = String::from_utf8(self.value.to_vec())?.parse::<i64>()?;
+                json!(v)
+            }
+            "float" => {
+                let v: f64 = String::from_utf8(self.value.to_vec())?.parse::<f64>()?;
+                json!(v)
+            }
+            "string" => {
+                let v: String = String::from_utf8(self.value.to_vec())?;
+                json!(v)
+            }
+            _ => return Err(format!("Invalid variable {:?}", self).into()),
+        };
+        Ok(json!({
+            "name": self.name,
+            "value": value
+        }))
+    }
+}

--- a/src/traits/json.rs
+++ b/src/traits/json.rs
@@ -1,4 +1,5 @@
 use crate::{
+    keypair::PubKeyBin,
     result::Result,
     traits::{B58, B64},
 };
@@ -48,7 +49,7 @@ fn vec_to_strings(vec: &[Vec<u8>]) -> Result<Vec<String>> {
 fn vec_to_b58s(vec: &[Vec<u8>]) -> Result<Vec<String>> {
     let mut seq = Vec::with_capacity(vec.len());
     for entry in vec {
-        seq.push(entry.to_b58()?);
+        seq.push(PubKeyBin::from_vec(entry).to_b58()?);
     }
     Ok(seq)
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,13 +1,15 @@
 pub use self::b58::B58;
 pub use self::b64::B64;
+pub use self::json::ToJson;
 pub use self::read_write::ReadWrite;
-pub use self::sign::{Sign, Signer};
+pub use self::sign::Sign;
 pub use self::txn_envelope::TxnEnvelope;
 pub use self::txn_fee::{TxnFee, TxnFeeConfig, TxnStakingFee};
 pub use self::txn_payer::TxnPayer;
 
 pub mod b58;
 pub mod b64;
+pub mod json;
 pub mod read_write;
 pub mod sign;
 pub mod txn_envelope;

--- a/src/traits/sign.rs
+++ b/src/traits/sign.rs
@@ -7,86 +7,59 @@ use helium_api::{
     BlockchainTxnVarsV1, Message,
 };
 
-#[derive(PartialEq)]
-pub enum Signer {
-    Owner,
-    Payer,
-    Gateway,
-    // Adds an unknown signer to allow the macro get/set_signature
-    // match arms to work
-    Unknown,
-}
-
 pub trait Sign: Message + std::clone::Clone {
-    fn sign(&mut self, keypair: &Keypair, signer: Signer) -> Result<&mut Self>
+    fn sign(&self, keypair: &Keypair) -> Result<Vec<u8>>
     where
         Self: std::marker::Sized;
-    fn verify(&self, pubkey: &PublicKey, signer: Signer) -> Result;
-
-    fn set_signature(&mut self, signer: Signer, signature: Vec<u8>) -> Result;
-    fn get_signature(&self, signer: Signer) -> Result<Vec<u8>>;
+    fn verify(&self, pubkey: &PublicKey, signature: &[u8]) -> Result;
 }
 
 macro_rules! impl_sign {
-    ($txn_type:ty, $( ($signer: ident, $sig: ident) ),+ ) => {
+    ($txn_type:ty, $( $sig: ident ),+ ) => {
         impl Sign for $txn_type {
-            fn sign(&mut self, keypair: &Keypair, signer: Signer) -> Result<&mut Self> {
+            fn sign(&self, keypair: &Keypair) -> Result<Vec<u8>> {
                 let mut buf = vec![];
                 let mut txn = self.clone();
                 $(txn.$sig = vec![];)+
                 txn.encode(& mut buf)?;
-                self.set_signature(signer, keypair.sign(&buf))?;
-                Ok(self)
+                Ok(keypair.sign(&buf))
             }
 
-            fn verify(&self, pubkey: &PublicKey, signer: Signer) -> Result {
+            fn verify(&self, pubkey: &PublicKey, signature: &[u8]) -> Result {
                 let mut buf = vec![];
                 let mut txn = self.clone();
                 $(txn.$sig = vec![];)+
                 txn.encode(& mut buf)?;
-                pubkey.verify(&buf, &self.get_signature(signer)?)
-            }
-
-            fn set_signature(&mut self, signer: Signer, signature: Vec<u8>) -> Result {
-                match signer {
-                    $( Signer::$signer => self.$sig = signature,)+
-                    _ => return Err("Invalid signer".into()),
-                };
-                Ok(())
-            }
-
-            fn get_signature(&self, signer: Signer) -> Result<Vec<u8>> {
-                match signer {
-                    $( Signer::$signer => Ok(self.$sig.clone()), )+
-                    _ => Err("Invalid signer".into()),
-                }
+                pubkey.verify(&buf, &signature)
             }
         }
     }
 }
 
-impl_sign!(BlockchainTxnPriceOracleV1, (Owner, signature));
-impl_sign!(BlockchainTxnPaymentV1, (Payer, signature));
-impl_sign!(BlockchainTxnPaymentV2, (Payer, signature));
-impl_sign!(BlockchainTxnCreateHtlcV1, (Payer, signature));
-impl_sign!(BlockchainTxnRedeemHtlcV1, (Owner, signature));
+impl_sign!(BlockchainTxnPriceOracleV1, signature);
+impl_sign!(BlockchainTxnPaymentV1, signature);
+impl_sign!(BlockchainTxnPaymentV2, signature);
+impl_sign!(BlockchainTxnCreateHtlcV1, signature);
+impl_sign!(BlockchainTxnRedeemHtlcV1, signature);
 impl_sign!(
     BlockchainTxnAddGatewayV1,
-    (Owner, owner_signature),
-    (Payer, payer_signature),
-    (Gateway, gateway_signature)
+    owner_signature,
+    payer_signature,
+    gateway_signature
 );
 impl_sign!(
     BlockchainTxnAssertLocationV1,
-    (Owner, owner_signature),
-    (Payer, payer_signature),
-    (Gateway, gateway_signature)
+    owner_signature,
+    payer_signature,
+    gateway_signature
 );
+impl_sign!(BlockchainTxnOuiV1, owner_signature, payer_signature);
+impl_sign!(BlockchainTxnSecurityExchangeV1, signature);
+impl_sign!(BlockchainTxnTokenBurnV1, signature);
 impl_sign!(
-    BlockchainTxnOuiV1,
-    (Owner, owner_signature),
-    (Payer, payer_signature)
+    BlockchainTxnVarsV1,
+    proof,
+    key_proof,
+    multi_proofs,
+    multi_key_proofs
 );
-impl_sign!(BlockchainTxnSecurityExchangeV1, (Payer, signature));
-impl_sign!(BlockchainTxnTokenBurnV1, (Payer, signature));
-impl_sign!(BlockchainTxnVarsV1, (Owner, proof));


### PR DESCRIPTION
This adds the multisig command to inspect, sign and combine an artifact
and one or more proofs.

The vars command is simplified to just creating and listing vars since committing is done through multisig

Code-wise this also refactors signing and setting signatures back to it's more
basic form

- [x] This requires https://github.com/helium/blockchain-etl/pull/102 to be merged and deployed