### PR TITLE
Add Binance International

### DIFF
--- a/src/cmd/oracle.rs
+++ b/src/cmd/oracle.rs
@@ -154,8 +154,7 @@ impl Price {
     }
 
     fn from_binance_int() -> Result<Self> {
-        let mut response =
-            reqwest::get("https://api.binance.us/api/v3/avgPrice?symbol=HNTUSDT")?;
+        let mut response = reqwest::get("https://api.binance.us/api/v3/avgPrice?symbol=HNTUSDT")?;
         let json: serde_json::Value = response.json()?;
         let amount = &json["price"];
         Price::from_str(amount.as_str().ok_or("No USD value found")?)


### PR DESCRIPTION
A new method of single-shot reporting by weighted average. It looks like this:

```
./helium-wallet oracle report-weighted-average --binance-us 1 --binance-int 2
Binance US                reports price of $1.1491
Binance International     reports price of $1.14958000
Report price 1.149419885058000 @ block height 553939?
Enter password to confirm.
Password: 
```

In addition, the user can set the helium-wallet up to report every N minutes, requiring only an unlock of the wallet at startup.