### PR TITLE
Cmd Onboard: sign when wallet is explicity set as payer

### DIFF
--- a/src/cmd/onboard.rs
+++ b/src/cmd/onboard.rs
@@ -74,8 +74,7 @@ impl Cmd {
                 };
                 print_txn(&envelope, &status, opts.format)
             }
-            Some(key) if key == wallet_key  => {
-
+            Some(key) if key == wallet_key => {
                 match &mut envelope.txn {
                     Some(Txn::AddGateway(t)) => {
                         t.payer_signature = t.sign(&keypair)?;

--- a/src/cmd/onboard.rs
+++ b/src/cmd/onboard.rs
@@ -68,29 +68,25 @@ impl Cmd {
                     Ok(staking_client.sign(&onboarding_key, &envelope)?)
                 }
             }
-            Some(key) if key == wallet_key => {
-                match &mut envelope.txn {
-                    Some(Txn::AddGateway(t)) => {
-                        t.payer_signature = t.owner_signature.clone();
-                        Ok(envelope)
-                    }
-                    Some(Txn::AssertLocation(t)) => {
-                        t.payer_signature = t.owner_signature.clone();
-                        Ok(envelope)
-                    }
-                    _ => Err("Unsupported transaction for onboarding".into()),
+            Some(key) if key == wallet_key => match &mut envelope.txn {
+                Some(Txn::AddGateway(t)) => {
+                    t.payer_signature = t.owner_signature.clone();
+                    Ok(envelope)
                 }
-            }
-            None => {
-                Ok(envelope)
-            }
+                Some(Txn::AssertLocation(t)) => {
+                    t.payer_signature = t.owner_signature.clone();
+                    Ok(envelope)
+                }
+                _ => Err("Unsupported transaction for onboarding".into()),
+            },
+            None => Ok(envelope),
             _ => {
                 // Payer is neither staking server nor wallet. We
                 // can't commit this transaction.
                 Err("Unknown payer in transaction".into())
             }
         };
-        
+
         match transaction {
             Ok(envelope) => {
                 let status = if self.commit {
@@ -100,7 +96,7 @@ impl Cmd {
                 };
                 print_txn(&envelope, &status, opts.format)
             }
-            Err(e) => Err(e)
+            Err(e) => Err(e),
         }
     }
 

--- a/src/cmd/onboard.rs
+++ b/src/cmd/onboard.rs
@@ -39,6 +39,7 @@ impl Cmd {
         // let staking_address = get_staking_address()?;
         // Now decode the given transaction
         let mut envelope = BlockchainTxn::from_b64(&self.read_txn()?)?;
+
         match &mut envelope.txn {
             Some(Txn::AddGateway(t)) => {
                 t.owner_signature = t.sign(&keypair)?;
@@ -47,7 +48,7 @@ impl Cmd {
                 t.owner_signature = t.sign(&keypair)?;
             }
             _ => return Err("Unsupported transaction for onboarding".into()),
-        };
+        }
 
         // Check staking address
         let staking_client = staking::Client::default();
@@ -77,10 +78,10 @@ impl Cmd {
             Some(key) if key == wallet_key => {
                 match &mut envelope.txn {
                     Some(Txn::AddGateway(t)) => {
-                        t.payer_signature = t.sign(&keypair)?;
+                        t.payer_signature = t.owner_signature.clone();
                     }
                     Some(Txn::AssertLocation(t)) => {
-                        t.payer_signature = t.sign(&keypair)?;
+                        t.payer_signature = t.owner_signature.clone();
                     }
                     _ => return Err("Unsupported transaction for onboarding".into()),
                 };


### PR DESCRIPTION
It was reported on Discord that CLI transaction fails due to invalid payer signature when the owner wallet is set as payer.

It seems in the [txn verification](https://github.com/helium/blockchain-core/blob/master/src/transactions/v1/blockchain_txn_assert_location_v1.erl#L276), an explicit payer signature is necessary, even when (payer ==  owner).

This PR attempts to resolve the issue.