### PR TITLE
Fix seed creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,8 +728,8 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.0.4"
-source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.0.4#7541efb97a82aada233e80bcad008a93d4f3236c"
+version = "0.0.5"
+source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.0.5#f71885a096a9751278b5fa23f887b789d97916be"
 dependencies = [
  "bs58",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde =  "1"
 serde_derive = "1"
 serde_json = "1"
 rust_decimal = {version = "1", features = ["serde-float"] }
-helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.0.4"}
+helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.0.5"}
 helium-api = { git = "https://github.com/helium/helium-api-rs", tag = "v1.1.8-rc.2"}
 
 


### PR DESCRIPTION
There was a bug in helium-crypto-rs that failed generating ed25519 keys from seed entropy (used by seed words). This was fixed in https://github.com/helium/helium-crypto-rs/pull/4 

Fixes #90 