### PR TITLE
Provide QR code representing Base64 encoded txn 

### DIFF
--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -81,7 +81,7 @@ impl Cmd {
             print_qr(&envelope.to_b64()?)?;
         }
 
-       print_txn(&txn, &envelope, &status, opts.format)
+        print_txn(&txn, &envelope, &status, opts.format)
     }
 }
 

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -9,10 +9,10 @@ use crate::{
 };
 use helium_api::{BlockchainTxn, BlockchainTxnPaymentV2, Client, Hnt, Payment, PendingTxnStatus};
 use prettytable::Table;
+use qr2term::print_qr;
 use serde_json::json;
 use std::str::FromStr;
 use structopt::StructOpt;
-use qr2term::print_qr;
 
 #[derive(Debug, StructOpt)]
 /// Send one or more payments to given addresses. Note that HNT only

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -12,6 +12,7 @@ use prettytable::Table;
 use serde_json::json;
 use std::str::FromStr;
 use structopt::StructOpt;
+use qr2term::print_qr;
 
 #[derive(Debug, StructOpt)]
 /// Send one or more payments to given addresses. Note that HNT only
@@ -29,6 +30,10 @@ pub struct Cmd {
     /// Commit the payment to the API
     #[structopt(long)]
     commit: bool,
+
+    /// Prints a QR code of the Base64 encoded transaction
+    #[structopt(long)]
+    qr: bool,
 }
 
 impl Cmd {
@@ -72,7 +77,11 @@ impl Cmd {
             None
         };
 
-        print_txn(&txn, &envelope, &status, opts.format)
+        if self.qr {
+            print_qr(&envelope.to_b64()?)?;
+        }
+
+       print_txn(&txn, &envelope, &status, opts.format)
     }
 }
 


### PR DESCRIPTION
### Background

In the new Validator paradigm, HNT holders are able to stake Validator nodes to generate ROI on the staked HNT. However, not all HNT holders possess the requisite 10k HNT to stake a Validator node, and instead have to rely on third party services to "pool" HNT with a plurality of other HNT holders to meet the 10k HNT requirement. As such, third party services are operating as HNT custodians for the broader Helium community and need to abide by custodial best practices, such as wallet airgapping, to ensure a high degree of security. 

By providing QR codes representing Base64 encoded txns, third party services can run the CLI wallet in an airgapped manner, while also being able to seamlessly convey txns to the Helium network.

### Proposed Resolution

A `--qr` flag has been added to the `pay` command which, when present, leads to a QR code representing a Base64 encoded txn to be displayed. 

`./helium-wallet pay -h`

![Screen Shot 2021-03-07 at 2 37 35 PM](https://user-images.githubusercontent.com/37127765/110252315-cdb26b00-7f52-11eb-9006-d87c270f48ea.png)

`./helium-wallet pay --qr --payee 1bmPZTdyMesBjom1p9anqoGmhdqSnY7dwEQ53fRgLZuR9izPvjW=5.00`

![Screen Shot 2021-03-07 at 2 35 40 PM](https://user-images.githubusercontent.com/37127765/110252394-26820380-7f53-11eb-8a74-d77197bfbdc1.png)
