### PR TITLE
Adding necessary args to pay and validators commands to enable airgapped CLI wallett

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,12 +588,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
+name = "futures"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -592,10 +619,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -615,12 +665,17 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
  "slab",
 ]
 
@@ -714,10 +769,10 @@ dependencies = [
 [[package]]
 name = "helium-api"
 version = "1.1.8-rc.2"
-source = "git+https://github.com/helium/helium-api-rs?tag=v1.1.8-rc.2#485b916f68d2a1c2485f9e0bcb2dfe5b9060e15b"
 dependencies = [
+ "async-trait",
  "base64",
- "helium-proto",
+ "futures",
  "prost",
  "reqwest",
  "rust_decimal",
@@ -764,6 +819,7 @@ dependencies = [
  "dialoguer",
  "helium-api",
  "helium-crypto",
+ "helium-proto",
  "hex",
  "hmac",
  "lazy_static",
@@ -782,6 +838,7 @@ dependencies = [
  "shamirsecretsharing",
  "sodiumoxide",
  "structopt",
+ "tokio",
 ]
 
 [[package]]
@@ -1290,6 +1347,18 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1896,7 +1965,23 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -151,9 +151,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5011ffc90248764d7005b0e10c7294f5aa1bd87d9dd7248f4ad475b347c294d"
+checksum = "1f682656975d3a682daff957be4ddeb65d6ad656737cd821f2d00685ae466af1"
 dependencies = [
  "funty",
  "radium",
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
@@ -769,6 +769,7 @@ dependencies = [
 [[package]]
 name = "helium-api"
 version = "1.1.8-rc.2"
+source = "git+https://github.com/helium/helium-api-rs?branch=madninja/streams_async#622476e1a10818a5b46b1d2be062c52319f13e58"
 dependencies = [
  "async-trait",
  "base64",
@@ -852,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -949,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1004,9 +1005,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "libsodium-sys"
@@ -1142,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -1277,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -1567,9 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0460542b551950620a3648c6aa23318ac6b3cd779114bd873209e6e8b5eb1c34"
+checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
 dependencies = [
  "async-compression",
  "base64",
@@ -1649,9 +1650,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfd318104249865096c8da1dfabf09ddbb6d0330ea176812a62ec75e40c4166"
+checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1672,18 +1673,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1838,9 +1839,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1955,9 +1956,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1996,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "ec31e5cc6b46e653cf57762f36f71d5e6386391d88a72fd6db4508f8f676fb29"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,9 +210,9 @@ checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "helium-api"
 version = "1.1.8-rc.2"
-source = "git+https://github.com/helium/helium-api-rs?branch=madninja/streams_async#622476e1a10818a5b46b1d2be062c52319f13e58"
+source = "git+https://github.com/helium/helium-api-rs?branch=madninja/streams_async#c1e2e2ed64b0c03f4623b35249b6b80d654eaa72"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,7 @@ serde_derive = "1"
 serde_json = "1"
 rust_decimal = {version = "1", features = ["serde-float"] }
 helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.0.5"}
-#helium-api = { git = "https://github.com/helium/helium-api-rs", tag = "v1.1.8-rc.2"}
-
-helium-api = { path = "../helium-api-rs"}
+helium-api = { git = "https://github.com/helium/helium-api-rs", branch = "madninja/streams_async"}
 helium-proto = { git = "https://github.com/helium/proto", branch="master"}
 tokio = {version = "1.2", features = ["full"]}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,11 @@ serde_derive = "1"
 serde_json = "1"
 rust_decimal = {version = "1", features = ["serde-float"] }
 helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.0.5"}
-helium-api = { git = "https://github.com/helium/helium-api-rs", tag = "v1.1.8-rc.2"}
+#helium-api = { git = "https://github.com/helium/helium-api-rs", tag = "v1.1.8-rc.2"}
 
+helium-api = { path = "../helium-api-rs"}
+helium-proto = { git = "https://github.com/helium/proto", branch="master"}
+tokio = {version = "1.2", features = ["full"]}
 
 # Add openssl-sys as a direct dependency so it can be cross compiled to
 # x86_64-unknown-linux-musl using the "vendored" feature below

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cmd::{get_file_extension, get_password, get_seed_words, verify, Opts},
+    cmd::*,
     format::{self, Format},
     keypair::{KeyTag, KeyType, Keypair, Network, KEYTYPE_ED25519_STR, NETTYPE_MAIN_STR},
     mnemonic::mnemonic_to_entropy,
@@ -11,7 +11,6 @@ use std::{
     fs, io,
     path::{Path, PathBuf},
 };
-use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 /// Create a new wallet
@@ -77,16 +76,16 @@ pub struct Sharded {
 }
 
 impl Cmd {
-    pub fn run(&self, opts: Opts) -> Result {
+    pub async fn run(&self, opts: Opts) -> Result {
         match self {
-            Cmd::Basic(cmd) => cmd.run(opts),
-            Cmd::Sharded(cmd) => cmd.run(opts),
+            Cmd::Basic(cmd) => cmd.run(opts).await,
+            Cmd::Sharded(cmd) => cmd.run(opts).await,
         }
     }
 }
 
 impl Basic {
-    pub fn run(&self, opts: Opts) -> Result {
+    pub async fn run(&self, opts: Opts) -> Result {
         let seed_words = if self.seed {
             Some(get_seed_words()?)
         } else {
@@ -109,7 +108,7 @@ impl Basic {
 }
 
 impl Sharded {
-    pub fn run(&self, opts: Opts) -> Result {
+    pub async fn run(&self, opts: Opts) -> Result {
         let seed_words = if self.seed {
             Some(get_seed_words()?)
         } else {

--- a/src/cmd/hotspots/add.rs
+++ b/src/cmd/hotspots/add.rs
@@ -4,8 +4,6 @@ use crate::{
     staking,
     traits::{TxnEnvelope, TxnSign},
 };
-use helium_api::{BlockchainTxnAddGatewayV1, PendingTxnStatus};
-use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 /// Add a hotspot to the blockchain. The original transaction is created by the
@@ -29,7 +27,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, opts: Opts) -> Result {
+    pub async fn run(self, opts: Opts) -> Result {
         let mut txn = BlockchainTxnAddGatewayV1::from_envelope(&read_txn(&self.txn)?)?;
 
         let password = get_password(false)?;
@@ -52,16 +50,14 @@ impl Cmd {
                     bail!("Staking server requires an onboarding key");
                 } else {
                     let onboarding_key = self.onboarding.as_ref().unwrap().replace("\"", "");
-                    staking_client.sign(&onboarding_key, &txn.in_envelope())
+                    staking_client
+                        .sign(&onboarding_key, &txn.in_envelope())
+                        .await
                 }
             }
         }?;
 
-        let status = if self.commit {
-            Some(client.submit_txn(&envelope)?)
-        } else {
-            None
-        };
+        let status = maybe_submit_txn(self.commit, &client, &envelope).await?;
         print_txn(&txn, &status, opts.format)
     }
 }

--- a/src/cmd/hotspots/mod.rs
+++ b/src/cmd/hotspots/mod.rs
@@ -1,5 +1,4 @@
 use crate::{cmd::*, result::Result};
-use structopt::StructOpt;
 
 mod add;
 mod assert;
@@ -17,12 +16,12 @@ pub enum Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, opts: Opts) -> Result {
+    pub async fn run(self, opts: Opts) -> Result {
         match self {
-            Self::Add(cmd) => cmd.run(opts),
-            Self::Assert(cmd) => cmd.run(opts),
-            Self::List(cmd) => cmd.run(opts),
-            Self::Transfer(cmd) => cmd.run(opts),
+            Self::Add(cmd) => cmd.run(opts).await,
+            Self::Assert(cmd) => cmd.run(opts).await,
+            Self::List(cmd) => cmd.run(opts).await,
+            Self::Transfer(cmd) => cmd.run(opts).await,
         }
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -5,12 +5,15 @@ use crate::{
     traits::{TxnFeeConfig, B64},
     wallet::Wallet,
 };
-use helium_api::{BlockchainTxn, Client, PendingTxnStatus};
+pub use helium_api::{pending_transactions::PendingTxnStatus, Client, Hnt, Hst, Usd};
+pub use helium_proto::*;
+pub use serde_json::json;
+
 use std::{
     env, fs, io,
     path::{Path, PathBuf},
 };
-use structopt::{clap::arg_enum, StructOpt};
+pub use structopt::{clap::arg_enum, StructOpt};
 
 pub mod balance;
 pub mod burn;
@@ -167,8 +170,8 @@ pub fn get_payer(staking_address: PublicKey, payer: &Option<String>) -> Result<O
     }
 }
 
-pub fn get_txn_fees(client: &Client) -> Result<TxnFeeConfig> {
-    let vars = client.get_vars()?;
+pub async fn get_txn_fees(client: &Client) -> Result<TxnFeeConfig> {
+    let vars = helium_api::vars::get(client).await?;
     if vars.contains_key("txn_fees") {
         match vars["txn_fees"].as_bool() {
             Some(true) => {
@@ -223,4 +226,25 @@ pub fn status_str(status: &Option<PendingTxnStatus>) -> &str {
 
 pub fn status_json(status: &Option<PendingTxnStatus>) -> serde_json::Value {
     status.as_ref().map_or(json!(null), |s| json!(s.hash))
+}
+
+pub async fn maybe_submit_txn(
+    commit: bool,
+    client: &Client,
+    txn: &BlockchainTxn,
+) -> Result<Option<PendingTxnStatus>> {
+    if commit {
+        let status = submit_txn(&client, txn).await?;
+        Ok(Some(status))
+    } else {
+        Ok(None)
+    }
+}
+
+pub async fn submit_txn(client: &Client, txn: &BlockchainTxn) -> Result<PendingTxnStatus> {
+    let mut data = vec![];
+    txn.encode(&mut data);
+    helium_api::pending_transactions::submit(client, &data)
+        .await
+        .map_err(|e| e.into())
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -243,7 +243,7 @@ pub async fn maybe_submit_txn(
 
 pub async fn submit_txn(client: &Client, txn: &BlockchainTxn) -> Result<PendingTxnStatus> {
     let mut data = vec![];
-    txn.encode(&mut data);
+    txn.encode(&mut data)?;
     helium_api::pending_transactions::submit(client, &data)
         .await
         .map_err(|e| e.into())

--- a/src/cmd/oracle.rs
+++ b/src/cmd/oracle.rs
@@ -49,11 +49,12 @@ impl Report {
         let keypair = wallet.decrypt(password.as_bytes())?;
 
         let client = Client::new_with_base_url(api_url(wallet.public_key.network));
-
+        let block_height = self.block.to_block(&client).await?;
+        let price = u64::from(self.price.to_usd().await?);
         let mut txn = BlockchainTxnPriceOracleV1 {
             public_key: keypair.public_key().into(),
-            price: u64::from(self.price.to_usd().await?),
-            block_height: self.block.to_block(&client).await?,
+            price,
+            block_height,
             signature: Vec::new(),
         };
         txn.signature = txn.sign(&keypair)?;
@@ -185,9 +186,9 @@ impl FromStr for Price {
             "binance-int" => Ok(Self::BinanceInt),
             _ => {
                 let data = Decimal::from_str(s).or_else(|_| Decimal::from_scientific(s))?;
-                Ok(Self::Usd(Usd {
-                    0: data.round_dp_with_strategy(8, RoundingStrategy::RoundHalfUp),
-                }))
+                Ok(Self::Usd(Usd::new(
+                    data.round_dp_with_strategy(8, RoundingStrategy::RoundHalfUp),
+                )))
             }
         }
     }

--- a/src/cmd/oui.rs
+++ b/src/cmd/oui.rs
@@ -4,9 +4,9 @@ use crate::{
     result::{anyhow, Result},
     traits::{TxnEnvelope, TxnFee, TxnSign, TxnStakingFee, B64},
 };
+use helium_api::ouis;
 use serde_json::json;
 use std::convert::TryInto;
-use structopt::StructOpt;
 
 /// Create or update an OUI
 #[derive(Debug, StructOpt)]
@@ -84,7 +84,7 @@ impl Create {
             addresses: map_addresses(self.addresses.clone(), |v| v.to_vec())?,
             owner: keypair.public_key().into(),
             payer: self.payer.as_ref().map_or(vec![], |v| v.into()),
-            oui: api_client.get_last_oui()?,
+            oui: ouis::last(&api_client).await?.oui,
             fee: 0,
             staking_fee: 1,
             owner_signature: vec![],

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -39,7 +39,6 @@ impl Cmd {
         let client = Client::new_with_base_url(api_url(wallet.public_key.network));
 
         let keypair = wallet.decrypt(password.as_bytes())?;
-        // let account = accounts::get(&client, &keypair.public_key().to_string()).await?;
 
         let payments: Vec<Payment> = self
             .payees

--- a/src/cmd/request.rs
+++ b/src/cmd/request.rs
@@ -1,10 +1,5 @@
-use crate::{
-    cmd::{load_wallet, print_json, Opts, OutputFormat},
-    result::Result,
-};
-use helium_api::Hnt;
+use crate::{cmd::*, result::Result};
 use qr2term::print_qr;
-use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 /// Construct various request (like payment) in a QR code
@@ -35,16 +30,16 @@ pub struct Burn {
 }
 
 impl Cmd {
-    pub fn run(&self, opts: Opts) -> Result {
+    pub async fn run(&self, opts: Opts) -> Result {
         match self {
-            Cmd::Payment(cmd) => cmd.run(opts),
-            Cmd::Burn(cmd) => cmd.run(opts),
+            Cmd::Payment(cmd) => cmd.run(opts).await,
+            Cmd::Burn(cmd) => cmd.run(opts).await,
         }
     }
 }
 
 impl Payment {
-    pub fn run(&self, opts: Opts) -> Result {
+    pub async fn run(&self, opts: Opts) -> Result {
         let wallet = load_wallet(opts.files)?;
 
         let mut request = json!({
@@ -59,7 +54,7 @@ impl Payment {
 }
 
 impl Burn {
-    pub fn run(&self, opts: Opts) -> Result {
+    pub async fn run(&self, opts: Opts) -> Result {
         let wallet = load_wallet(opts.files)?;
 
         let mut request = json!({

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -1,12 +1,11 @@
 use crate::{
-    cmd::{get_file_extension, get_password, load_wallet, open_output_file, verify, Opts},
+    cmd::*,
     format::{self, Format},
     pwhash::PwHash,
     result::Result,
     wallet::Wallet,
 };
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 /// Upgrade a wallet to the latest supported version of the given
@@ -50,16 +49,16 @@ pub struct Sharded {
 }
 
 impl Cmd {
-    pub fn run(&self, opts: Opts) -> Result {
+    pub async fn run(&self, opts: Opts) -> Result {
         match self {
-            Cmd::Basic(cmd) => cmd.run(opts),
-            Cmd::Sharded(cmd) => cmd.run(opts),
+            Cmd::Basic(cmd) => cmd.run(opts).await,
+            Cmd::Sharded(cmd) => cmd.run(opts).await,
         }
     }
 }
 
 impl Basic {
-    pub fn run(&self, opts: Opts) -> Result {
+    pub async fn run(&self, opts: Opts) -> Result {
         let password = get_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
@@ -75,7 +74,7 @@ impl Basic {
 }
 
 impl Sharded {
-    pub fn run(&self, opts: Opts) -> Result {
+    pub async fn run(&self, opts: Opts) -> Result {
         let password = get_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;

--- a/src/cmd/validators/list.rs
+++ b/src/cmd/validators/list.rs
@@ -1,0 +1,99 @@
+use crate::{
+    cmd::*,
+    keypair::PublicKey,
+    result::{anyhow, Result},
+};
+use helium_api::{accounts, validators::Validator, IntoVec};
+use prettytable::{format, Table};
+
+#[derive(Debug, StructOpt)]
+/// Get the list of validators owned by one or more wallet addresses
+pub struct Cmd {
+    /// Addresses to get hotspots for
+    #[structopt(short = "a", long = "address")]
+    addresses: Vec<PublicKey>,
+}
+
+impl Cmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        let addresses = collect_addresses(opts.files, self.addresses.clone())?;
+        let api_url = api_url(
+            addresses
+                .first()
+                .map(|key| key.network)
+                .ok_or_else(|| anyhow!("at least one address expected"))?,
+        );
+        let client = Client::new_with_base_url(api_url);
+        let mut results: Vec<(PublicKey, Result<Vec<Validator>>)> =
+            Vec::with_capacity(self.addresses.len());
+        for address in addresses {
+            let validators: Result<Vec<Validator>> =
+                accounts::validators(&client, &address.to_string())
+                    .into_vec()
+                    .await
+                    .map_err(|e| e.into());
+            results.push((address.clone(), validators));
+        }
+        print_results(results, opts.format)
+    }
+}
+
+fn print_results(
+    results: Vec<(PublicKey, Result<Vec<Validator>>)>,
+    format: OutputFormat,
+) -> Result {
+    match format {
+        OutputFormat::Table => {
+            let mut table = Table::new();
+            table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
+            table.set_titles(row!["Address", "Owner", "Stake", "Status"]);
+
+            for (address, result) in results {
+                #[allow(clippy::unused_unit)]
+                match result {
+                    Ok(validators) if validators.is_empty() => {
+                        table.add_row(row![address, H4 -> "No validators found".to_string()]);
+                        ()
+                    }
+                    Ok(validators) => {
+                        for validator in validators {
+                            table.add_row(row![
+                                validator.address,
+                                validator.owner,
+                                Hnt::from(validator.stake),
+                                validator.stake_status
+                            ]);
+                        }
+                    }
+                    Err(err) => {
+                        table.add_row(row![address.to_string(), H4 -> err.to_string()]);
+                    }
+                };
+            }
+            print_table(&table)
+        }
+        OutputFormat::Json => {
+            let mut table = Vec::with_capacity(results.len());
+            for (address, result) in results {
+                let mut table_validators = vec![];
+                if let Ok(validators) = result {
+                    for validator in validators {
+                        table_validators.push(json!({
+                            "address": validator.address,
+                            "owner": validator.address,
+                            "last_heartbeat": validator.last_heartbeat,
+                            "version_heartbeat": validator.version_heartbeat,
+                            "stake": validator.stake,
+                            "status": validator.stake_status,
+                        }))
+                    }
+                };
+                table.push(json!({
+                    "address": address.to_string(),
+                    "validators": table_validators,
+                }));
+            }
+            print_json(&table)
+        }
+    }
+}

--- a/src/cmd/validators/mod.rs
+++ b/src/cmd/validators/mod.rs
@@ -1,5 +1,4 @@
 use crate::{cmd::*, result::Result};
-use structopt::StructOpt;
 
 mod stake;
 mod transfer;
@@ -19,12 +18,12 @@ pub enum Cmd {
 }
 
 impl Cmd {
-    pub fn run(self, opts: Opts) -> Result {
+    pub async fn run(self, opts: Opts) -> Result {
         match self {
             // Self::List(cmd) => cmd.run(opts),
-            Self::Stake(cmd) => cmd.run(opts),
-            Self::Unstake(cmd) => cmd.run(opts),
-            Self::Transfer(cmd) => cmd.run(opts),
+            Self::Stake(cmd) => cmd.run(opts).await,
+            Self::Unstake(cmd) => cmd.run(opts).await,
+            Self::Transfer(cmd) => cmd.run(opts).await,
         }
     }
 }

--- a/src/cmd/validators/mod.rs
+++ b/src/cmd/validators/mod.rs
@@ -1,5 +1,6 @@
 use crate::{cmd::*, result::Result};
 
+mod list;
 mod stake;
 mod transfer;
 mod unstake;
@@ -15,15 +16,17 @@ pub enum Cmd {
     Unstake(unstake::Cmd),
     /// Transfer a validator stake to a new validator and owner
     Transfer(Box<transfer::Cmd>),
+    /// List all validators for one or more account addresses
+    List(list::Cmd),
 }
 
 impl Cmd {
     pub async fn run(self, opts: Opts) -> Result {
         match self {
-            // Self::List(cmd) => cmd.run(opts),
             Self::Stake(cmd) => cmd.run(opts).await,
             Self::Unstake(cmd) => cmd.run(opts).await,
             Self::Transfer(cmd) => cmd.run(opts).await,
+            Self::List(cmd) => cmd.run(opts).await,
         }
     }
 }

--- a/src/cmd/validators/stake.rs
+++ b/src/cmd/validators/stake.rs
@@ -14,6 +14,10 @@ pub struct Cmd {
     /// Amoun to stake
     stake: Hnt,
 
+    /// Manually set fee to pay for the transaction
+    #[structopt(long)]
+    fee: Option<u64>,
+
     /// Whether to commit the transaction to the blockchain
     #[structopt(long)]
     commit: bool,
@@ -35,7 +39,11 @@ impl Cmd {
             owner_signature: vec![],
         };
 
-        txn.fee = txn.txn_fee(&get_txn_fees(&client).await?)?;
+        txn.fee = if let Some(fee) = self.fee {
+            fee
+        } else {
+            txn.txn_fee(&get_txn_fees(&client).await?)?
+        };
         txn.owner_signature = txn.sign(&keypair)?;
 
         let envelope = txn.in_envelope();

--- a/src/cmd/vars.rs
+++ b/src/cmd/vars.rs
@@ -1,12 +1,12 @@
 use crate::{
-    cmd::{api_url, multisig::Artifact, print_json, Opts},
+    cmd::multisig::Artifact,
+    cmd::*,
     keypair::{Network, PublicKey},
     result::Result,
     traits::{ToJson, TxnEnvelope},
 };
-use helium_api::{BlockchainTxnVarsV1, BlockchainVarV1, Client};
+use helium_api::vars;
 use std::{convert::TryInto, str::FromStr};
-use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 /// Commands for chain variables
@@ -56,26 +56,27 @@ pub struct Create {
 }
 
 impl Cmd {
-    pub fn run(&self, opts: Opts) -> Result {
+    pub async fn run(&self, opts: Opts) -> Result {
         match self {
-            Cmd::Current(cmd) => cmd.run(opts),
-            Cmd::Create(cmd) => cmd.run(opts),
+            Cmd::Current(cmd) => cmd.run(opts).await,
+            Cmd::Create(cmd) => cmd.run(opts).await,
         }
     }
 }
 
 impl Current {
-    pub fn run(&self, _opts: Opts) -> Result {
+    pub async fn run(&self, _opts: Opts) -> Result {
         let client = Client::new_with_base_url(api_url(self.network));
-        let vars = client.get_vars()?;
+        let vars = vars::get(&client).await?;
         print_json(&vars)
     }
 }
 
 impl Create {
-    pub fn run(&self, _opts: Opts) -> Result {
+    pub async fn run(&self, _opts: Opts) -> Result {
         let client = Client::new_with_base_url(api_url(self.network));
-        let vars = client.get_vars()?;
+        let vars = vars::get(&client).await?;
+
         let mut txn = BlockchainTxnVarsV1 {
             version_predicate: 0,
             master_key: vec![],

--- a/src/cmd/verify.rs
+++ b/src/cmd/verify.rs
@@ -1,18 +1,13 @@
-use crate::{
-    cmd::{get_password, load_wallet, print_json, print_table, Opts, OutputFormat},
-    result::Result,
-    wallet::Wallet,
-};
+use crate::{cmd::*, result::Result, wallet::Wallet};
 use prettytable::{format, Table};
 use serde_json::json;
-use structopt::StructOpt;
 
 /// Verify an encypted wallet
 #[derive(Debug, StructOpt)]
 pub struct Cmd {}
 
 impl Cmd {
-    pub fn run(&self, opts: Opts) -> Result {
+    pub async fn run(&self, opts: Opts) -> Result {
         let password = get_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let result = wallet.decrypt(password.as_bytes());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,7 @@
 #[macro_use]
-extern crate prettytable;
-
-#[macro_use]
 extern crate lazy_static;
-
 #[macro_use]
-extern crate serde_json;
+extern crate prettytable;
 
 pub mod cmd;
 pub mod format;

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,31 +37,32 @@ pub enum Cmd {
     Validators(validators::Cmd),
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let cli = Cli::from_args();
-    if let Err(e) = run(cli) {
+    if let Err(e) = run(cli).await {
         eprintln!("error: {}", e);
         process::exit(1);
     }
 }
 
-fn run(cli: Cli) -> Result {
+async fn run(cli: Cli) -> Result {
     match cli.cmd {
-        Cmd::Info(cmd) => cmd.run(cli.opts),
-        Cmd::Verify(cmd) => cmd.run(cli.opts),
-        Cmd::Balance(cmd) => cmd.run(cli.opts),
-        Cmd::Hotspots(cmd) => cmd.run(cli.opts),
-        Cmd::Create(cmd) => cmd.run(cli.opts),
-        Cmd::Upgrade(cmd) => cmd.run(cli.opts),
-        Cmd::Pay(cmd) => cmd.run(cli.opts),
-        Cmd::Htlc(cmd) => cmd.run(cli.opts),
-        Cmd::Oui(cmd) => cmd.run(cli.opts),
-        Cmd::Oracle(cmd) => cmd.run(cli.opts),
-        Cmd::Securities(cmd) => cmd.run(cli.opts),
-        Cmd::Burn(cmd) => cmd.run(cli.opts),
-        Cmd::Multisig(cmd) => cmd.run(cli.opts),
-        Cmd::Request(cmd) => cmd.run(cli.opts),
-        Cmd::Vars(cmd) => cmd.run(cli.opts),
-        Cmd::Validators(cmd) => cmd.run(cli.opts),
+        Cmd::Info(cmd) => cmd.run(cli.opts).await,
+        Cmd::Verify(cmd) => cmd.run(cli.opts).await,
+        Cmd::Balance(cmd) => cmd.run(cli.opts).await,
+        Cmd::Hotspots(cmd) => cmd.run(cli.opts).await,
+        Cmd::Create(cmd) => cmd.run(cli.opts).await,
+        Cmd::Upgrade(cmd) => cmd.run(cli.opts).await,
+        Cmd::Pay(cmd) => cmd.run(cli.opts).await,
+        Cmd::Htlc(cmd) => cmd.run(cli.opts).await,
+        Cmd::Oui(cmd) => cmd.run(cli.opts).await,
+        Cmd::Oracle(cmd) => cmd.run(cli.opts).await,
+        Cmd::Securities(cmd) => cmd.run(cli.opts).await,
+        Cmd::Burn(cmd) => cmd.run(cli.opts).await,
+        Cmd::Multisig(cmd) => cmd.run(cli.opts).await,
+        Cmd::Request(cmd) => cmd.run(cli.opts).await,
+        Cmd::Vars(cmd) => cmd.run(cli.opts).await,
+        Cmd::Validators(cmd) => cmd.run(cli.opts).await,
     }
 }

--- a/src/traits/b64.rs
+++ b/src/traits/b64.rs
@@ -1,5 +1,5 @@
 use crate::result::Result;
-use helium_api::{BlockchainTxn, Message};
+use helium_proto::{BlockchainTxn, Message};
 use std::convert::TryInto;
 
 pub trait B64 {

--- a/src/traits/json.rs
+++ b/src/traits/json.rs
@@ -3,7 +3,8 @@ use crate::{
     result::{anyhow, Result},
     traits::B64,
 };
-use helium_api::{BlockchainTxnTransferHotspotV1, BlockchainTxnVarsV1, BlockchainVarV1};
+use helium_proto::*;
+use serde_json::json;
 
 pub(crate) fn maybe_b58(data: &[u8]) -> Result<Option<String>> {
     if data.is_empty() {

--- a/src/traits/txn_envelope.rs
+++ b/src/traits/txn_envelope.rs
@@ -1,12 +1,5 @@
 use crate::result::{anyhow, Result};
-use helium_api::{
-    BlockchainTxn, BlockchainTxnAddGatewayV1, BlockchainTxnAssertLocationV1,
-    BlockchainTxnCreateHtlcV1, BlockchainTxnOuiV1, BlockchainTxnPaymentV1, BlockchainTxnPaymentV2,
-    BlockchainTxnPriceOracleV1, BlockchainTxnRedeemHtlcV1, BlockchainTxnSecurityExchangeV1,
-    BlockchainTxnStakeValidatorV1, BlockchainTxnTokenBurnV1, BlockchainTxnTransferHotspotV1,
-    BlockchainTxnTransferValidatorStakeV1, BlockchainTxnUnstakeValidatorV1, BlockchainTxnVarsV1,
-    Txn,
-};
+use helium_proto::*;
 
 pub trait TxnEnvelope {
     fn in_envelope(&self) -> BlockchainTxn;

--- a/src/traits/txn_fee.rs
+++ b/src/traits/txn_fee.rs
@@ -1,12 +1,6 @@
 use super::TxnEnvelope;
 use crate::result::Result;
-use helium_api::{
-    BlockchainTxnAddGatewayV1, BlockchainTxnAssertLocationV1, BlockchainTxnCreateHtlcV1,
-    BlockchainTxnOuiV1, BlockchainTxnPaymentV1, BlockchainTxnPaymentV2, BlockchainTxnRedeemHtlcV1,
-    BlockchainTxnSecurityExchangeV1, BlockchainTxnStakeValidatorV1, BlockchainTxnTokenBurnV1,
-    BlockchainTxnTransferHotspotV1, BlockchainTxnTransferValidatorStakeV1,
-    BlockchainTxnUnstakeValidatorV1, Message,
-};
+use helium_proto::*;
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -158,7 +152,7 @@ impl TxnStakingFee for BlockchainTxnOuiV1 {
 mod tests {
     use super::*;
     use crate::keypair::Keypair;
-    use helium_api::Payment;
+    use helium_proto::Payment;
 
     macro_rules! assert_txn_fee {
         ($txn: expr, $cfg: expr, $expected: expr) => {

--- a/src/traits/txn_payer.rs
+++ b/src/traits/txn_payer.rs
@@ -2,7 +2,7 @@ use crate::{
     keypair::PublicKey,
     result::{anyhow, Result},
 };
-use helium_api::{BlockchainTxn, Txn};
+use helium_proto::*;
 
 pub trait TxnPayer {
     fn payer(&self) -> Result<Option<PublicKey>>;

--- a/src/traits/txn_sign.rs
+++ b/src/traits/txn_sign.rs
@@ -1,13 +1,6 @@
 use crate::keypair::{Keypair, PublicKey, Verify};
 use crate::result::Result;
-use helium_api::{
-    BlockchainTxnAddGatewayV1, BlockchainTxnAssertLocationV1, BlockchainTxnCreateHtlcV1,
-    BlockchainTxnOuiV1, BlockchainTxnPaymentV1, BlockchainTxnPaymentV2, BlockchainTxnPriceOracleV1,
-    BlockchainTxnRedeemHtlcV1, BlockchainTxnSecurityExchangeV1, BlockchainTxnStakeValidatorV1,
-    BlockchainTxnTokenBurnV1, BlockchainTxnTransferHotspotV1,
-    BlockchainTxnTransferValidatorStakeV1, BlockchainTxnUnstakeValidatorV1, BlockchainTxnVarsV1,
-    Message,
-};
+use helium_proto::*;
 
 pub trait TxnSign: Message + std::clone::Clone {
     fn sign(&self, keypair: &Keypair) -> Result<Vec<u8>>


### PR DESCRIPTION
This PR:

- Adds a `--fee` flag to `validator stake`, `validator unstake`, and `validator transfer create` commands
- Updates the `print_txn` function in `validator unstake` to print base64 encoded txn
- Updates `validator transfer create` to output to print base64 encoded txn
- Updates `pay` command to include a `--nonce` flag

Ultimately, the above enables running the CLI wallet in an airgapped configuration.