### PR TITLE
fix printed address in htlx redeem txn

### DIFF
--- a/src/cmd/htlc.rs
+++ b/src/cmd/htlc.rs
@@ -167,7 +167,7 @@ fn print_redeem_txn(
             ptable!(
                 ["Key", "Value"],
                 ["Payee", PublicKey::from_bytes(&txn.payee)?.to_string()],
-                ["Address", PublicKey::from_bytes(&txn.payee)?.to_string()],
+                ["Address", PublicKey::from_bytes(&txn.address)?.to_string()],
                 ["Preimage", std::str::from_utf8(&txn.preimage)?],
                 ["Hash", status_str(status)]
             );


### PR DESCRIPTION
The payee was being print in place of the address on the HTLC redeem transaction