### PR TITLE
Adding necessary args to pay and validators commands to enable airgapped CLI wallet

### DIFF
--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -18,7 +18,11 @@ pub struct Cmd {
     #[structopt(long = "payee", short = "p", name = "payee=hnt", required = true)]
     payees: Vec<Payee>,
 
-    /// Manually set DC fee to pay for the transaction
+    /// Manually set the nonce to use for the transaction
+    #[structopt(long)]
+    nonce: Option<u64>,
+    
+    /// Manually set the DC fee to pay for the transaction
     #[structopt(long)]
     fee: Option<u64>,
 
@@ -35,7 +39,6 @@ impl Cmd {
         let client = Client::new_with_base_url(api_url(wallet.public_key.network));
 
         let keypair = wallet.decrypt(password.as_bytes())?;
-        let account = accounts::get(&client, &keypair.public_key().to_string()).await?;
 
         let payments: Vec<Payment> = self
             .payees
@@ -49,7 +52,7 @@ impl Cmd {
             fee: 0,
             payments,
             payer: keypair.public_key().to_vec(),
-            nonce: account.speculative_nonce + 1,
+            nonce: 0,
             signature: Vec::new(),
         };
 
@@ -57,6 +60,12 @@ impl Cmd {
             fee
         } else {
             txn.txn_fee(&get_txn_fees(&client).await?)?
+        };
+        txn.nonce = if let Some(nonce) = self.nonce {
+            nonce
+        } else {
+            let account = accounts::get(&client, &keypair.public_key().to_string()).await?;
+            account.speculative_nonce + 1
         };
         txn.signature = txn.sign(&keypair)?;
 

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -53,11 +53,11 @@ impl Cmd {
             payments,
             payer: keypair.public_key().to_vec(),
             nonce: if let Some(nonce) = self.nonce {
-                    nonce
-                } else {
-                    let account = accounts::get(&client, &keypair.public_key().to_string()).await?;
-                    account.speculative_nonce + 1
-                },
+                nonce
+            } else {
+                let account = accounts::get(&client, &keypair.public_key().to_string()).await?;
+                account.speculative_nonce + 1
+            },
             signature: Vec::new(),
         };
 

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -52,7 +52,12 @@ impl Cmd {
             fee: 0,
             payments,
             payer: keypair.public_key().to_vec(),
-            nonce: 0,
+            nonce: if let Some(nonce) = self.nonce {
+                    nonce
+                } else {
+                    let account = accounts::get(&client, &keypair.public_key().to_string()).await?;
+                    account.speculative_nonce + 1
+                },
             signature: Vec::new(),
         };
 
@@ -60,12 +65,6 @@ impl Cmd {
             fee
         } else {
             txn.txn_fee(&get_txn_fees(&client).await?)?
-        };
-        txn.nonce = if let Some(nonce) = self.nonce {
-            nonce
-        } else {
-            let account = accounts::get(&client, &keypair.public_key().to_string()).await?;
-            account.speculative_nonce + 1
         };
         txn.signature = txn.sign(&keypair)?;
 

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -21,7 +21,7 @@ pub struct Cmd {
     /// Manually set the nonce to use for the transaction
     #[structopt(long)]
     nonce: Option<u64>,
-    
+
     /// Manually set the DC fee to pay for the transaction
     #[structopt(long)]
     fee: Option<u64>,

--- a/src/cmd/validators/stake.rs
+++ b/src/cmd/validators/stake.rs
@@ -17,7 +17,7 @@ pub struct Cmd {
     /// Manually set fee to pay for the transaction
     #[structopt(long)]
     fee: Option<u64>,
-    
+
     /// Whether to commit the transaction to the blockchain
     #[structopt(long)]
     commit: bool,

--- a/src/cmd/validators/stake.rs
+++ b/src/cmd/validators/stake.rs
@@ -14,6 +14,10 @@ pub struct Cmd {
     /// Amount to stake
     stake: Hnt,
 
+    /// Manually set fee to pay for the transaction
+    #[structopt(long)]
+    fee: Option<u64>,
+    
     /// Whether to commit the transaction to the blockchain
     #[structopt(long)]
     commit: bool,
@@ -35,7 +39,11 @@ impl Cmd {
             owner_signature: vec![],
         };
 
-        txn.fee = txn.txn_fee(&get_txn_fees(&client).await?)?;
+        txn.fee = if let Some(fee) = self.fee {
+            fee
+        } else {
+            txn.txn_fee(&get_txn_fees(&client).await?)?
+        };
         txn.owner_signature = txn.sign(&keypair)?;
 
         let envelope = txn.in_envelope();

--- a/src/cmd/validators/transfer.rs
+++ b/src/cmd/validators/transfer.rs
@@ -101,7 +101,13 @@ impl Create {
                 .map(|o| o.to_vec())
                 .unwrap_or_else(Vec::new),
             fee: 0,
-            stake_amount: 0,
+            stake_amount: if let Some(stake_amount) = self.stake_amount {
+                    u64::from(stake_amount)
+                } else {
+                    helium_api::validators::get(&client, &self.old_address.to_string())
+                        .await?
+                        .stake
+                },
             payment_amount: u64::from(self.amount),
             old_owner_signature: vec![],
             new_owner_signature: vec![],
@@ -111,13 +117,6 @@ impl Create {
             fee
         } else {
             txn.txn_fee(&get_txn_fees(&client).await?)?
-        };
-        txn.stake_amount = if let Some(stake_amount) = self.stake_amount {
-            u64::from(stake_amount)
-        } else {
-            helium_api::validators::get(&client, &self.old_address.to_string())
-                .await?
-                .stake
         };
         if old_owner == &wallet.public_key {
             txn.old_owner_signature = txn.sign(&keypair)?;

--- a/src/cmd/validators/transfer.rs
+++ b/src/cmd/validators/transfer.rs
@@ -102,12 +102,12 @@ impl Create {
                 .unwrap_or_else(Vec::new),
             fee: 0,
             stake_amount: if let Some(stake_amount) = self.stake_amount {
-                    u64::from(stake_amount)
-                } else {
-                    helium_api::validators::get(&client, &self.old_address.to_string())
-                        .await?
-                        .stake
-                },
+                u64::from(stake_amount)
+            } else {
+                helium_api::validators::get(&client, &self.old_address.to_string())
+                    .await?
+                    .stake
+            },
             payment_amount: u64::from(self.amount),
             old_owner_signature: vec![],
             new_owner_signature: vec![],

--- a/src/cmd/validators/transfer.rs
+++ b/src/cmd/validators/transfer.rs
@@ -48,7 +48,7 @@ pub struct Create {
     /// Manually set fee to pay for the transaction
     #[structopt(long)]
     fee: Option<u64>,
-    
+
     /// Whether to commit the transaction to the blockchain
     #[structopt(long)]
     commit: bool,
@@ -116,8 +116,8 @@ impl Create {
             u64::from(stake_amount)
         } else {
             helium_api::validators::get(&client, &self.old_address.to_string())
-            .await?
-            .stake
+                .await?
+                .stake
         };
         if old_owner == &wallet.public_key {
             txn.old_owner_signature = txn.sign(&keypair)?;

--- a/src/cmd/validators/transfer.rs
+++ b/src/cmd/validators/transfer.rs
@@ -41,6 +41,14 @@ pub struct Create {
     #[structopt(long, default_value = "0")]
     amount: Hnt,
 
+    /// The amount of HNT of the original stake
+    #[structopt(long)]
+    stake_amount: Option<Hnt>,
+
+    /// Manually set fee to pay for the transaction
+    #[structopt(long)]
+    fee: Option<u64>,
+    
     /// Whether to commit the transaction to the blockchain
     #[structopt(long)]
     commit: bool,
@@ -82,9 +90,6 @@ impl Create {
         let client = helium_api::Client::new_with_base_url(api_url(wallet.public_key.network));
 
         let old_owner = self.old_owner.as_ref().unwrap_or(&wallet.public_key);
-        let stake_amount = helium_api::validators::get(&client, &self.old_address.to_string())
-            .await?
-            .stake;
 
         let mut txn = BlockchainTxnTransferValidatorStakeV1 {
             old_address: self.old_address.to_vec(),
@@ -96,13 +101,24 @@ impl Create {
                 .map(|o| o.to_vec())
                 .unwrap_or_else(Vec::new),
             fee: 0,
-            stake_amount,
+            stake_amount: 0,
             payment_amount: u64::from(self.amount),
             old_owner_signature: vec![],
             new_owner_signature: vec![],
         };
 
-        txn.fee = txn.txn_fee(&get_txn_fees(&client).await?)?;
+        txn.fee = if let Some(fee) = self.fee {
+            fee
+        } else {
+            txn.txn_fee(&get_txn_fees(&client).await?)?
+        };
+        txn.stake_amount = if let Some(stake_amount) = self.stake_amount {
+            u64::from(stake_amount)
+        } else {
+            helium_api::validators::get(&client, &self.old_address.to_string())
+            .await?
+            .stake
+        };
         if old_owner == &wallet.public_key {
             txn.old_owner_signature = txn.sign(&keypair)?;
         }
@@ -139,7 +155,7 @@ impl Accept {
 
         let envelope = txn.in_envelope();
         let status = maybe_submit_txn(self.commit, &client, &envelope).await?;
-        print_txn(None, &txn, &status, opts.format)
+        print_txn(Some(&envelope), &txn, &status, opts.format)
     }
 }
 

--- a/src/cmd/validators/unstake.rs
+++ b/src/cmd/validators/unstake.rs
@@ -18,7 +18,7 @@ pub struct Cmd {
     /// Manually set the fee to pay for the transaction
     #[structopt(long)]
     fee: Option<u64>,
-    
+
     /// Whether to commit the transaction to the blockchain
     #[structopt(long)]
     commit: bool,
@@ -49,8 +49,8 @@ impl Cmd {
             u64::from(stake_amount)
         } else {
             helium_api::validators::get(&client, &self.address.to_string())
-            .await?
-            .stake
+                .await?
+                .stake
         };
         txn.owner_signature = txn.sign(&keypair)?;
 

--- a/src/cmd/validators/unstake.rs
+++ b/src/cmd/validators/unstake.rs
@@ -36,12 +36,12 @@ impl Cmd {
             address: self.address.to_vec(),
             owner: wallet.public_key.to_vec(),
             stake_amount: if let Some(stake_amount) = self.stake_amount {
-                    u64::from(stake_amount)
-                } else {
-                    helium_api::validators::get(&client, &self.address.to_string())
-                        .await?
-                        .stake
-                },
+                u64::from(stake_amount)
+            } else {
+                helium_api::validators::get(&client, &self.address.to_string())
+                    .await?
+                    .stake
+            },
             fee: 0,
             owner_signature: vec![],
         };


### PR DESCRIPTION
This PR:

- Adds a `--nonce` flag to the `pay` command
- Adds a `--fee` flag to `validators stake`, `validators unstake`, and `validators transfer create` commands
- Adds a `--stake-amout` flag to `validators unstake` and `validators transfer create` commands
- Updates the `print_txn` function in `validators unstake` to print base64 encoded txn
- Updates `validators transfer accept` to print base64 encoded txn

Ultimately, the above enables running the CLI wallet in an airgapped configuration.