### PR TITLE
Adds validator generate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "angry-purple-tiger"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c749eb8b90a5c85a879ac35bba5374ba18ff41d609878d7d37dd2ac0122a3c"
+dependencies = [
+ "md5",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,7 +487,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.9.6"
-source = "git+https://github.com/helium/traits.git?branch=rg/compact#a8c709ed04118eaa0f10ec5b4c8f59162b507898"
+source = "git+https://github.com/helium/traits.git?branch=rg/compact#c6cef06097aa9f8dbf608ffb96f95d6497622f86"
 dependencies = [
  "ff",
  "funty",
@@ -781,6 +790,7 @@ name = "helium-wallet"
 version = "1.5.1-dev"
 dependencies = [
  "aes-gcm",
+ "angry-purple-tiger",
  "anyhow",
  "base64",
  "bs58",
@@ -975,9 +985,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
+checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "libsodium-sys"
@@ -1015,6 +1025,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2182a122f3b7f3f5329cb1972cee089ba2459a0a80a56935e6e674f096f8d839"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
@@ -1051,11 +1067,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi",
 ]
 
@@ -1587,18 +1602,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,10 @@ serde_derive = "1"
 serde_json = "1"
 rust_decimal = {version = "1", features = ["serde-float"] }
 helium-api = "2"
+angry-purple-tiger = "0"
 helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.0.7"}
 helium-proto = { git = "https://github.com/helium/proto", branch="master"}
-tokio = {version = "1.2", features = ["full"]}
+tokio = {version = "1", features = ["full"]}
 
 [dev-dependencies]
 bs58 = "0.4"

--- a/src/cmd/validators/generate.rs
+++ b/src/cmd/validators/generate.rs
@@ -1,0 +1,55 @@
+use crate::{
+    cmd::*,
+    keypair::{KeyTag, KeyType, Keypair, NETTYPE_MAIN_STR},
+    result::Result,
+    traits::ReadWrite,
+};
+use angry_purple_tiger::AnimalName;
+use std::path::PathBuf;
+
+#[derive(Debug, StructOpt)]
+/// Create a keypair ready for a validator to use.
+pub struct Cmd {
+    /// Output file to store the key in
+    #[structopt(short, long, default_value = "swarm_key")]
+    output: PathBuf,
+
+    #[structopt(long)]
+    /// Overwrite an existing file
+    force: bool,
+
+    #[structopt(long, default_value = NETTYPE_MAIN_STR)]
+    /// The network to generate the keypair on (testnet/mainnet)
+    network: Network,
+}
+
+impl Cmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        let tag = KeyTag {
+            network: self.network,
+            key_type: KeyType::EccCompact,
+        };
+        let keypair = Keypair::generate(tag);
+        let mut writer = open_output_file(&self.output, !self.force)?;
+        keypair.write(&mut writer)?;
+        print_keypair(&keypair, opts.format)
+    }
+}
+
+fn print_keypair(keypair: &Keypair, format: OutputFormat) -> Result {
+    let address = keypair.public_key().to_string();
+    let name = address.parse::<AnimalName>()?.to_string();
+    match format {
+        OutputFormat::Table => {
+            ptable!(["Key", "Value"], ["Address", address], ["Name", name]);
+            Ok(())
+        }
+        OutputFormat::Json => {
+            let table = json!({
+                "address": address,
+                "name": name,
+            });
+            print_json(&table)
+        }
+    }
+}

--- a/src/cmd/validators/mod.rs
+++ b/src/cmd/validators/mod.rs
@@ -1,5 +1,6 @@
 use crate::{cmd::*, result::Result};
 
+mod generate;
 mod list;
 mod stake;
 mod transfer;
@@ -18,6 +19,8 @@ pub enum Cmd {
     Transfer(Box<transfer::Cmd>),
     /// List all validators for one or more account addresses
     List(list::Cmd),
+    /// Generate a validator key
+    Generate(generate::Cmd),
 }
 
 impl Cmd {
@@ -27,6 +30,7 @@ impl Cmd {
             Self::Unstake(cmd) => cmd.run(opts).await,
             Self::Transfer(cmd) => cmd.run(opts).await,
             Self::List(cmd) => cmd.run(opts).await,
+            Self::Generate(cmd) => cmd.run(opts).await,
         }
     }
 }


### PR DESCRIPTION
This adds a `valdiator generate` command to generate a swarm_key file ready to be used by validator services.

**Note** that this key is _not_ encrypted like a wallet


Fixes: #105 