### PR TITLE
Update JSON output for validators list cmd to print validator owner 

### DIFF
--- a/src/cmd/validators/list.rs
+++ b/src/cmd/validators/list.rs
@@ -80,7 +80,7 @@ fn print_results(
                     for validator in validators {
                         table_validators.push(json!({
                             "address": validator.address,
-                            "owner": validator.address,
+                            "owner": validator.owner,
                             "last_heartbeat": validator.last_heartbeat,
                             "version_heartbeat": validator.version_heartbeat,
                             "stake": validator.stake,


### PR DESCRIPTION
Currently the `owner` field in the JSON output for the `validators list` command prints the validator address.

This PR updates to print the owner address.