### PR TITLE
Add memo to payments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,13 +957,14 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.0.7"
-source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.0.7#8041c2aaf82bac689cb55ef6a070d6c3a826effc"
+version = "0.0.8"
+source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.0.8#353ad62d22f7e8eb6a6bb12a2e14a2d41ec1eb14"
 dependencies = [
  "bs58",
  "ed25519-dalek",
  "p256",
  "rand_core 0.6.2",
+ "serde",
  "signature",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ h3ron = "^0.10"
 geo-types = "^0.6" # pinned by h3ron but required here for geo_types::Point
 helium-api = "2"
 angry-purple-tiger = "0"
-helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.0.7"}
+helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.0.8"}
 helium-proto = { git = "https://github.com/helium/proto", branch="master"}
 tokio = {version = "1", features = ["full"]}
 

--- a/src/cmd/burn.rs
+++ b/src/cmd/burn.rs
@@ -16,8 +16,8 @@ pub struct Cmd {
     payee: PublicKey,
 
     /// Memo field to include. Provide as a base64 encoded string
-    #[structopt(long)]
-    memo: Option<Memo>,
+    #[structopt(long, default_value)]
+    memo: Memo,
 
     /// Amount of HNT to burn to DC
     #[structopt(long)]
@@ -43,7 +43,7 @@ impl Cmd {
             payee: self.payee.to_bytes().to_vec(),
             amount: u64::from(self.amount),
             payer: keypair.public_key().into(),
-            memo: *self.memo.as_ref().unwrap_or(&Memo::default()).as_ref(),
+            memo: u64::from(&self.memo),
             nonce: account.speculative_nonce + 1,
             signature: Vec::new(),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate prettytable;
 pub mod cmd;
 pub mod format;
 pub mod keypair;
+pub mod memo;
 pub mod mnemonic;
 pub mod pwhash;
 pub mod result;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ pub enum Cmd {
     Hotspots(Box<hotspots::Cmd>),
     Create(create::Cmd),
     Upgrade(upgrade::Cmd),
-    Pay(pay::Cmd),
+    Pay(Box<pay::Cmd>),
     Htlc(htlc::Cmd),
     Oui(oui::Cmd),
     Oracle(oracle::Cmd),

--- a/src/memo.rs
+++ b/src/memo.rs
@@ -1,0 +1,37 @@
+use crate::{
+    result::{anyhow, Result},
+    traits::B64,
+};
+use std::{fmt, str::FromStr};
+
+#[derive(Debug, Default, PartialEq)]
+pub struct Memo(u64);
+
+impl FromStr for Memo {
+    type Err = crate::result::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match u64::from_b64(s) {
+            Ok(v) => Ok(Memo(v)),
+            Err(_) => Err(anyhow!("Invalid base64 memo")),
+        }
+    }
+}
+
+impl From<u64> for Memo {
+    fn from(v: u64) -> Self {
+        Memo(v)
+    }
+}
+
+impl AsRef<u64> for Memo {
+    fn as_ref(&self) -> &u64 {
+        &self.0
+    }
+}
+
+impl fmt::Display for Memo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0.to_b64().unwrap())
+    }
+}

--- a/src/memo.rs
+++ b/src/memo.rs
@@ -2,6 +2,7 @@ use crate::{
     result::{anyhow, Result},
     traits::B64,
 };
+use serde::de::{self, Deserialize, Deserializer, Visitor};
 use std::{fmt, str::FromStr};
 
 #[derive(Debug, Default, PartialEq)]
@@ -24,14 +25,43 @@ impl From<u64> for Memo {
     }
 }
 
-impl AsRef<u64> for Memo {
-    fn as_ref(&self) -> &u64 {
-        &self.0
+impl From<&Memo> for u64 {
+    fn from(v: &Memo) -> Self {
+        v.0
     }
 }
 
 impl fmt::Display for Memo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0.to_b64().unwrap())
+    }
+}
+
+impl<'de> Deserialize<'de> for Memo {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct MemoVisitor;
+
+        impl<'de> Visitor<'de> for MemoVisitor {
+            type Value = Memo;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("base64 string")
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<Memo, E>
+            where
+                E: de::Error,
+            {
+                match u64::from_b64(value) {
+                    Ok(v) => Ok(Memo(v)),
+                    Err(_) => Err(de::Error::custom("invalid memo")),
+                }
+            }
+        }
+
+        deserializer.deserialize_str(MemoVisitor)
     }
 }


### PR DESCRIPTION
Adds memo supports to payments. This includes a breaking change to the payment CLI.

Previously, a payment could be described as follows:
```
<payee>=<amount>
```

Now, the same payment would require the following description:
```
<payee>?amount=<amount>
```

A memo may be added:
```
<payee>?amount=<amount>?memo=<memo>
```

Equivalently:
```
<payee>?memo=<memo>?amount=<amount>
```

Note: URL syntax was abandoned as it required encapsulation of the command within a string to avoid having the `&` push the command to the background. Since the command otherwise works and loses the memo in this situation, it was deemed to prone to error and unsafe.