### PR TITLE
Add multi validator stake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99446914425f48a667458b33c7fb920e24cf9e7c149a072a9fc420731b353835"
+checksum = "32380222440685202b62f23002e668519a6bf2d8df5e7655ed96223b6482b4be"
 dependencies = [
  "cfg-if",
  "cipher 0.3.0",
@@ -372,9 +372,12 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd5a7748210e7ec1a9696610b1015e6e31fbf58f77a160801f124bd1c36592a"
+checksum = "dec1028182c380cc45a2e2c5ec841134f2dfd0f8f5f0a5bcd68004f81b5efdf4"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpuid-bool"
@@ -565,7 +568,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.9.11"
-source = "git+https://github.com/helium/traits.git?branch=rg/compact#c94b54ebd908c195638e98904848de9da8e99581"
+source = "git+https://github.com/helium/traits.git?branch=rg/compact#4a17f24a1fb7355af284558926491ab6da817047"
 dependencies = [
  "bitvec",
  "ff",
@@ -657,9 +660,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -672,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -682,15 +685,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -699,16 +702,17 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -717,22 +721,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1055,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
@@ -1066,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1ce40d6fc9764887c2fdc7305c3dcc429ba11ff981c1509416afd5697e4437"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
@@ -1183,9 +1188,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1361,8 +1366,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.8.0"
-source = "git+https://github.com/helium/elliptic-curves?branch=rg/compact#cea43802b1a110457e7d58047438c1b6f5893dd2"
+version = "0.8.1"
+source = "git+https://github.com/helium/elliptic-curves?branch=rg/compact#1c360bddb599db9af19ded0be493a79e7748bc1e"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1723,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5f1ceb7f74abbce32601642fcf8e8508a8a8991e0621c7d750295b9095702b"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1903,18 +1908,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1946,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f6b75b17576b792bef0db1bcc4b8b8bcdf9506744cf34b974195487af6cff2"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer",
  "cfg-if",
@@ -2384,9 +2389,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2430,9 +2435,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if",
  "serde",
@@ -2442,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2457,9 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2469,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2479,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2492,15 +2497,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src/cmd/validators/stake.rs
+++ b/src/cmd/validators/stake.rs
@@ -1,54 +1,123 @@
 use crate::{
     cmd::*,
+    keypair::Keypair,
     result::Result,
     traits::{TxnEnvelope, TxnFee, TxnSign},
 };
+use serde::Deserialize;
 
 #[derive(Debug, StructOpt)]
-/// Onboard a given encoded validator staking transaction with this wallet.
-/// transaction signed by the Helium staking server.
+/// Onboard one (or more) validators  with this wallet. If an input file is
+/// specified for multiple payments, the address and stake arguments are
+/// ignored.
+///
+/// The input file for multiple validator stakes is expected to be json file
+/// with a list of address and staking amounts. For example:
+///
+/// [
+///     {
+///         "address": "<adddress1>",
+///         "stake": 10000,
+///     },
+///     {
+///         "address": "<adddress2>",
+///         "stake": 10000
+///     }
+/// ]
+///
+/// The payment is not submitted to the system unless the '--commit' option is
+/// given.
+///
+/// Note that multiple staking transactions are submitted individually and not as a
+/// single transaction. Any failures will abort the remaining staking entries.
 pub struct Cmd {
+    /// File to read multiple validator stakes from.
+    #[structopt(long)]
+    input: Option<PathBuf>,
+
     /// Address of the validator to stake
-    address: PublicKey,
+    #[structopt(long)]
+    address: Option<PublicKey>,
 
     /// Amount to stake
-    stake: Hnt,
+    #[structopt(long)]
+    stake: Option<Hnt>,
 
-    /// Manually set fee to pay for the transaction
+    /// Manually set fee to pay for the transaction(s)
     #[structopt(long)]
     fee: Option<u64>,
 
-    /// Whether to commit the transaction to the blockchain
+    /// Whether to commit the transaction(s) to the blockchain
     #[structopt(long)]
     commit: bool,
 }
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
+        let validators = self.collect_validators()?;
+
         let password = get_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
 
         let client = helium_api::Client::new_with_base_url(api_url(wallet.public_key.network));
+        let fee_config = if self.fee.is_none() {
+            Some(get_txn_fees(&client).await?)
+        } else {
+            None
+        };
 
+        for validator in validators {
+            let txn = self.mk_txn(&keypair, &fee_config, &validator)?;
+            let envelope = txn.in_envelope();
+            let status = maybe_submit_txn(self.commit, &client, &envelope).await?;
+            print_txn(&envelope, &txn, &status, &opts.format)?
+        }
+        Ok(())
+    }
+
+    fn mk_txn(
+        &self,
+        keypair: &Keypair,
+        fee_config: &Option<TxnFeeConfig>,
+        validator: &Validator,
+    ) -> Result<BlockchainTxnStakeValidatorV1> {
         let mut txn = BlockchainTxnStakeValidatorV1 {
-            address: self.address.to_vec(),
-            owner: wallet.public_key.to_vec(),
-            stake: u64::from(self.stake),
+            address: validator.address.to_vec(),
+            owner: keypair.public_key().to_vec(),
+            stake: u64::from(validator.stake),
             fee: 0,
             owner_signature: vec![],
         };
-
         txn.fee = if let Some(fee) = self.fee {
             fee
         } else {
-            txn.txn_fee(&get_txn_fees(&client).await?)?
+            txn.txn_fee(&fee_config.as_ref().unwrap())?
         };
         txn.owner_signature = txn.sign(&keypair)?;
+        Ok(txn)
+    }
 
-        let envelope = txn.in_envelope();
-        let status = maybe_submit_txn(self.commit, &client, &envelope).await?;
-        print_txn(&envelope, &txn, &status, opts.format)
+    fn collect_validators(&self) -> Result<Vec<Validator>> {
+        match &self.input {
+            None => Ok(vec![Validator {
+                address: if let Some(address) = &self.address {
+                    address.clone()
+                } else {
+                    bail!("address expected for validator")
+                },
+                stake: if let Some(stake) = self.stake {
+                    stake
+                } else {
+                    bail!("stake expected for validator")
+                },
+            }]),
+            Some(path) => {
+                let file = std::fs::File::open(path)?;
+                let validators: Vec<Validator> = serde_json::from_reader(file)?;
+                Ok(validators)
+            }
+        }
     }
 }
 
@@ -56,7 +125,7 @@ fn print_txn(
     envelope: &BlockchainTxn,
     txn: &BlockchainTxnStakeValidatorV1,
     status: &Option<PendingTxnStatus>,
-    format: OutputFormat,
+    format: &OutputFormat,
 ) -> Result {
     let validator = PublicKey::from_bytes(&txn.address)?.to_string();
     match format {
@@ -64,8 +133,12 @@ fn print_txn(
             ptable!(
                 ["Key", "Value"],
                 ["Validator", validator],
-                ["Fee", txn.fee],
-                ["Hash", status_str(status)]
+                ["Stake (HNT)", Hnt::from(txn.stake)],
+                ["Fee (DC)", txn.fee],
+                ["Hash", status_str(status)],
+                [Frb => "WARNING",
+                "Once staked an owner cannot access the staked amount until\n\
+                250,000 blocks (approx. 5 months) after unstaking."]
             );
             print_footer(status)
         }
@@ -73,10 +146,17 @@ fn print_txn(
             let table = json!({
                 "validator" : validator,
                 "fee": txn.fee,
+                "staking_fee": txn.stake,
                 "txn": envelope.to_b64()?,
                 "hash": status_json(status)
             });
             print_json(&table)
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Validator {
+    address: PublicKey,
+    stake: Hnt,
 }


### PR DESCRIPTION
This adds the ability to provide an `--input <filename.json> ` option to provide multiple validator stakes in one command line. 

See the `validators stake --help` output on how to structure the json file and caveats around the transaction behavior. 

Fixes #127 
Fixes #123 