### PR TITLE
Retrieve mnemonic phrase with verify command.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +677,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
 name = "futures"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1019,7 @@ dependencies = [
  "angry-purple-tiger",
  "anyhow",
  "base64 0.13.0",
+ "bitvec",
  "bs58",
  "byteorder",
  "dialoguer",
@@ -1636,6 +1655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
 name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,6 +2623,12 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xsalsa20poly1305"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ angry-purple-tiger = "0"
 helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.2.2"}
 helium-proto = { git = "https://github.com/helium/proto", branch="master"}
 tokio = {version = "1", features = ["full"]}
+bitvec = "*" # inherits from elliptic-curve crate
 
 [dev-dependencies]
 bs58 = "0.4"

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -100,7 +100,12 @@ impl Basic {
             .seed_words(seed_words)
             .create()?;
 
-        verify::print_result(&wallet, true, opts.format)
+        verify::print_result(
+            &wallet,
+            &wallet.decrypt(password.as_bytes()),
+            None,
+            opts.format,
+        )
     }
 }
 
@@ -130,6 +135,11 @@ impl Sharded {
             .shard(Some(shard_config))
             .create()?;
 
-        verify::print_result(&wallet, true, opts.format)
+        verify::print_result(
+            &wallet,
+            &wallet.decrypt(password.as_bytes()),
+            None,
+            opts.format,
+        )
     }
 }

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -69,7 +69,7 @@ impl Basic {
         let new_wallet = Wallet::encrypt(&keypair, password.as_bytes(), Format::Basic(format))?;
         let mut writer = open_output_file(&self.output, !self.force)?;
         new_wallet.write(&mut writer)?;
-        verify::print_result(&new_wallet, true, opts.format)
+        verify::print_result(&wallet, &Ok(keypair), None, opts.format)
     }
 }
 
@@ -95,6 +95,6 @@ impl Sharded {
             let mut writer = open_output_file(&filename, !self.force)?;
             shard.write(&mut writer)?;
         }
-        verify::print_result(&new_wallet, true, opts.format)
+        verify::print_result(&wallet, &Ok(keypair), None, opts.format)
     }
 }

--- a/src/cmd/verify.rs
+++ b/src/cmd/verify.rs
@@ -1,37 +1,67 @@
-use crate::{cmd::*, result::Result, wallet::Wallet};
-use prettytable::{format, Table};
+use crate::{cmd::*, keypair::Keypair, mnemonic::SeedType, result::Result, wallet::Wallet};
+use prettytable::{Cell, Row, Table};
 use serde_json::json;
 
 /// Verify an encypted wallet
 #[derive(Debug, StructOpt)]
-pub struct Cmd {}
+pub struct Cmd {
+    #[structopt(long, possible_values = &["bip39", "mobile"], case_insensitive = true)]
+    /// Use a BIP39 or mobile app seed phrase to generate the wallet keys
+    seed: Option<SeedType>,
+}
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let password = get_password(false)?;
         let wallet = load_wallet(opts.files)?;
-        let result = wallet.decrypt(password.as_bytes());
-        print_result(&wallet, result.is_ok(), opts.format)
+        let decryped_wallet = wallet.decrypt(password.as_bytes());
+        print_result(&wallet, &decryped_wallet, self.seed.as_ref(), opts.format)
     }
 }
 
-pub fn print_result(wallet: &Wallet, result: bool, format: OutputFormat) -> Result {
+pub fn print_result(
+    wallet: &Wallet,
+    decrypted_wallet: &Result<Keypair>,
+    seed_type: Option<&SeedType>,
+    format: OutputFormat,
+) -> Result {
     let address = wallet.address().unwrap_or_else(|_| "unknown".to_string());
+    let phrase = seed_type.map(|seed_type| {
+        decrypted_wallet
+            .as_ref()
+            .map_or(Ok(vec![]), |decrypted_wallet| {
+                decrypted_wallet.phrase(seed_type)
+            })
+    });
+
     match format {
         OutputFormat::Table => {
             let mut table = Table::new();
-            table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
-            table.set_titles(row!["Address", "Sharded", "Verify", "PwHash"]);
-            table.add_row(row![address, wallet.is_sharded(), result, wallet.pwhash()]);
+            table.add_row(row!["Key", "Value"]);
+            table.add_row(row!["Address", address]);
+            table.add_row(row!["Sharded", wallet.is_sharded()]);
+            table.add_row(row!["Verify", decrypted_wallet.is_ok()]);
+            table.add_row(row!["PwHash", wallet.pwhash()]);
+            if let Some(phrase) = phrase {
+                let mut phrase_table = Table::new();
+                phrase_table.set_format(*prettytable::format::consts::FORMAT_CLEAN);
+                for segment in phrase?.chunks(4) {
+                    phrase_table.add_row(Row::new(segment.iter().map(|s| Cell::new(s)).collect()));
+                }
+                table.add_row(row!["Phrase", phrase_table]);
+            }
             print_table(&table)
         }
         OutputFormat::Json => {
-            let table = json!({
+            let mut table = json!({
                 "address": address,
                 "sharded": wallet.is_sharded(),
-                "verify": result,
+                "verify": decrypted_wallet.is_ok(),
                 "pwhash": wallet.pwhash().to_string()
             });
+            if let Some(phrase) = phrase {
+                table["phrase"] = serde_json::Value::String(phrase?.join(" "));
+            }
             print_json(&table)
         }
     }

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -1,4 +1,8 @@
-use crate::{result::Result, traits::ReadWrite};
+use crate::{
+    mnemonic::{entropy_to_mnemonic, SeedType},
+    result::Result,
+    traits::ReadWrite,
+};
 use byteorder::ReadBytesExt;
 use std::{convert::TryFrom, io};
 
@@ -40,6 +44,14 @@ impl Keypair {
 
     pub fn sign(&self, msg: &[u8]) -> Result<Vec<u8>> {
         Ok(self.0.sign(msg)?)
+    }
+
+    /// Return the mnemonic phrase that can be used to recreate this Keypair.
+    /// This function is implemented here to avoid passing the secret between
+    /// too many modules.
+    pub fn phrase(&self, seed_type: &SeedType) -> Result<Vec<String>> {
+        let entropy: Vec<u8> = self.0.to_bytes()[1..33].to_vec();
+        entropy_to_mnemonic(&entropy, seed_type)
     }
 }
 


### PR DESCRIPTION
### OVERALL
Output a seed phrase as part of `verify`.

The verify command now takes the same --seed <bip39|mobile> option
as the create command. This will add a mnemonic phrase to the output
of `verify`. This phrase can be used to recreate the wallet.

It is important for the user to specify the correct seed type. The
same wallet will output different phrases when given different seed
types. The difference is the checksum bits at then end.

While it is possible to retrieve the phrase from a wallet  that was
originally imported from the mobile app, it is not possible to take
a cli-generated wallet (which has real 256-bits of entropy) and get
a 12-word phrase that the mobile wallet will accept.


### OUTPUT 
```
$ ./target/release/helium-wallet   create basic --seed bip39 --network testnet
Space separated seed words: split mandate wild spread gun vibrant gather hawk dawn latin harsh faint base cement only slight crumble smart siege bring parrot upper slab veteran
Password: [hidden]
+-----------------------------------------------------+---------+--------+------------+
| Address                                             | Sharded | Verify | PwHash     |
+-----------------------------------------------------+---------+--------+------------+
| 1bTTquWTpSmAb8vq1bBJjZWVbeiFBpqg4xu4pmYeukscUmx1dTr | false   | true   | Argon2id13 |
+-----------------------------------------------------+---------+--------+------------+
$
$ ./target/release/helium-wallet -f wallet.key  verify --seed bip39
Password: [hidden]
+-----------------------------------------------------+---------+--------+------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
| Address                                             | Sharded | Verify | PwHash     | Phrase                                                                                                                                               |
+-----------------------------------------------------+---------+--------+------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
| 1bTTquWTpSmAb8vq1bBJjZWVbeiFBpqg4xu4pmYeukscUmx1dTr | false   | true   | Argon2id13 | split mandate wild spread gun vibrant gather hawk dawn latin harsh faint base cement only slight crumble smart siege bring parrot upper slab veteran |
+-----------------------------------------------------+---------+--------+------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
```
### TESTING
I have not actually tested importing from mobile to CLI then back
to mobile.


### NOTES
- `keypair::phrase()` is the entry point to all this. For self, it returns a phrase. I originally had a function in `verify` do all the work. It grabbed the entropy from Keypair then called entropy_to_mnemonic(). That felt more natural, but that also meant I had to explicitly copy the entropy out of Keypair in order to the verify module to pass it to entropy_to_mnemonic(). I thought it was more important to limit passing copies of the secret around, so I made keypair::phrase orchestrate everything.

- I'd like feedback especially on the slice, array, vec, bit-twiddling in entropy_to_mnemonic. While I'm comfortable with bit-twiddling in C, I'm a Rust newbie. The bit_vec crate made entropy_to_mnemonic() much more natural to read IMO, but I struggled with getting the borrow and copy parts to compile. I also struggled at the end to 11-bit chunk of bits into an usize to be used as an index. If anyone has suggestions for improvements along with links to reasons why, I would really appreciate it!


- Based on earlier comments, I hung this off the `verify` command and I think it works ok, but it doesn't feel very discoverable AND the phrase makes the table format really wide. I played with other ways to format the phrase, but they all made copying to the clipboard harder.

fixes #145 