### PR TITLE
Fixes default memo value

### DIFF
--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -183,6 +183,6 @@ pub struct Payee {
     amount: Hnt,
     /// Memo field to include. Provide as a base64 encoded string
     #[serde(default)]
-    #[structopt(long, default_value = "AA==")]
+    #[structopt(long, default_value = "AAAAAAAAAAA=")]
     memo: Memo,
 }


### PR DESCRIPTION
The default value of a memo was only two bytes (base64 encoded) instead of the required 8 bytes. This fixes the default memo value to be 8 0-bytes