### PR TITLE
Add commit command

### DIFF
--- a/src/cmd/commit.rs
+++ b/src/cmd/commit.rs
@@ -1,0 +1,48 @@
+use crate::{cmd::*, result::Result};
+use serde_json::json;
+
+#[derive(Debug, StructOpt)]
+/// Commit a transaction to the blockchain.
+///
+/// The transaction is submitted to the network that the current wallet is
+/// active on (mainnet or testnet)
+pub struct Cmd {
+    /// Base64 encoded transaction to sign. If no transaction is given stdin is
+    /// read for the transaction.
+    #[structopt(name = "TRANSACTION")]
+    txn: Option<Transaction>,
+}
+
+impl Cmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        let envelope = read_txn(&self.txn)?;
+
+        let wallet = load_wallet(opts.files)?;
+        let client = helium_api::Client::new_with_base_url(api_url(wallet.public_key.network));
+
+        let status = maybe_submit_txn(true, &client, &envelope).await?;
+        print_txn(&envelope, &status, opts.format)
+    }
+}
+
+fn print_txn(
+    envelope: &BlockchainTxn,
+    status: &Option<PendingTxnStatus>,
+    format: OutputFormat,
+) -> Result {
+    match format {
+        OutputFormat::Table => {
+            ptable!(["Key", "Value"], ["Hash", status_str(status)]);
+
+            print_footer(status)
+        }
+        OutputFormat::Json => {
+            let table = json!({
+                "hash": status_json(status),
+                "txn": envelope.to_b64()?
+            });
+
+            print_json(&table)
+        }
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -17,6 +17,7 @@ pub use structopt::{clap::arg_enum, StructOpt};
 
 pub mod balance;
 pub mod burn;
+pub mod commit;
 pub mod create;
 pub mod hotspots;
 pub mod htlc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use helium_wallet::{
     cmd::{
-        balance, burn, create, hotspots, htlc, info, multisig, oracle, oui, pay, request,
+        balance, burn, commit, create, hotspots, htlc, info, multisig, oracle, oui, pay, request,
         securities, upgrade, validators, vars, verify, Opts,
     },
     result::Result,
@@ -35,6 +35,7 @@ pub enum Cmd {
     Request(request::Cmd),
     Vars(vars::Cmd),
     Validators(validators::Cmd),
+    Commit(commit::Cmd),
 }
 
 #[tokio::main]
@@ -64,5 +65,6 @@ async fn run(cli: Cli) -> Result {
         Cmd::Request(cmd) => cmd.run(cli.opts).await,
         Cmd::Vars(cmd) => cmd.run(cli.opts).await,
         Cmd::Validators(cmd) => cmd.run(cli.opts).await,
+        Cmd::Commit(cmd) => cmd.run(cli.opts).await,
     }
 }


### PR DESCRIPTION
A simple command to commit any base64 encoded envelope to the blockchain.

Fixes: #112 