### PR TITLE
Assert command staking_mode addition

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     keypair::{Network, PublicKey},
     mnemonic,
     result::{bail, Error, Result},
-    traits::{TxnFeeConfig, B64},
+    traits::{StakingMode, TxnFeeConfig, B64},
     wallet::Wallet,
 };
 pub use helium_api::{models::PendingTxnStatus, Client, Hnt, Hst, Usd};

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -2,7 +2,7 @@ pub use self::b64::B64;
 pub use self::json::ToJson;
 pub use self::read_write::ReadWrite;
 pub use self::txn_envelope::TxnEnvelope;
-pub use self::txn_fee::{TxnFee, TxnFeeConfig, TxnStakingFee};
+pub use self::txn_fee::{StakingMode, TxnFee, TxnFeeConfig, TxnModeStakingFee, TxnStakingFee};
 pub use self::txn_payer::TxnPayer;
 pub use self::txn_sign::TxnSign;
 


### PR DESCRIPTION
adds a —mode option to assert to allow the assert staking mode to be set for light/dataonly/full gateways (full by default)