### PR TITLE
adds create wallet builder to lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
+checksum = "b2a930fd487faaa92a30afa92cc9dd1526a5cff67124abbbb1c617ce070f4dcf"
 dependencies = [
  "aead 0.4.2",
  "aes",
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.4",
  "subtle",
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher 0.3.0",
 ]
@@ -579,9 +579,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e5c176479da93a0983f0a6fdc3c1b8e7d5be0d7fe3fe05a99f15b96582b9a8"
+checksum = "069397e10739989e400628cbc0556a817a8a64119d7a2315767f4456e1332c23"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbd60caa311237d508927dbba7594b483db3ef05faa55172fcf89b1bcda7853"
+checksum = "b442c439366184de619215247d24e908912b175e824a530253845ac4c251a5c1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -951,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "helium-api"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e90ae27bf5f3220976ecc200aff558cbb160561beb46cf1188d0a963a42496"
+checksum = "9a009dbd50079d61b2af5d02381d345a9285854532894646bcd997c03480cd99"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -968,8 +968,8 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.2.2-dev"
-source = "git+https://github.com/helium/helium-crypto-rs#3dca2184887f551ea27a4a961b9599f32e871430"
+version = "0.2.2"
+source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.2.2#e686f58a7d2a37790ddc0fd672d532a8dc521cb3"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -1475,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e597450cbf209787f0e6de80bf3795c6b2356a380ee87837b545aded8dbc1823"
+checksum = "a6ba6a405ef63530d6cb12802014b22f9c5751bd17cdcddbe9e46d5c8ae83287"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "4ac2e1d4bd0f75279cfd5a076e0d578bbf02c22b7c39e766c437dd49b3ec43e0"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2238,9 +2238,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "c2602b8af3767c285202012822834005f596c811042315fa7e9f5b12b2a43207"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2368,9 +2368,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array 0.14.4",
  "subtle",
@@ -2611,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeafe61337cb2c879d328b74aa6cd9d794592c82da6be559fdf11493f02a2d18"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922b33332f54fc0ad13fa3e514601e8d30fb54e1f3eadc36643f6526db645621"
+checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
  "generic-array 0.14.4",
 ]
@@ -44,7 +44,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
 dependencies = [
- "aead 0.4.1",
+ "aead 0.4.2",
  "aes",
  "cipher 0.3.0",
  "ctr",
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "approx"
@@ -261,9 +261,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cexpr"
@@ -376,9 +376,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
@@ -435,12 +435,14 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281d926f72b42bf3ba840b88cd53e39f36be9f66e34c8df3fb336372b3753d41"
+checksum = "b32a398eb1ccfbe7e4f452bc749c44d38dd732e9a253f19da224c416f00ee7f4"
 dependencies = [
  "generic-array 0.14.4",
+ "rand_core 0.6.3",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -537,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c4363c082db1a39dc354b9693923252c333bd41c918a64639da87aec1a6288"
+checksum = "713c32426287891008edb98f8b5c6abb2130aa043c93a818728fcda78606f274"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -577,15 +579,15 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59029dd05f60215bbe37eda4b32ba1a142abc8b01a938955b20b92ff0d713e8e"
+checksum = "83e5c176479da93a0983f0a6fdc3c1b8e7d5be0d7fe3fe05a99f15b96582b9a8"
 dependencies = [
  "crypto-bigint",
  "ff",
  "generic-array 0.14.4",
  "group",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
  "subtle",
  "zeroize",
 ]
@@ -624,7 +626,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -862,7 +864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -894,7 +896,7 @@ dependencies = [
  "geo",
  "geo-types",
  "h3ron-h3-sys",
- "itertools 0.10.1",
+ "itertools",
  "serde",
  "svgbobdoc",
  "thiserror",
@@ -922,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heapless"
@@ -966,13 +968,13 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.2.1"
-source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.2.1#8abf4074633f77e68a21bfc6d8d6367af1231bce"
+version = "0.2.2-dev"
+source = "git+https://github.com/helium/helium-crypto-rs#3dca2184887f551ea27a4a961b9599f32e871430"
 dependencies = [
  "bs58",
  "ed25519-dalek",
  "p256",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
  "serde",
  "signature",
  "thiserror",
@@ -998,7 +1000,7 @@ dependencies = [
  "aes-gcm",
  "angry-purple-tiger",
  "anyhow",
- "base64 0.12.3",
+ "base64 0.13.0",
  "bs58",
  "byteorder",
  "dialoguer",
@@ -1029,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -1094,9 +1096,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
+checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1144,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1154,27 +1156,18 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -1214,9 +1207,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libloading"
@@ -1230,13 +1223,14 @@ dependencies = [
 
 [[package]]
 name = "libsodium-sys"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a685b64f837b339074115f2e7f7b431ac73681d08d75b389db7498b8892b8a58"
+checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
+ "walkdir",
 ]
 
 [[package]]
@@ -1382,7 +1376,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "p256"
 version = "0.9.0"
-source = "git+https://github.com/helium/elliptic-curves?branch=madninja/compact_point_impl#76f547b420d029cc9eab3a74723773feeb4a8864"
+source = "git+https://github.com/helium/elliptic-curves?branch=madninja/compact_point_impl#b3051010e5f3c05430ed556a0165291322ac2fa5"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1409,7 +1403,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall 0.2.8",
+ "redox_syscall 0.2.9",
  "smallvec",
  "winapi",
 ]
@@ -1453,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -1564,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1574,13 +1568,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.9.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
@@ -1592,12 +1586,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -1605,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
  "prost",
@@ -1643,13 +1637,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
  "rand_hc",
 ]
 
@@ -1660,7 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1674,20 +1668,20 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.3",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1698,9 +1692,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
@@ -1750,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "async-compression",
  "base64 0.13.0",
@@ -1833,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.14.2"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9787e62372fc0c5a0f3af64c392652db72d3ec1cc0cff1becc175d2c11e6fbcc"
+checksum = "01127cb8617e5e21bcf2e19b5eb48317735ca677f1d0a94833c21c331c446582"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -1875,6 +1869,15 @@ checksum = "399f290ffc409596022fce5ea5d4138184be4784f2b28c62c59f0d8389059a15"
 dependencies = [
  "cipher 0.2.5",
  "zeroize",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1988,12 +1991,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2020,10 +2023,11 @@ dependencies = [
 
 [[package]]
 name = "sodiumoxide"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7038b67c941e23501573cb7242ffb08709abe9b11eb74bceff875bbda024a6a8"
+checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
 dependencies = [
+ "ed25519",
  "libc",
  "libsodium-sys",
  "serde",
@@ -2049,9 +2053,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2060,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2073,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svg"
@@ -2124,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2143,7 +2147,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rand",
- "redox_syscall 0.2.8",
+ "redox_syscall 0.2.9",
  "remove_dir_all",
  "winapi",
 ]
@@ -2189,18 +2193,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2234,9 +2238,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2254,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2346,9 +2350,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -2401,6 +2405,17 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2596,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "eeafe61337cb2c879d328b74aa6cd9d794592c82da6be559fdf11493f02a2d18"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ h3ron = "^0.10"
 geo-types = "^0.6" # pinned by h3ron but required here for geo_types::Point
 helium-api = "3"
 angry-purple-tiger = "0"
-helium-crypto = {git = "https://github.com/helium/helium-crypto-rs"}
+helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.2.2"}
 helium-proto = { git = "https://github.com/helium/proto", branch="master"}
 tokio = {version = "1", features = ["full"]}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ h3ron = "^0.10"
 geo-types = "^0.6" # pinned by h3ron but required here for geo_types::Point
 helium-api = "3"
 angry-purple-tiger = "0"
-helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.2.1"}
+helium-crypto = {git = "https://github.com/helium/helium-crypto-rs"}
 helium-proto = { git = "https://github.com/helium/proto", branch="master"}
 tokio = {version = "1", features = ["full"]}
 

--- a/examples/create_wallet.rs
+++ b/examples/create_wallet.rs
@@ -1,0 +1,20 @@
+use helium_wallet::wallet::Wallet;
+
+fn main() {
+
+    let password = "pass123";
+    let filename = "my-example-wallet.key";
+
+    let wallet = Wallet::builder()
+    .password(password)
+    .output(&filename.into())
+    .force(true)
+    .create()
+    .expect("it should have created a wallet");
+
+    let keypair = wallet.decrypt(password.as_bytes()).expect("it should decrypt the wallet");
+
+    println!("{:?}", keypair);
+
+
+}

--- a/examples/create_wallet.rs
+++ b/examples/create_wallet.rs
@@ -1,12 +1,13 @@
 use helium_wallet::wallet::Wallet;
+use std::path::Path;
 
 fn main() {
     let password = "pass123";
-    let filename = "my-example-wallet.key";
+    let filename = Path::new("my-example-wallet.key");
 
     let wallet = Wallet::builder()
         .password(password)
-        .output(&filename.into())
+        .output(&filename)
         .force(true)
         .create()
         .expect("it should have created a wallet");

--- a/examples/create_wallet.rs
+++ b/examples/create_wallet.rs
@@ -1,20 +1,19 @@
 use helium_wallet::wallet::Wallet;
 
 fn main() {
-
     let password = "pass123";
     let filename = "my-example-wallet.key";
 
     let wallet = Wallet::builder()
-    .password(password)
-    .output(&filename.into())
-    .force(true)
-    .create()
-    .expect("it should have created a wallet");
+        .password(password)
+        .output(&filename.into())
+        .force(true)
+        .create()
+        .expect("it should have created a wallet");
 
-    let keypair = wallet.decrypt(password.as_bytes()).expect("it should decrypt the wallet");
+    let keypair = wallet
+        .decrypt(password.as_bytes())
+        .expect("it should decrypt the wallet");
 
     println!("{:?}", keypair);
-
-
 }

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -1,16 +1,11 @@
 use crate::{
     cmd::*,
-    format::{self, Format},
-    keypair::{KeyTag, KeyType, Keypair, Network, KEYTYPE_ED25519_STR, NETTYPE_MAIN_STR},
-    mnemonic::{mnemonic_to_entropy, SeedType},
-    pwhash::PwHash,
+    keypair::{KeyTag, KeyType, Network, KEYTYPE_ED25519_STR, NETTYPE_MAIN_STR},
+    mnemonic::SeedType,
     result::Result,
-    wallet::Wallet,
+    wallet::{ShardConfig, Wallet},
 };
-use std::{
-    fs, io,
-    path::{Path, PathBuf},
-};
+use std::path::PathBuf;
 
 #[derive(Debug, StructOpt)]
 /// Create a new wallet
@@ -95,13 +90,16 @@ impl Basic {
             network: self.network,
             key_type: self.key_type,
         };
-        let keypair = gen_keypair(tag, seed_words, self.seed.as_ref())?;
-        let format = format::Basic {
-            pwhash: PwHash::argon2id13_default(),
-        };
-        let wallet = Wallet::encrypt(&keypair, password.as_bytes(), Format::Basic(format))?;
-        let mut writer = open_output_file(&self.output, !self.force)?;
-        wallet.write(&mut writer)?;
+
+        let wallet = Wallet::builder()
+            .output(&self.output)
+            .password(&password)
+            .key_tag(&tag)
+            .force(self.force)
+            .seed_type(self.seed.to_owned())
+            .seed_words(seed_words)
+            .create()?;
+
         verify::print_result(&wallet, true, opts.format)
     }
 }
@@ -117,49 +115,21 @@ impl Sharded {
             network: self.network,
             key_type: self.key_type,
         };
-
-        let keypair = gen_keypair(tag, seed_words, self.seed.as_ref())?;
-        let format = format::Sharded {
+        let shard_config = ShardConfig {
             key_share_count: self.key_share_count,
-            recovery_threshold: self.recovery_threshold,
-            pwhash: PwHash::argon2id13_default(),
-            key_shares: vec![],
+            recovery_threshold: self.key_share_count,
         };
-        let wallet = Wallet::encrypt(&keypair, password.as_bytes(), Format::Sharded(format))?;
 
-        let extension = get_file_extension(&self.output);
-        for (i, shard) in wallet.shards()?.iter().enumerate() {
-            let mut filename = self.output.clone();
-            let share_extension = format!("{}.{}", extension, (i + 1).to_string());
-            filename.set_extension(share_extension);
-            let mut writer = open_output_file(&filename, !self.force)?;
-            shard.write(&mut writer)?;
-        }
+        let wallet = Wallet::builder()
+            .output(&self.output)
+            .password(&password)
+            .key_tag(&tag)
+            .force(self.force)
+            .seed_type(self.seed.to_owned())
+            .seed_words(seed_words)
+            .shard_config(Some(shard_config))
+            .create()?;
+
         verify::print_result(&wallet, true, opts.format)
     }
-}
-
-fn gen_keypair(
-    tag: KeyTag,
-    seed_words: Option<Vec<String>>,
-    seed_type: Option<&SeedType>,
-) -> Result<Keypair> {
-    // Callers of this function should either have Some of both or None of both.
-    // Anything else is an error.
-    match (seed_words, seed_type) {
-        (Some(words), Some(seed_type)) => {
-            let entropy = mnemonic_to_entropy(words, seed_type)?;
-            Keypair::generate_from_entropy(tag, &entropy)
-        }
-        (None, None) => Ok(Keypair::generate(tag)),
-        _ => bail!("Invalid parameters in gen_keypair(). Report this to the development team."),
-    }
-}
-
-fn open_output_file(filename: &Path, create: bool) -> io::Result<fs::File> {
-    fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .create_new(create)
-        .open(filename)
 }

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -127,7 +127,7 @@ impl Sharded {
             .force(self.force)
             .seed_type(self.seed.to_owned())
             .seed_words(seed_words)
-            .shard_config(Some(shard_config))
+            .shard(Some(shard_config))
             .create()?;
 
         verify::print_result(&wallet, true, opts.format)

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -117,7 +117,7 @@ impl Sharded {
         };
         let shard_config = ShardConfig {
             key_share_count: self.key_share_count,
-            recovery_threshold: self.key_share_count,
+            recovery_threshold: self.recovery_threshold,
         };
 
         let wallet = Wallet::builder()

--- a/src/mnemonic/mod.rs
+++ b/src/mnemonic/mod.rs
@@ -9,7 +9,7 @@ include!(concat!(env!("OUT_DIR"), "/english.rs"));
 type WordList = &'static [&'static str];
 
 arg_enum! {
-    #[derive( Debug, StructOpt)]
+    #[derive( Debug, Clone, Copy, StructOpt)]
     pub enum SeedType {
         Bip39,
         Mobile,

--- a/src/mnemonic/mod.rs
+++ b/src/mnemonic/mod.rs
@@ -9,7 +9,7 @@ include!(concat!(env!("OUT_DIR"), "/english.rs"));
 type WordList = &'static [&'static str];
 
 arg_enum! {
-    #[derive( Debug, Clone, Copy, StructOpt)]
+    #[derive( Debug, Clone, StructOpt)]
     pub enum SeedType {
         Bip39,
         Mobile,

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -304,7 +304,7 @@ impl Builder {
     pub fn create(self) -> Result<Wallet> {
         let keypair = gen_keypair(self.key_tag, self.seed_words, self.seed_type.as_ref())?;
 
-        let wallet = if let Some(shard_config) = self.shard {
+        let wallet = if let Some(shard_config) = &self.shard {
             let format = format::Sharded {
                 key_share_count: shard_config.key_share_count,
                 recovery_threshold: shard_config.recovery_threshold,

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -221,6 +221,8 @@ pub struct Builder {
     /// Password to access wallet
     password: String,
 
+    pwhash: PwHash,
+
     /// Overwrite an existing file
     force: bool,
 
@@ -243,6 +245,7 @@ impl Builder {
         Builder {
             output: PathBuf::from("wallet.key"),
             password: Default::default(),
+            pwhash: PwHash::argon2id13_default(),
             force: false,
             seed_type: None,
             seed_words: None,
@@ -262,6 +265,13 @@ impl Builder {
     /// Defaults to '' (empty string)
     pub fn password(mut self, pwd: &str) -> Builder {
         self.password = pwd.to_owned();
+        self
+    }
+
+    /// Sets the wallet's password hasher
+    /// Defaults to `PwHash::argon2id13_default()`
+    pub fn pwhash(mut self, pwhash: PwHash) -> Builder {
+        self.pwhash = pwhash.to_owned();
         self
     }
 
@@ -308,7 +318,7 @@ impl Builder {
             let format = format::Sharded {
                 key_share_count: shard_config.key_share_count,
                 recovery_threshold: shard_config.recovery_threshold,
-                pwhash: PwHash::argon2id13_default(),
+                pwhash: self.pwhash,
                 key_shares: vec![],
             };
             Wallet::encrypt(&keypair, self.password.as_bytes(), Format::Sharded(format))?

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,6 +1,7 @@
 use crate::{
     format::{self, Format},
-    keypair::{Keypair, PublicKey},
+    keypair::{KeyTag, Keypair, PublicKey},
+    mnemonic::{mnemonic_to_entropy, SeedType},
     pwhash::PwHash,
     result::{anyhow, bail, Result},
     traits::ReadWrite,
@@ -12,6 +13,11 @@ use aes_gcm::{
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use sodiumoxide::randombytes;
 use std::io::{self, Cursor};
+use std::{
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+};
 
 pub type Tag = [u8; 16];
 pub type Iv = [u8; 12];
@@ -35,6 +41,11 @@ pub struct Wallet {
 }
 
 impl Wallet {
+    /// Creates a basic wallet
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+
     pub fn encrypt(keypair: &Keypair, password: &[u8], fmt: Format) -> Result<Wallet> {
         let mut encryption_key = AesKey::default();
         let mut format = fmt;
@@ -194,6 +205,175 @@ impl Wallet {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct ShardConfig {
+    /// Number of shards to break the key into
+    pub key_share_count: u8,
+
+    /// Number of shards required to recover the key
+    pub recovery_threshold: u8,
+}
+
+pub struct Builder {
+    /// Output file to store the key in
+    output: PathBuf,
+
+    /// Password to access wallet
+    password: String,
+
+    /// Overwrite an existing file
+    force: bool,
+
+    /// Use a BIP39 or mobile app seed phrase to generate the wallet keys
+    seed_type: Option<SeedType>,
+
+    /// The seed words used to create this wallet
+    seed_words: Option<Vec<String>>,
+
+    /// The KeyTag (network and key type) to use for this wallet
+    key_tag: KeyTag,
+
+    /// Optional shard config info to use in order to create a sharded wallet
+    /// otherwise, creates a basic non-sharded wallet
+    shard_config: Option<ShardConfig>,
+}
+
+impl Builder {
+    pub fn new() -> Builder {
+        Builder {
+            output: PathBuf::from("wallet.key"),
+            password: Default::default(),
+            force: false,
+            seed_type: None,
+            seed_words: None,
+            key_tag: Default::default(),
+            shard_config: None,
+        }
+    }
+
+    /// Sets the output file for the wallet.
+    /// Defaults to 'main.key'
+    pub fn output(mut self, path: &PathBuf) -> Builder {
+        self.output = path.clone();
+        self
+    }
+
+    /// Sets the wallet's password
+    /// Defaults to '' (empty string)
+    pub fn password(mut self, pwd: &str) -> Builder {
+        self.password = pwd.to_owned();
+        self
+    }
+
+    /// Force overwrite of wallet if output already exists
+    /// Defaults to false
+    pub fn force(mut self, overwrite: bool) -> Builder {
+        self.force = overwrite;
+        self
+    }
+
+    /// Set the seed type if using seed words to create this wallet
+    /// Defaults to None
+    pub fn seed_type(mut self, seed_type: Option<SeedType>) -> Builder {
+        self.seed_type = seed_type;
+        self
+    }
+
+    /// The seed words used to create this wallet
+    /// Defaults to None
+    pub fn seed_words(mut self, seed_words: Option<Vec<String>>) -> Builder {
+        self.seed_words = seed_words;
+        self
+    }
+
+    /// The type of key to generate (ecc_compact/ed25519)
+    /// Defaults to ed25519
+    pub fn key_tag(mut self, key_tag: &KeyTag) -> Builder {
+        self.key_tag = key_tag.clone();
+        self
+    }
+
+    /// Optional shard config info to use in order to create a sharded wallet
+    /// otherwise, creates a basic non-sharded wallet
+    pub fn shard_config(mut self, shard_config: Option<ShardConfig>) -> Builder {
+        self.shard_config = shard_config.clone();
+        self
+    }
+
+    /// Creates a new wallet
+    pub fn create(self) -> Result<Wallet> {
+        let keypair = gen_keypair(self.key_tag, self.seed_words, self.seed_type.as_ref())?;
+
+        let wallet = if let Some(shard_config) = self.shard_config {
+            let format = format::Sharded {
+                key_share_count: shard_config.key_share_count,
+                recovery_threshold: shard_config.recovery_threshold,
+                pwhash: PwHash::argon2id13_default(),
+                key_shares: vec![],
+            };
+            Wallet::encrypt(&keypair, self.password.as_bytes(), Format::Sharded(format))?
+        } else {
+            let format = format::Basic {
+                pwhash: PwHash::argon2id13_default(),
+            };
+            Wallet::encrypt(&keypair, self.password.as_bytes(), Format::Basic(format))?
+        };
+
+        if self.shard_config.is_some() {
+            let extension = self
+                .output
+                .extension()
+                .unwrap_or_else(|| OsStr::new(""))
+                .to_str()
+                .unwrap()
+                .to_string();
+            for (i, shard) in wallet.shards()?.iter().enumerate() {
+                let mut filename = self.output.clone();
+                let share_extension = format!("{}.{}", extension, (i + 1).to_string());
+                filename.set_extension(share_extension);
+                let mut writer = open_output_file(&filename, !self.force)?;
+                shard.write(&mut writer)?;
+            }
+        } else {
+            let mut writer = open_output_file(&self.output, !self.force)?;
+            wallet.write(&mut writer)?;
+        }
+
+        Ok(wallet)
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn gen_keypair(
+    tag: KeyTag,
+    seed_words: Option<Vec<String>>,
+    seed_type: Option<&SeedType>,
+) -> Result<Keypair> {
+    // Callers of this function should either have Some of both or None of both.
+    // Anything else is an error.
+    match (seed_words, seed_type) {
+        (Some(words), Some(seed_type)) => {
+            let entropy = mnemonic_to_entropy(words, seed_type)?;
+            Keypair::generate_from_entropy(tag, &entropy)
+        }
+        (None, None) => Ok(Keypair::generate(tag)),
+        _ => bail!("Invalid parameters in gen_keypair(). Report this to the development team."),
+    }
+}
+
+fn open_output_file(filename: &Path, create: bool) -> io::Result<fs::File> {
+    fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .create_new(create)
+        .open(filename)
+}
+
 //
 // Test
 //
@@ -213,6 +393,105 @@ mod tests {
             .expect("wallet creation");
         let to_keypair = wallet.decrypt(password).expect("wallet to keypair");
         assert_eq!(from_keypair, to_keypair);
+    }
+
+    #[test]
+    fn basic_from_builder() {
+        use std::fs;
+        let path: PathBuf = ".test-basic.key".into();
+        // Delete Any existing test wallet in case prev error
+        let _ = fs::remove_file(&path);
+
+        let password = String::from("password");
+        let tag = KeyTag::default();
+        let seed_words: Vec<String> = vec![
+            "drill".to_string(),
+            "toddler".to_string(),
+            "tongue".to_string(),
+            "laundry".to_string(),
+            "access".to_string(),
+            "silly".to_string(),
+            "few".to_string(),
+            "faint".to_string(),
+            "glove".to_string(),
+            "birth".to_string(),
+            "crumble".to_string(),
+            "add".to_string(),
+        ];
+        let from_keypair = gen_keypair(tag, Some(seed_words.clone()), Some(&SeedType::Bip39))
+            .expect("to generate a keypair");
+
+        let wallet = Wallet::builder()
+            .password(&password)
+            .output(&path)
+            .key_tag(&tag)
+            .seed_words(Some(seed_words.clone()))
+            .seed_type(Some(SeedType::Bip39))
+            .create()
+            .expect("wallet to be created");
+
+        let to_keypair = wallet
+            .decrypt(password.as_bytes())
+            .expect("wallet to keypair");
+        assert_eq!(from_keypair, to_keypair);
+
+        // clean up
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn sharded_from_builder() {
+        let path = ".test-sharded.key".to_string();
+        // Delete Any existing test wallet in case prev error
+        let _ = clean_up_shards(&path, 3);
+
+        let password = String::from("password");
+        let tag = KeyTag::default();
+        let shard_config = ShardConfig {
+            key_share_count: 3,
+            recovery_threshold: 2,
+        };
+
+        let seed_words: Vec<String> = vec![
+            "drill".to_string(),
+            "toddler".to_string(),
+            "tongue".to_string(),
+            "laundry".to_string(),
+            "access".to_string(),
+            "silly".to_string(),
+            "few".to_string(),
+            "faint".to_string(),
+            "glove".to_string(),
+            "birth".to_string(),
+            "crumble".to_string(),
+            "add".to_string(),
+        ];
+        let from_keypair = gen_keypair(tag, Some(seed_words.clone()), Some(&SeedType::Bip39))
+            .expect("to generate a keypair");
+
+        let wallet = Wallet::builder()
+            .password(&password)
+            .output(&path.clone().into())
+            .key_tag(&tag)
+            .seed_words(Some(seed_words.clone()))
+            .seed_type(Some(SeedType::Bip39))
+            .shard_config(Some(shard_config))
+            .create()
+            .expect("wallet to be created");
+
+        let to_keypair = wallet
+            .decrypt(password.as_bytes())
+            .expect("wallet to keypair");
+        assert_eq!(from_keypair, to_keypair);
+
+        // clean up
+        let _ = clean_up_shards(&path, 3);
+    }
+
+    fn clean_up_shards(path: &str, shards: u8) {
+        for i in 1..=shards {
+            let _ = fs::remove_file(format!("{}.{}", path, i));
+        }
     }
 
     #[test]

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -235,7 +235,7 @@ pub struct Builder {
 
     /// Optional shard config info to use in order to create a sharded wallet
     /// otherwise, creates a basic non-sharded wallet
-    shard_config: Option<ShardConfig>,
+    shard: Option<ShardConfig>,
 }
 
 impl Builder {
@@ -247,7 +247,7 @@ impl Builder {
             seed_type: None,
             seed_words: None,
             key_tag: Default::default(),
-            shard_config: None,
+            shard: None,
         }
     }
 
@@ -295,8 +295,8 @@ impl Builder {
 
     /// Optional shard config info to use in order to create a sharded wallet
     /// otherwise, creates a basic non-sharded wallet
-    pub fn shard_config(mut self, shard_config: Option<ShardConfig>) -> Builder {
-        self.shard_config = shard_config;
+    pub fn shard(mut self, shard_config: Option<ShardConfig>) -> Builder {
+        self.shard = shard_config;
         self
     }
 
@@ -304,7 +304,7 @@ impl Builder {
     pub fn create(self) -> Result<Wallet> {
         let keypair = gen_keypair(self.key_tag, self.seed_words, self.seed_type.as_ref())?;
 
-        let wallet = if let Some(shard_config) = self.shard_config {
+        let wallet = if let Some(shard_config) = self.shard {
             let format = format::Sharded {
                 key_share_count: shard_config.key_share_count,
                 recovery_threshold: shard_config.recovery_threshold,
@@ -319,7 +319,7 @@ impl Builder {
             Wallet::encrypt(&keypair, self.password.as_bytes(), Format::Basic(format))?
         };
 
-        if self.shard_config.is_some() {
+        if self.shard.is_some() {
             let extension = self
                 .output
                 .extension()
@@ -475,7 +475,7 @@ mod tests {
             .key_tag(&tag)
             .seed_words(Some(seed_words.clone()))
             .seed_type(Some(SeedType::Bip39))
-            .shard_config(Some(shard_config))
+            .shard(Some(shard_config))
             .create()
             .expect("wallet to be created");
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -205,7 +205,7 @@ impl Wallet {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct ShardConfig {
     /// Number of shards to break the key into
     pub key_share_count: u8,

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -441,7 +441,7 @@ mod tests {
 
     #[test]
     fn sharded_from_builder() {
-        let path = ".test-sharded.key".to_string();
+        let path = Path::new(".test-sharded.key");
         // Delete Any existing test wallet in case prev error
         let _ = clean_up_shards(&path, 3);
 
@@ -471,7 +471,7 @@ mod tests {
 
         let wallet = Wallet::builder()
             .password(&password)
-            .output(&path.clone().into())
+            .output(&path)
             .key_tag(&tag)
             .seed_words(Some(seed_words.clone()))
             .seed_type(Some(SeedType::Bip39))
@@ -488,9 +488,9 @@ mod tests {
         let _ = clean_up_shards(&path, 3);
     }
 
-    fn clean_up_shards(path: &str, shards: u8) {
+    fn clean_up_shards(path: &Path, shards: u8) {
         for i in 1..=shards {
-            let _ = fs::remove_file(format!("{}.{}", path, i));
+            let _ = fs::remove_file(format!("{}.{}", path.to_string_lossy(), i));
         }
     }
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -253,8 +253,8 @@ impl Builder {
 
     /// Sets the output file for the wallet.
     /// Defaults to 'main.key'
-    pub fn output(mut self, path: &PathBuf) -> Builder {
-        self.output = path.clone();
+    pub fn output(mut self, path: &Path) -> Builder {
+        self.output = path.to_path_buf();
         self
     }
 
@@ -289,14 +289,14 @@ impl Builder {
     /// The type of key to generate (ecc_compact/ed25519)
     /// Defaults to ed25519
     pub fn key_tag(mut self, key_tag: &KeyTag) -> Builder {
-        self.key_tag = key_tag.clone();
+        self.key_tag = *key_tag;
         self
     }
 
     /// Optional shard config info to use in order to create a sharded wallet
     /// otherwise, creates a basic non-sharded wallet
     pub fn shard_config(mut self, shard_config: Option<ShardConfig>) -> Builder {
-        self.shard_config = shard_config.clone();
+        self.shard_config = shard_config;
         self
     }
 


### PR DESCRIPTION
This is the part of refactoring the wallet to better support lib use.

This PR adds `builder` pattern to `Wallet` in order to create a wallet outside of the `cli` interface. The builder can be used to create a basic or sharded wallet.

- Tests added
- example added