### PR TITLE
Fix assert location definition to use elevation in "above ground level" 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "helium-wallet"
-version = "1.6.5"
+version = "1.6.6-dev"
 dependencies = [
  "aes-gcm",
  "angry-purple-tiger",

--- a/src/cmd/hotspots/assert.rs
+++ b/src/cmd/hotspots/assert.rs
@@ -32,7 +32,7 @@ pub struct Cmd {
     #[structopt(long)]
     gain: Option<Dbi>,
 
-    /// The elevation for the asserted hotspot in meters relative to sea level.
+    /// The elevation for the asserted hotspot in meters above ground level.
     /// Defaults to the last assserted value
     #[structopt(long)]
     elevation: Option<i32>,


### PR DESCRIPTION
Fixes #174 