### PR TITLE
Upgrade helium-crypto to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,8 +986,8 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.2.2"
-source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.2.2#e686f58a7d2a37790ddc0fd672d532a8dc521cb3"
+version = "0.3.0"
+source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.3.0#f446f0e7fab57b4286aa61dd90e9997a17358619"
 dependencies = [
  "bs58",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ h3ron = "^0.10"
 geo-types = "^0.6" # pinned by h3ron but required here for geo_types::Point
 helium-api = "3"
 angry-purple-tiger = "0"
-helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.2.2"}
+helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.3.0"}
 helium-proto = { git = "https://github.com/helium/proto", branch="master"}
 tokio = {version = "1", features = ["full"]}
 bitvec = "*" # inherits from elliptic-curve crate

--- a/src/cmd/burn.rs
+++ b/src/cmd/burn.rs
@@ -40,7 +40,7 @@ impl Cmd {
 
         let mut txn = BlockchainTxnTokenBurnV1 {
             fee: 0,
-            payee: self.payee.to_bytes().to_vec(),
+            payee: self.payee.to_vec(),
             amount: u64::from(self.amount),
             payer: keypair.public_key().into(),
             memo: u64::from(&self.memo),

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -109,7 +109,7 @@ impl Cmd {
     fn collect_payments(&self) -> Result<Vec<Payment>> {
         match &self {
             Self::One(one) => Ok(vec![Payment {
-                payee: one.payee.address.to_bytes().to_vec(),
+                payee: one.payee.address.to_vec(),
                 amount: u64::from(one.payee.amount),
                 memo: u64::from(&one.payee.memo),
             }]),

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -8,7 +8,7 @@ use std::{convert::TryFrom, io};
 
 pub use helium_crypto::{
     ecc_compact, ed25519, KeyTag, KeyType, Network, PublicKey, Sign, Verify, KEYTYPE_ED25519_STR,
-    NETTYPE_MAIN_STR, PUBLIC_KEY_LENGTH,
+    NETTYPE_MAIN_STR,
 };
 
 #[derive(PartialEq, Debug)]
@@ -50,7 +50,7 @@ impl Keypair {
     /// This function is implemented here to avoid passing the secret between
     /// too many modules.
     pub fn phrase(&self, seed_type: &SeedType) -> Result<Vec<String>> {
-        let entropy: Vec<u8> = self.0.to_bytes()[1..33].to_vec();
+        let entropy = self.0.secret_to_vec();
         entropy_to_mnemonic(&entropy, seed_type)
     }
 }
@@ -59,12 +59,12 @@ impl ReadWrite for Keypair {
     fn write(&self, writer: &mut dyn io::Write) -> Result {
         match &self.0 {
             helium_crypto::Keypair::Ed25519(key) => {
-                writer.write_all(&key.to_bytes())?;
-                writer.write_all(&key.public_key.to_bytes())?;
+                writer.write_all(&key.to_vec())?;
+                writer.write_all(&key.public_key.to_vec())?;
             }
             helium_crypto::Keypair::EccCompact(key) => {
-                writer.write_all(&key.to_bytes())?;
-                writer.write_all(&key.public_key.to_bytes())?;
+                writer.write_all(&key.to_vec())?;
+                writer.write_all(&key.public_key.to_vec())?;
             }
         }
         Ok(())

--- a/src/traits/read_write.rs
+++ b/src/traits/read_write.rs
@@ -1,9 +1,7 @@
-use crate::{
-    keypair::{PublicKey, PUBLIC_KEY_LENGTH},
-    result::Result,
-};
+use crate::{keypair::PublicKey, result::Result};
+use helium_crypto::{ecc_compact, ed25519, KeyType};
 use io::{Read, Write};
-use std::io;
+use std::{convert::TryFrom, io};
 
 pub trait ReadWrite {
     fn read(reader: &mut dyn Read) -> Result<Self>
@@ -14,12 +12,18 @@ pub trait ReadWrite {
 
 impl ReadWrite for PublicKey {
     fn write(&self, writer: &mut dyn io::Write) -> Result {
-        Ok(writer.write_all(&self.to_bytes())?)
+        Ok(writer.write_all(&self.to_vec())?)
     }
 
     fn read(reader: &mut dyn Read) -> Result<PublicKey> {
-        let mut data = [0u8; PUBLIC_KEY_LENGTH];
-        reader.read_exact(&mut data)?;
+        let mut data = vec![0u8; 1];
+        reader.read_exact(&mut data[0..1])?;
+        let key_size = match KeyType::try_from(data[0])? {
+            KeyType::Ed25519 => ed25519::PUBLIC_KEY_LENGTH,
+            KeyType::EccCompact => ecc_compact::PUBLIC_KEY_LENGTH,
+        };
+        data.resize(key_size, 0);
+        reader.read_exact(&mut data[1..])?;
         Ok(PublicKey::from_bytes(data)?)
     }
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -62,7 +62,7 @@ impl Wallet {
 
         match aead.encrypt_in_place_detached(
             iv.as_ref().into(),
-            &public_key.to_bytes(),
+            &public_key.to_vec(),
             &mut encrypted,
         ) {
             Err(_) => Err(anyhow!("Failed to encrypt wallet")),
@@ -85,7 +85,7 @@ impl Wallet {
         let mut buffer = self.encrypted.to_owned();
         match aead.decrypt_in_place_detached(
             self.iv.as_ref().into(),
-            &self.public_key.to_bytes(),
+            &self.public_key.to_vec(),
             &mut buffer,
             self.tag.as_ref().into(),
         ) {


### PR DESCRIPTION
This upgrades the crypto library dependency to 0.3.0 and adjusts for the breaking differences in the api