### PR TITLE
constrain hmac, sha2, and pbkdf2 dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ structopt = "0.3"
 dialoguer = "0.8"
 sodiumoxide = "~0.2"
 hex = "0.4"
-hmac = "0"
-sha2 = "0"
+hmac = "0.11"
+sha2 = "0.9"
 base64 = "0"
 reqwest = {version = "0", default-features=false, features=["rustls-tls"]}
-pbkdf2 = {version = "0", default-features=false }
+pbkdf2 = {version = "0.9", default-features=false }
 aes-gcm = "0"
 shamirsecretsharing = {version="0.1.4", features=["have_libsodium"]}
 prettytable-rs = "0.8"


### PR DESCRIPTION
External projects that depends on helium-wallet-rs as a library will run into issues as the newer versions of these libraries having breaking changes.