### PR TITLE
Update mnemomic_to_entropy with bitvec

### DIFF
--- a/src/mnemonic/mod.rs
+++ b/src/mnemonic/mod.rs
@@ -102,7 +102,7 @@ pub fn mnemonic_to_entropy(words: Vec<String>, seed_type: &SeedType) -> Result<[
     let mut entropy_bytes = [0u8; 32];
     let valid_checksum = if words.len() == 12 {
         // Duplicate entropy bits into the first half and last half of the final
-        // byte array so we can always return an 256 bits (32 bytes) of entropy.
+        // byte array so we can always return 256 bits (32 bytes) of entropy.
         // Keep entropy_half instead of doing this inline so we can calculate the
         // checksum.
         let mut entropy_half = [0u8; 16];


### PR DESCRIPTION
Since we're now using bitvec for other operations like entropy_to_mnemonic, update mnemonic_to_entropy to use bitvec instead of the vector of "1" and "0" strings.

NOTES:
I did a tiny bit of cleanup with comments while I was here.

This code also probably gets even simpler when [PR #250](https://github.com/helium/helium-wallet-rs/pull/250) is merged. In my opinion this should get merged first then I can rebase and fixup that one. But, it's fine either way.
