### PR TITLE
Unstake multiple validators at once

### DIFF
--- a/src/cmd/validators/mod.rs
+++ b/src/cmd/validators/mod.rs
@@ -10,7 +10,7 @@ mod unstake;
 /// Commands for validators
 pub enum Cmd {
     /// Stake a validator with the given wallet as the owner.
-    Stake(stake::Cmd),
+    Stake(Box<stake::Cmd>),
     /// Unstake a validator
     Unstake(unstake::Cmd),
     /// Transfer a validator stake to a new validator and owner

--- a/src/cmd/validators/stake.rs
+++ b/src/cmd/validators/stake.rs
@@ -24,7 +24,7 @@ pub enum Cmd {
 #[derive(Debug, StructOpt)]
 pub struct One {
     #[structopt(flatten)]
-    validator: Validator,
+    validator: StakeValidator,
     /// Manually set fee to pay for the transaction(s)
     #[structopt(long)]
     fee: Option<u64>,
@@ -60,7 +60,7 @@ pub struct Multi {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let validators = self.collect_validators()?;
+        let validators = self.collect_stake_validators()?;
 
         let password = get_password(false)?;
         let wallet = load_wallet(opts.files)?;
@@ -93,7 +93,7 @@ impl Cmd {
         &self,
         keypair: &Keypair,
         fee_config: &Option<TxnFeeConfig>,
-        validator: &Validator,
+        validator: &StakeValidator,
     ) -> Result<BlockchainTxnStakeValidatorV1> {
         let mut txn = BlockchainTxnStakeValidatorV1 {
             address: validator.address.to_vec(),
@@ -111,12 +111,12 @@ impl Cmd {
         Ok(txn)
     }
 
-    fn collect_validators(&self) -> Result<Vec<Validator>> {
+    fn collect_stake_validators(&self) -> Result<Vec<StakeValidator>> {
         match &self {
             Self::One(one) => Ok(vec![one.validator.clone()]),
             Self::Multi(multi) => {
                 let file = std::fs::File::open(multi.path.clone())?;
-                let validators: Vec<Validator> = serde_json::from_reader(file)?;
+                let validators: Vec<StakeValidator> = serde_json::from_reader(file)?;
                 Ok(validators)
             }
         }
@@ -172,7 +172,7 @@ fn print_txn(
 }
 
 #[derive(Debug, Deserialize, StructOpt, Clone)]
-pub struct Validator {
+pub struct StakeValidator {
     /// The validator address to stake
     address: PublicKey,
     /// The amount of HNT to stake

--- a/src/cmd/validators/unstake.rs
+++ b/src/cmd/validators/unstake.rs
@@ -1,8 +1,10 @@
 use crate::{
     cmd::*,
+    keypair::Keypair,
     result::Result,
     traits::{TxnEnvelope, TxnFee, TxnSign},
 };
+use serde::Deserialize;
 
 #[derive(Debug, StructOpt)]
 /// Unstake a given validator. The stake will be in a cooldown period after
@@ -12,64 +14,165 @@ use crate::{
 /// be at least the current block height plus the chain cooldown period (as
 /// defined by a chain variable), and 5-10 blocks to allow for chain
 /// processing delays.
-pub struct Cmd {
-    /// Address of the validator to unstake
-    address: PublicKey,
+/// 
+/// Note that multiple staking transactions are submitted individually and not as a
+/// single transaction. Any failures will abort the remaining staking entries.
+pub enum Cmd {
+    /// Unstake a single validator
+    One(One),
+    /// Unstake multiple validators via file import
+    Multi(Multi),
+}
 
-    /// The amount of HNT of the original stake
-    #[structopt(long)]
-    stake_amount: Option<Hnt>,
-
-    /// The stake release block height. This should be at least the current
-    /// block height plus the cooldown period, and 5-10 blocks to allow for
-    /// chain processing delays.
-    #[structopt(long)]
-    stake_release_height: u64,
-
-    /// Manually set the fee to pay for the transaction
+#[derive(Debug, StructOpt)]
+pub struct One {
+    #[structopt(flatten)]
+    validator: UnstakeValidator,
     #[structopt(long)]
     fee: Option<u64>,
+    /// The stake release block height.
+    #[structopt(long)]
+    stake_release_height: Option<u64>,
+    /// Whether to commit the transaction(s) to the blockchain
+    #[structopt(long)]
+    commit: bool,
+}
 
-    /// Whether to commit the transaction to the blockchain
+#[derive(Debug, StructOpt)]
+/// The input file for multiple validator is expected to be json file
+/// with a list of address, stake_release_height and stake (the original stake of the validator). For example:
+///
+/// [
+///     {
+///         "address": "<adddress1>",
+///         "stake_release_height": 1440223,
+///         "stake": 10000
+///     },
+///     {
+///         "address": "<adddress2>",
+///         "stake": 10000
+///     }
+/// ]
+/// 
+/// If stake_release_height is not specified for a validator in this array, it will be taken from the command argument with the same name.
+pub struct Multi {
+    /// File to read multiple stakes from
+    path: PathBuf,
+    /// Manually set fee to pay for the transaction(s)
+    #[structopt(long)]
+    fee: Option<u64>,
+    /// The stake release block height.
+    #[structopt(long)]
+    stake_release_height: Option<u64>,
+    /// Whether to commit the transaction(s) to the blockchain
     #[structopt(long)]
     commit: bool,
 }
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
+        let validators = self.collect_unstake_validators()?;
+
         let password = get_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
 
         let client = new_client(api_url(wallet.public_key.network));
+        let fee_config = if self.fee().is_none() {
+            Some(get_txn_fees(&client).await?)
+        } else {
+            None
+        };
 
+        for validator in validators {
+            if validator.address.network != wallet.public_key.network {
+                bail!(
+                    "valiator: {} is not on {}",
+                    validator.address.to_string(),
+                    wallet.public_key.network
+                )
+            }
+            let txn = self.mk_txn(&client, &keypair, &fee_config, &validator).await?;
+            let envelope = txn.in_envelope();
+            let status = maybe_submit_txn(self.commit(), &client, &envelope).await?;
+            print_txn(&envelope, &txn, &status, &opts.format)?
+        }
+
+        Ok(())
+    }
+
+    async fn mk_txn(
+        &self,
+        client: &Client,
+        keypair: &Keypair,
+        fee_config: &Option<TxnFeeConfig>,
+        validator: &UnstakeValidator,
+    ) -> Result<BlockchainTxnUnstakeValidatorV1> {
         let mut txn = BlockchainTxnUnstakeValidatorV1 {
-            address: self.address.to_vec(),
-            owner: wallet.public_key.to_vec(),
-            stake_amount: if let Some(stake_amount) = self.stake_amount {
+            address: validator.address.to_vec(),
+            owner: keypair.public_key().to_vec(),
+            stake_amount: if let Some(stake_amount) = validator.stake {
                 u64::from(stake_amount)
             } else {
                 u64::from(
-                    helium_api::validators::get(&client, &self.address.to_string())
+                    helium_api::validators::get(client, &validator.address.to_string())
                         .await?
                         .stake,
                 )
             },
-            stake_release_height: self.stake_release_height,
             fee: 0,
             owner_signature: vec![],
+            stake_release_height: validator.stake_release_height.unwrap(),
         };
-
-        txn.fee = if let Some(fee) = self.fee {
+        txn.fee = if let Some(fee) = self.fee() {
             fee
         } else {
-            txn.txn_fee(&get_txn_fees(&client).await?)?
+            txn.txn_fee(fee_config.as_ref().unwrap())?
         };
-        txn.owner_signature = txn.sign(&keypair)?;
 
-        let envelope = txn.in_envelope();
-        let status = maybe_submit_txn(self.commit, &client, &envelope).await?;
-        print_txn(&envelope, &txn, &status, opts.format)
+        txn.owner_signature = txn.sign(keypair)?;
+        Ok(txn)
+    }
+
+    fn fee(&self) -> Option<u64> {
+        match &self {
+            Self::One(one) => one.fee,
+            Self::Multi(multi) => multi.fee,
+        }
+    }
+
+    fn collect_unstake_validators(&self) -> Result<Vec<UnstakeValidator>> {
+        match &self {
+            Self::One(one) => Ok(vec![self.mk_unstake_validator(&one.validator, one.stake_release_height)?]),
+            Self::Multi(multi) => {
+                let file = std::fs::File::open(multi.path.clone())?;
+                let validators: Vec<UnstakeValidator> = serde_json::from_reader(file)?;
+                let validators = validators.iter()
+                    .map(|v| self.mk_unstake_validator(&v, multi.stake_release_height))
+                    .collect::<Result<Vec<UnstakeValidator>>>()?;
+                Ok(validators)
+            }
+        }
+    }
+
+    fn mk_unstake_validator(&self, validator: &UnstakeValidator, stake_release_height: Option<u64>) -> Result<UnstakeValidator> {
+        let mut validator = validator.clone();
+        validator.stake_release_height = match validator.stake_release_height {
+            Some(h) => Some(h),
+            None => match stake_release_height {
+                Some(h) => Some(h),
+                None => bail!("stake-relase-height must be specified, either for each validator in the validators file, or in the command."),
+            }
+        };
+        Ok(validator)
+    }
+
+
+    fn commit(&self) -> bool {
+        match &self {
+            Self::One(one) => one.commit,
+            Self::Multi(multi) => multi.commit,
+        }
     }
 }
 
@@ -77,7 +180,7 @@ fn print_txn(
     envelope: &BlockchainTxn,
     txn: &BlockchainTxnUnstakeValidatorV1,
     status: &Option<PendingTxnStatus>,
-    format: OutputFormat,
+    format: &OutputFormat,
 ) -> Result {
     let validator = PublicKey::from_bytes(&txn.address)?.to_string();
     match format {
@@ -105,4 +208,19 @@ fn print_txn(
             print_json(&table)
         }
     }
+}
+
+#[derive(Debug, Deserialize, StructOpt, Clone)]
+pub struct UnstakeValidator {
+    // The validator address to unstake
+    address: PublicKey,
+    /// The amount of HNT of the original stake
+    #[structopt(long)]
+    stake: Option<Hnt>,
+    /// The stake release block height. This should be at least the current
+    /// block height plus the cooldown period, and 5-10 blocks to allow for
+    /// chain processing delays.
+    /// This field is optional, and stake release height from the command arguments will be used if this is not suplied.
+    #[structopt(skip)]
+    stake_release_height: Option<u64>,
 }

--- a/src/cmd/validators/unstake.rs
+++ b/src/cmd/validators/unstake.rs
@@ -19,9 +19,9 @@ use serde::Deserialize;
 /// single transaction. Any failures will abort the remaining staking entries.
 pub enum Cmd {
     /// Unstake a single validator
-    One(One),
+    One(Box<One>),
     /// Unstake multiple validators via file import
-    Multi(Multi),
+    Multi(Box<Multi>),
 }
 
 #[derive(Debug, StructOpt)]
@@ -156,7 +156,7 @@ impl Cmd {
                 let validators: Vec<UnstakeValidator> = serde_json::from_reader(file)?;
                 let validators = validators
                     .iter()
-                    .map(|v| self.mk_unstake_validator(&v, multi.stake_release_height))
+                    .map(|v| self.mk_unstake_validator(v, multi.stake_release_height))
                     .collect::<Result<Vec<UnstakeValidator>>>()?;
                 Ok(validators)
             }


### PR DESCRIPTION
This is similar to the `multi` feature in the `stake` command, but for `unstake`.

User can create a json file that'll hold an array of (address, stake (optional), stake release height (optional))

```
[
  {
    "address": "...",
    "stake": 10000,
    "stake_release_height": ...
  }
]
```

if `stake` is not specified for a validator in the file, it'll be queried for that validator via the API
if `stake_release_height` is not specified for a validator in the file, it'll be taken from the command line argument