### PR TITLE
Implement Payment with New Tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "helium-api"
 version = "3.2.2-dev"
-source = "git+https://github.com/helium/helium-api-rs?branch=lthiery/add-new-tokens#4ee9e3f671d056d6b99b87203cd75c016c03a629"
+source = "git+https://github.com/helium/helium-api-rs?branch=lthiery/add-new-tokens#6460e10952470dfba991cc219e547f44b6946862"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,12 +1110,11 @@ dependencies = [
 
 [[package]]
 name = "helium-api"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd90ff69f197482676574db441887d32126bc07d228205efa62884d5fc9c4540"
+version = "3.2.2-dev"
+source = "git+https://github.com/helium/helium-api-rs?branch=lthiery/add-new-tokens#86d74e9e1a604e458c83882a05f689153b168d92"
 dependencies = [
  "async-trait",
- "base64 0.13.0",
+ "base64 0.12.3",
  "chrono",
  "futures",
  "reqwest",
@@ -1144,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#97438b2cbbc0851f66bf8aaf4a6ec727bd424771"
+source = "git+https://github.com/helium/proto?branch=master#52cd9427c1c6d69ce93fbb1ead6e0f0d02b8cde0"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,11 +1110,12 @@ dependencies = [
 
 [[package]]
 name = "helium-api"
-version = "3.2.2-dev"
-source = "git+https://github.com/helium/helium-api-rs?branch=lthiery/add-new-tokens#6460e10952470dfba991cc219e547f44b6946862"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65e73b392df563b29559c7ab573635906b4921d75d0a7fd6dc2f12303bb0de5"
 dependencies = [
  "async-trait",
- "base64 0.12.3",
+ "base64 0.13.0",
  "chrono",
  "futures",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "helium-api"
 version = "3.2.2-dev"
-source = "git+https://github.com/helium/helium-api-rs?branch=lthiery/add-new-tokens#86d74e9e1a604e458c83882a05f689153b168d92"
+source = "git+https://github.com/helium/helium-api-rs?branch=lthiery/add-new-tokens#4ee9e3f671d056d6b99b87203cd75c016c03a629"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1"
 rust_decimal = {version = "1", features = ["serde-float"] }
 h3ron = "^0.13"
 geo-types = "*"
-helium-api = { git = "https://github.com/helium/helium-api-rs", branch = "lthiery/add-new-tokens"}
+helium-api = "3.3"
 angry-purple-tiger = "0"
 helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.3.3", features = ["multisig"]}
 helium-proto = { git = "https://github.com/helium/proto", branch="master"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1"
 rust_decimal = {version = "1", features = ["serde-float"] }
 h3ron = "^0.13"
 geo-types = "*"
-helium-api = "3"
+helium-api = { git = "https://github.com/helium/helium-api-rs", branch = "lthiery/add-new-tokens"}
 angry-purple-tiger = "0"
 helium-crypto = {git = "https://github.com/helium/helium-crypto-rs", tag="v0.3.3", features = ["multisig"]}
 helium-proto = { git = "https://github.com/helium/proto", branch="master"}

--- a/src/cmd/balance.rs
+++ b/src/cmd/balance.rs
@@ -52,7 +52,7 @@ fn print_results(results: Vec<(String, Result<Account>)>, format: OutputFormat) 
                 "Data Credits",
                 "Security Tokens",
                 "IOT Balance",
-                "MOB Balance"
+                "MOBILE Balance"
             ]);
             for (address, result) in results {
                 match result {

--- a/src/cmd/balance.rs
+++ b/src/cmd/balance.rs
@@ -47,10 +47,12 @@ fn print_results(results: Vec<(String, Result<Account>)>, format: OutputFormat) 
             table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
             table.set_titles(row![
                 "Address",
-                "Balance",
-                "Staked Balance",
+                "HNT Balance",
+                "Staked HNT Balance",
                 "Data Credits",
-                "Security Tokens"
+                "Security Tokens",
+                "IOT Balance",
+                "MOB Balance"
             ]);
             for (address, result) in results {
                 match result {
@@ -59,7 +61,9 @@ fn print_results(results: Vec<(String, Result<Account>)>, format: OutputFormat) 
                         account.balance,
                         account.staked_balance,
                         account.dc_balance,
-                        account.sec_balance
+                        account.sec_balance,
+                        account.iot_balance,
+                        account.mobile_balance,
                     ]),
                     Err(err) => table.add_row(row![address, H3 -> err.to_string()]),
                 };

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     wallet::Wallet,
 };
 pub use helium_api::{
-    models::{transactions::PendingTxnStatus, Hnt, Hst, Usd},
+    models::{transactions::PendingTxnStatus, Generic, Hnt, Hst, Iot, Mobile, Usd},
     Client,
 };
 pub use helium_proto::*;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     wallet::Wallet,
 };
 pub use helium_api::{
-    models::{transactions::PendingTxnStatus, Generic, Hnt, Hst, Iot, Mobile, Usd},
+    models::{transactions::PendingTxnStatus, Hnt, Hst, Iot, Mobile, Token, Usd},
     Client,
 };
 pub use helium_proto::*;

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -134,6 +134,8 @@ impl Cmd {
         match &self {
             Self::One(one) => Ok(vec![Payment {
                 payee: one.payee.address.to_vec(),
+                // we safely create u64 from the amount of type Generic
+                // only because each token_type has the same amount of decimals
                 amount: u64::from(one.payee.amount),
                 memo: u64::from(&one.payee.memo),
                 max: false,
@@ -151,6 +153,8 @@ impl Cmd {
                     .iter()
                     .map(|p| Payment {
                         payee: p.address.to_vec(),
+                        // we safely create u64 from the amount of type Generic
+                        // only because each token_type has the same amount of decimals
                         amount: u64::from(p.amount),
                         memo: u64::from(&p.memo),
                         max: false,

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -11,29 +11,6 @@ use prettytable::Table;
 use serde::Deserialize;
 use serde_json::json;
 
-#[derive(Debug, Deserialize)]
-pub enum TokenInput {
-    Hnt,
-    Iot,
-    Mobile,
-    Hst,
-}
-
-impl std::str::FromStr for TokenInput {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        let s = s.to_lowercase();
-        match s.as_str() {
-            "hnt" => Ok(TokenInput::Hnt),
-            "iot" => Ok(TokenInput::Iot),
-            "mobile" => Ok(TokenInput::Mobile),
-            "hst" => Ok(TokenInput::Hst),
-            _ => Err(anyhow::anyhow!("Invalid token input {s}")),
-        }
-    }
-}
-
 #[derive(Debug, StructOpt)]
 /// Send one (or more) payments to given addresses.
 ///
@@ -266,4 +243,27 @@ pub struct Payee {
     #[serde(default)]
     #[structopt(long, default_value = "AAAAAAAAAAA=")]
     memo: Memo,
+}
+
+#[derive(Debug, Deserialize)]
+pub enum TokenInput {
+    Hnt,
+    Iot,
+    Mobile,
+    Hst,
+}
+
+impl std::str::FromStr for TokenInput {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let s = s.to_lowercase();
+        match s.as_str() {
+            "hnt" => Ok(TokenInput::Hnt),
+            "iot" => Ok(TokenInput::Iot),
+            "mob" | "mobile" => Ok(TokenInput::Mobile),
+            "hst" => Ok(TokenInput::Hst),
+            _ => Err(anyhow::anyhow!("Invalid token input {s}")),
+        }
+    }
 }

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -12,23 +12,23 @@ use serde::Deserialize;
 use serde_json::json;
 
 #[derive(Debug, Deserialize)]
-pub enum Token {
+pub enum TokenInput {
     Hnt,
     Iot,
     Mobile,
     Hst,
 }
 
-impl std::str::FromStr for Token {
+impl std::str::FromStr for TokenInput {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self> {
         let s = s.to_lowercase();
         match s.as_str() {
-            "hnt" => Ok(Token::Hnt),
-            "iot" => Ok(Token::Iot),
-            "mobile" => Ok(Token::Mobile),
-            "hst" => Ok(Token::Hst),
+            "hnt" => Ok(TokenInput::Hnt),
+            "iot" => Ok(TokenInput::Iot),
+            "mobile" => Ok(TokenInput::Mobile),
+            "hst" => Ok(TokenInput::Hst),
             _ => Err(anyhow::anyhow!("Invalid token input {s}")),
         }
     }
@@ -134,16 +134,16 @@ impl Cmd {
         match &self {
             Self::One(one) => Ok(vec![Payment {
                 payee: one.payee.address.to_vec(),
-                // we safely create u64 from the amount of type Generic
+                // we safely create u64 from the amount of type Token
                 // only because each token_type has the same amount of decimals
                 amount: u64::from(one.payee.amount),
                 memo: u64::from(&one.payee.memo),
                 max: false,
                 token_type: match one.payee.token {
-                    Token::Hnt => BlockchainTokenTypeV1::Hnt.into(),
-                    Token::Hst => BlockchainTokenTypeV1::Hst.into(),
-                    Token::Iot => BlockchainTokenTypeV1::Iot.into(),
-                    Token::Mobile => BlockchainTokenTypeV1::Mobile.into(),
+                    TokenInput::Hnt => BlockchainTokenTypeV1::Hnt.into(),
+                    TokenInput::Hst => BlockchainTokenTypeV1::Hst.into(),
+                    TokenInput::Iot => BlockchainTokenTypeV1::Iot.into(),
+                    TokenInput::Mobile => BlockchainTokenTypeV1::Mobile.into(),
                 },
             }]),
             Self::Multi(multi) => {
@@ -153,16 +153,16 @@ impl Cmd {
                     .iter()
                     .map(|p| Payment {
                         payee: p.address.to_vec(),
-                        // we safely create u64 from the amount of type Generic
+                        // we safely create u64 from the amount of type Token
                         // only because each token_type has the same amount of decimals
                         amount: u64::from(p.amount),
                         memo: u64::from(&p.memo),
                         max: false,
                         token_type: match p.token {
-                            Token::Hnt => BlockchainTokenTypeV1::Hnt.into(),
-                            Token::Hst => BlockchainTokenTypeV1::Hst.into(),
-                            Token::Iot => BlockchainTokenTypeV1::Iot.into(),
-                            Token::Mobile => BlockchainTokenTypeV1::Mobile.into(),
+                            TokenInput::Hnt => BlockchainTokenTypeV1::Hnt.into(),
+                            TokenInput::Hst => BlockchainTokenTypeV1::Hst.into(),
+                            TokenInput::Iot => BlockchainTokenTypeV1::Iot.into(),
+                            TokenInput::Mobile => BlockchainTokenTypeV1::Mobile.into(),
                         },
                     })
                     .collect();
@@ -207,7 +207,7 @@ fn print_txn(
             for payment in txn.payments.clone() {
                 let token_type = BlockchainTokenTypeV1::from_i32(payment.token_type)
                     .expect("Invalid token_type found in transaction!");
-                let amount_decimal = Generic::from(payment.amount);
+                let amount_decimal = Token::from(payment.amount);
                 let amount_units = match token_type {
                     BlockchainTokenTypeV1::Hnt => "HNT",
                     BlockchainTokenTypeV1::Hst => "HST",
@@ -258,10 +258,10 @@ pub struct Payee {
     /// Address to send the tokens to.
     address: PublicKey,
     /// Amount of token to send
-    amount: Generic,
+    amount: Token,
     /// Type of token to send (hnt, iot, mobile, hst).
     #[structopt(default_value = "hnt")]
-    token: Token,
+    token: TokenInput,
     /// Memo field to include. Provide as a base64 encoded string
     #[serde(default)]
     #[structopt(long, default_value = "AAAAAAAAAAA=")]

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -42,21 +42,29 @@ pub struct One {
 
 #[derive(Debug, StructOpt)]
 /// The input file for multiple payments is expected to be json file with a list
-/// of payees, amounts, and optional memos. For example:
+/// of payees, amounts (in bones), token, and optional memos.
+///
+/// For example:
 ///
 /// [
 ///     {
 ///         "address": "<adddress1>",
-///         "amount": 1.6,
-///         "memo": "AAAAAAAAAAA="
+///         "amount": 160000000,
+///         "memo": "AAAAAAAAAAA=",
+///         "token": "Hnt",
 ///     },
 ///     {
 ///         "address": "<adddress2>",
-///         "amount": 0.5
+///         "amount": 50000000
+///         "token": "Mobile"
 ///     }
 /// ]
 ///
-/// Note that HNT only goes to 8 decimals of precision.
+/// Recall that all amounts given in bones are 10^8.
+/// That is to say, 1 HNT    = 100000000 bones
+///                 1 MOBILE = 100000000 Mbones
+///                 1 HST    = 100000000 Sbones
+///
 pub struct Multi {
     /// File to read multiple payments from.
     path: PathBuf,
@@ -189,7 +197,7 @@ fn print_txn(
                     BlockchainTokenTypeV1::Hnt => "HNT",
                     BlockchainTokenTypeV1::Hst => "HST",
                     BlockchainTokenTypeV1::Iot => "IOT",
-                    BlockchainTokenTypeV1::Mobile => "MOB",
+                    BlockchainTokenTypeV1::Mobile => "MOBILE",
                 };
 
                 table.add_row(row![

--- a/src/memo.rs
+++ b/src/memo.rs
@@ -5,7 +5,7 @@ use crate::{
 use serde::de::{self, Deserialize, Deserializer, Visitor};
 use std::{fmt, str::FromStr};
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct Memo(u64);
 
 impl FromStr for Memo {

--- a/src/mnemonic/mod.rs
+++ b/src/mnemonic/mod.rs
@@ -151,8 +151,7 @@ pub fn entropy_to_mnemonic(entropy: &[u8], seed_type: &SeedType) -> Result<Vec<S
     let working_bits = working_entropy.len() * 8;
 
     if working_bits % ENTROPY_MULTIPLE != 0
-        || working_bits < MIN_ENTROPY_BITS
-        || working_bits > MAX_ENTROPY_BITS
+        || !(MIN_ENTROPY_BITS..=MAX_ENTROPY_BITS).contains(&working_bits)
     {
         bail!("Incorrect entropy length: {}", working_bits)
     }


### PR DESCRIPTION
Depends on https://github.com/helium/helium-api-rs/pull/69

Implement token_type for pay, allowing the transaction to be used for transferring IOT, MOB, and HST.

Syntax for users allows them to optionally specify token_type at the end of the pay command; otherwise, it defaults to HNT which makes the command compatible with older versions of the wallet.

 For example, to pay someone HNT:
 ```
./helium-wallet pay one 1bcxuy2jZzmSKB2eRgMDo3gPUSV18WnojpZhk5Ppwqr5iM9JfU8 1
Password: [hidden]
+-----------------------------------------------------+----------------+--------------+
| Payee                                               | Amount         | Memo         |
+-----------------------------------------------------+----------------+--------------+
| 1bcxuy2jZzmSKB2eRgMDo3gPUSV18WnojpZhk5Ppwqr5iM9JfU8 | 1.00000000 HNT | AAAAAAAAAAA= |
+-----------------------------------------------------+----------------+--------------+
+----------+-------+
| Key      | Value |
+----------+-------+
| Fee (DC) | 35000 |
+----------+-------+
| Nonce    | 1     |
+----------+-------+
| Hash     | none  |
+----------+-------+
```

To pay HST, the transaction looks like this:
```
./helium-wallet pay one 1bcxuy2jZzmSKB2eRgMDo3gPUSV18WnojpZhk5Ppwqr5iM9JfU8 1 hst`
Password: [hidden]
+-----------------------------------------------------+----------------+--------------+
| Payee                                               | Amount         | Memo         |
+-----------------------------------------------------+----------------+--------------+
| 1bcxuy2jZzmSKB2eRgMDo3gPUSV18WnojpZhk5Ppwqr5iM9JfU8 | 1.00000000 HST | AAAAAAAAAAA= |
+-----------------------------------------------------+----------------+--------------+
```

Note, that since the payment transaction allows a vector of payments, token_type may be mixed. Therefore, the table header no longer provides token_type but instead, the token type is expressed in each row.

Also note the use of the `Generic` type. This allows decimal parsing to be done on the CLI before knowing what the token_type actually is. Since all tokens have the same amount of decimals, you can safely translate the amount into a u64 for all tokens.


