### PR TITLE
QR code export of seed for importing into a mobile app.

### DIFF
--- a/src/cmd/burn.rs
+++ b/src/cmd/burn.rs
@@ -38,7 +38,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
 
         let client = new_client(api_url(wallet.public_key.network));

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -95,7 +95,7 @@ impl Basic {
         } else {
             None
         };
-        let password = get_password(true)?;
+        let password = get_wallet_password(true)?;
 
         let mut builder = Wallet::builder()
             .output(&self.output)
@@ -121,7 +121,7 @@ impl Basic {
 impl Sharded {
     pub async fn run(&self, opts: Opts) -> Result {
         let seed_words = self.seed.then_some(get_seed_words()?);
-        let password = get_password(true)?;
+        let password = get_wallet_password(true)?;
 
         let shard_config = ShardConfig {
             key_share_count: self.key_share_count,

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -1,0 +1,167 @@
+use crate::{cmd::*, keypair::Keypair, pwhash::*, result::Result};
+use qr2term::print_qr;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sodiumoxide::crypto::{pwhash::argon2id13 as pwhash, secretbox::xsalsa20poly1305 as secretbox};
+
+//NOTE: The ops and memlimits are set lower than the CLI wallet uses for itself because
+//      initial testing on the mobile devices found SENSITIVE settings took too long.
+const ARGON_OPS_LIMIT: pwhash::OpsLimit = pwhash::OPSLIMIT_MODERATE;
+const ARGON_MEM_LIMIT: pwhash::MemLimit = pwhash::MEMLIMIT_MODERATE;
+
+/// Export an encypted wallet seed as JSON
+#[derive(Debug, StructOpt)]
+pub struct Cmd {}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EncryptedSeed {
+    version: u16,
+    salt: String,
+    nonce: String,
+    ciphertext: String,
+}
+
+impl Cmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        let password = get_wallet_password(false)?;
+        let wallet = load_wallet(opts.files)?;
+        let keypair = wallet.decrypt(password.as_bytes())?;
+        let seed_pwd = get_password("Export Password", true)?;
+        let json_data = json!({
+            "address": wallet.public_key.to_string(),
+            "seed": encrypt_seed_v1(&keypair, &seed_pwd)?,
+        });
+
+        print_qr(&json_data.to_string())?;
+        Ok(())
+    }
+}
+
+/// Encrypted seeds V1:
+///  1) Given the user entered password, generate an encryption key using the same pwhash
+///     alogrithm (Argong2id13) as the existing wallet.
+///  2) Use libsodium xsalsa20poly1305 and the encryption key to encrypt the seed phrase.
+///  3) base64 encode the salt, the nonce, and the encrypted result so it is easier to
+///     render in JSON later.
+pub fn encrypt_seed_v1(keypair: &Keypair, password: &String) -> Result<EncryptedSeed> {
+    let address = keypair.public_key().to_string();
+    let phrase = keypair.phrase()?.join(" ");
+
+    let hasher = Argon2id13::with_limits(ARGON_OPS_LIMIT, ARGON_MEM_LIMIT);
+    let mut key = secretbox::Key([0; secretbox::KEYBYTES]);
+    let secretbox::Key(ref mut key_buffer) = key;
+    hasher.pwhash(password.as_bytes(), key_buffer)?;
+
+    let nonce = secretbox::gen_nonce();
+    let ciphertext = secretbox::seal(phrase.as_bytes(), &nonce, &key);
+
+    let result = EncryptedSeed {
+        version: 1,
+        salt: base64::encode(hasher.salt()),
+        nonce: base64::encode(nonce),
+        ciphertext: base64::encode(ciphertext),
+    };
+
+    if cfg!(debug_assertions) {
+        println!("DEBUG encrypt_seed_v1:  password: {}", password);
+        println!(
+            "DEBUG encrypt_seed_v1:  key: {}",
+            base64::encode(key.clone())
+        );
+        let json_data = json!({
+            "address": address,
+            "seed": result,
+        });
+        print_json(&json_data)?;
+    };
+
+    Ok(result)
+}
+
+/// Decrypt an EncyptedSeed that was encrypted by encrypt_seed_v1
+///
+pub fn decrypt_seed_v1(es: &EncryptedSeed, password: &String) -> Result<String> {
+    if es.version != 1 {
+        bail!("Incompatible version format");
+    }
+    let salt = pwhash::Salt::from_slice(base64::decode(&es.salt)?.as_slice())
+        .ok_or_else(|| anyhow::anyhow!("Failed to decode salt"))?;
+    let hasher = Argon2id13::with_salt_and_limits(salt, ARGON_OPS_LIMIT, ARGON_MEM_LIMIT);
+    let mut key = secretbox::Key([0; secretbox::KEYBYTES]);
+    let secretbox::Key(ref mut key_buffer) = key;
+    hasher.pwhash(password.as_bytes(), key_buffer)?;
+
+    let nonce: [u8; secretbox::NONCEBYTES] = base64::decode(&es.nonce)?.as_slice().try_into()?;
+    let ciphertext = base64::decode(&es.ciphertext)?;
+
+    if cfg!(debug_assertions) {
+        println!("DEBUG decrypt_seed_v1: password: {}", password);
+        println!("DEBUG decrypt_seed_v1: es: {:?}", es);
+        println!(
+            "DEBUG decrypt_seed_v1: nonce: {:?}, salt: {:?}",
+            nonce, salt
+        );
+    };
+
+    if let Ok(decrypted_bytes) = secretbox::open(&ciphertext, &secretbox::Nonce(nonce), &key) {
+        String::from_utf8(decrypted_bytes).map_err(anyhow::Error::from)
+    } else {
+        Err(anyhow::anyhow!("Couldn't decrypt EncryptedSeed"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keypair::KeyTag;
+
+    const JSON_DATA: &str = r#"
+        {
+            "ciphertext": "yKU6haopJpIjIWoiYxa07fGnXjtgh30zuOv9PKQcs59tlOqrjUCSqFITr7wi2ARkypZQZ2BnM4UsjcNGU7oBBHUg4MTqhiWrKyFXDs6AdjOL5RzZasB2cvtA4a/35znyG7E2m+aydn9gUKCpS60fQdcDS7cjO6BilGH82PUof3NcnvmSs6pr526b+ooqCexPpXrR0oc+9gpjGjndekxzXfJ+Wk6tdfRT/r74",
+            "nonce": "n1RCu1R3tDt6UDQ4Zv8bMPRMvWA9BcKM",
+            "salt": "w9NIcC6BBrTuxqkXBursmw==",
+            "version": 1
+        }"#;
+
+    const MNEMONIC_PHRASE: &str = "pelican sphere tackle click broken hurt \
+                                    fork nephew choice seven announce moment \
+                                    tobacco tribe topple pause october drama \
+                                    sock erase news glove okay bubble";
+    const SEED_PWD: &str = "h3l1Um";
+
+    fn create_test_keypair() -> Keypair {
+        let word_list = String::from(MNEMONIC_PHRASE)
+            .split_whitespace()
+            .map(|w| w.to_string())
+            .collect();
+        let entropy = mnemonic::mnemonic_to_entropy(word_list).unwrap();
+        Keypair::generate_from_entropy(KeyTag::default(), &entropy).unwrap()
+    }
+
+    #[test]
+    fn decrypt_seed() {
+        let es: EncryptedSeed = serde_json::from_str(JSON_DATA).expect("Failed to parse JSON");
+        let decrypted_phrase =
+            decrypt_seed_v1(&es, &String::from(SEED_PWD)).expect("Failed to decrypt");
+
+        assert_eq!(decrypted_phrase, String::from(MNEMONIC_PHRASE));
+    }
+
+    #[test]
+    fn decrypt_seed_fail() {
+        let es: EncryptedSeed = serde_json::from_str(JSON_DATA).expect("Failed to parse JSON");
+        decrypt_seed_v1(&es, &String::from("fizbuzz"))
+            .expect_err("Should not been able to decrypt");
+    }
+
+    #[test]
+    fn encrypt_decrypt_seed() {
+        let keypair = create_test_keypair();
+        let created_es: EncryptedSeed = encrypt_seed_v1(&keypair, &String::from(SEED_PWD))
+            .expect("Failed to encrypt seed phrase");
+
+        let decrypted_phrase = decrypt_seed_v1(&created_es, &String::from(SEED_PWD))
+            .expect("Failed to decrypt seed phrase");
+        assert_eq!(decrypted_phrase, MNEMONIC_PHRASE);
+    }
+}

--- a/src/cmd/hotspots/add.rs
+++ b/src/cmd/hotspots/add.rs
@@ -30,7 +30,7 @@ impl Cmd {
     pub async fn run(self, opts: Opts) -> Result {
         let mut txn = BlockchainTxnAddGatewayV1::from_envelope(&read_txn(&self.txn)?)?;
 
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
 

--- a/src/cmd/hotspots/assert.rs
+++ b/src/cmd/hotspots/assert.rs
@@ -62,7 +62,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
 

--- a/src/cmd/hotspots/transfer.rs
+++ b/src/cmd/hotspots/transfer.rs
@@ -35,7 +35,7 @@ impl Cmd {
             owner_signature: vec![],
         };
         txn.fee = txn.txn_fee(&get_txn_fees(&client).await?)?;
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
         txn.owner_signature = txn.sign(&keypair)?;
 

--- a/src/cmd/htlc.rs
+++ b/src/cmd/htlc.rs
@@ -64,7 +64,7 @@ impl Cmd {
 
 impl Create {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let client = new_client(api_url(wallet.public_key.network));
 
@@ -133,7 +133,7 @@ fn print_create_txn(
 
 impl Redeem {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
         let client = new_client(api_url(wallet.public_key.network));

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -22,6 +22,7 @@ pub mod balance;
 pub mod burn;
 pub mod commit;
 pub mod create;
+pub mod export;
 pub mod hotspots;
 pub mod htlc;
 pub mod info;
@@ -94,19 +95,21 @@ fn load_wallet(files: Vec<PathBuf>) -> Result<Wallet> {
     Ok(first_wallet)
 }
 
-fn get_password(confirm: bool) -> std::io::Result<String> {
+fn get_wallet_password(confirm: bool) -> std::io::Result<String> {
     match env::var("HELIUM_WALLET_PASSWORD") {
         Ok(str) => Ok(str),
-        _ => {
-            use dialoguer::Password;
-            let mut builder = Password::new();
-            builder.with_prompt("Password");
-            if confirm {
-                builder.with_confirmation("Confirm password", "Passwords do not match");
-            };
-            builder.interact()
-        }
+        _ => get_password("Wallet Password", confirm),
     }
+}
+
+fn get_password(prompt: &str, confirm: bool) -> std::io::Result<String> {
+    use dialoguer::Password;
+    let mut builder = Password::new();
+    builder.with_prompt(prompt);
+    if confirm {
+        builder.with_confirmation("Confirm password", "Passwords do not match");
+    };
+    builder.interact()
 }
 
 const DEFAULT_TESTNET_BASE_URL: &str = "https://testnet-api.helium.wtf/v1";

--- a/src/cmd/multisig.rs
+++ b/src/cmd/multisig.rs
@@ -91,7 +91,7 @@ impl Inspect {
 
 impl Prove {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
 

--- a/src/cmd/oracle.rs
+++ b/src/cmd/oracle.rs
@@ -44,7 +44,7 @@ impl Cmd {
 
 impl Report {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
 

--- a/src/cmd/oui/create.rs
+++ b/src/cmd/oui/create.rs
@@ -48,7 +48,7 @@ pub struct Create {
 
 impl Create {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
         let wallet_key = keypair.public_key();

--- a/src/cmd/oui/update.rs
+++ b/src/cmd/oui/update.rs
@@ -101,7 +101,7 @@ pub struct RequestSubnet {
 
 impl Update {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
         let client = new_client(api_url(wallet.public_key.network));

--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -83,7 +83,7 @@ impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let payments = self.collect_payments()?;
 
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
 
         let client = new_client(api_url(wallet.public_key.network));

--- a/src/cmd/sign.rs
+++ b/src/cmd/sign.rs
@@ -30,7 +30,7 @@ pub struct File {
 impl File {
     pub async fn run(&self, opts: Opts) -> Result {
         use std::io::Read;
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
         let mut data = Vec::new();
@@ -50,7 +50,7 @@ pub struct Msg {
 
 impl Msg {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
         let signature = keypair.sign(self.msg.as_bytes())?;

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -59,7 +59,7 @@ impl Cmd {
 
 impl Basic {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
 
@@ -75,7 +75,7 @@ impl Basic {
 
 impl Sharded {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
 

--- a/src/cmd/validators/stake.rs
+++ b/src/cmd/validators/stake.rs
@@ -62,7 +62,7 @@ impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let validators = self.collect_stake_validators()?;
 
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
 

--- a/src/cmd/validators/transfer.rs
+++ b/src/cmd/validators/transfer.rs
@@ -82,7 +82,7 @@ impl Cmd {
 
 impl Create {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
 
@@ -138,7 +138,7 @@ impl Accept {
     pub async fn run(&self, opts: Opts) -> Result {
         let mut txn = BlockchainTxnTransferValidatorStakeV1::from_envelope(&read_txn(&self.txn)?)?;
 
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
 

--- a/src/cmd/validators/unstake.rs
+++ b/src/cmd/validators/unstake.rs
@@ -73,7 +73,7 @@ impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let validators = self.collect_unstake_validators()?;
 
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let keypair = wallet.decrypt(password.as_bytes())?;
 

--- a/src/cmd/verify.rs
+++ b/src/cmd/verify.rs
@@ -8,7 +8,7 @@ pub struct Cmd {}
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_password(false)?;
+        let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
         let decryped_wallet = wallet.decrypt(password.as_bytes());
         print_result(&wallet, &decryped_wallet, opts.format)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use helium_wallet::{
     cmd::{
-        balance, burn, commit, create, hotspots, htlc, info, multisig, oracle, oui, pay, request,
-        sign, upgrade, validators, vars, verify, Opts,
+        balance, burn, commit, create, export, hotspots, htlc, info, multisig, oracle, oui, pay,
+        request, sign, upgrade, validators, vars, verify, Opts,
     },
     result::Result,
 };
@@ -36,6 +36,7 @@ pub enum Cmd {
     Validators(validators::Cmd),
     Commit(commit::Cmd),
     Sign(sign::Cmd),
+    Export(export::Cmd),
 }
 
 #[tokio::main]
@@ -66,5 +67,6 @@ async fn run(cli: Cli) -> Result {
         Cmd::Validators(cmd) => cmd.run(cli.opts).await,
         Cmd::Commit(cmd) => cmd.run(cli.opts).await,
         Cmd::Sign(cmd) => cmd.run(cli.opts).await,
+        Cmd::Export(cmd) => cmd.run(cli.opts).await,
     }
 }

--- a/src/pwhash.rs
+++ b/src/pwhash.rs
@@ -106,11 +106,23 @@ impl Default for Argon2id13 {
 
 impl Argon2id13 {
     pub fn with_limits(ops_limit: argon2id13::OpsLimit, mem_limit: argon2id13::MemLimit) -> Self {
+        Self::with_salt_and_limits(argon2id13::gen_salt(), ops_limit, mem_limit)
+    }
+
+    pub fn with_salt_and_limits(
+        salt: argon2id13::Salt,
+        ops_limit: argon2id13::OpsLimit,
+        mem_limit: argon2id13::MemLimit,
+    ) -> Self {
         Self {
-            salt: argon2id13::gen_salt(),
-            mem_limit,
+            salt,
             ops_limit,
+            mem_limit,
         }
+    }
+
+    pub fn salt(&self) -> argon2id13::Salt {
+        self.salt
     }
 
     pub fn pwhash(&self, password: &[u8], hash: &mut [u8]) -> Result {


### PR DESCRIPTION
I've been talking with @lthiery, @bones, and @Perronef5  about this. 
The overall idea is to be able to import a CLI wallet into the `#new-helium-wallet` app via a QR code output on the CLI. 

Add an `export` command, which asks for a password, then uses that password to encrypt a copy of the mnemonic seed phrase. Finally, output a QR code of a JSON blob which contains the encrypted text along with the nonce and seed needed to decrypt it. The user will have to supply the original password to decrypt.

The process is roughly like this:
* Generate a secret key using pwhash() set to use the argon2id13 algorithm with MODERATE ops and memlimits. The settings here were chosen to be usable on mobile devices during decryption.

* Encrypt the mnemonic phrase using libsodium's `secretbox_easy()` set to use the xsalsa20poly1305 algorithm. This algorithm was chosen because it is available in the existing sodium npm the mobile apps use, we couldn't find an implementation of the libsodium aead_aes256gcm algorithm (used by the CLI wallet already) in JavaScript.

* Output some JSON that includes the ciphertext, the salt, and the nonce all as base64-encoded strings. The base64 encoding is so that the resulting JSON contains only strings, making debugging easier.

* Turn the JSON into a QR code, output that.

NOTES: 
@Perronef5 confirmed he has code in ReactNative that could decrypt some JSON I had earlier. I've given him the following JSON and QR code for an end-to-end test:
<img width="528" alt="qr-test1" src="https://user-images.githubusercontent.com/3513964/186289579-cbb93f8e-20e2-41cb-8b1d-f529d9c40985.png">

This should decode to:
```
{
    "address":"14eci9QRRVmCD3Um2VZgcS4LVdBoaRPpReb5oYp9uYUNtfoajLv",
    "seed": {
        "ciphertext":"xCT5KryMhj4UatDtbnTUKaqUAINqrCnNgVos97DszntYnhz1btaIujQShgppYnGc2TBfGOSNvvG8UmSnOkRDHqWtWg9rEAPyvo/ipVxQxDctjEhR3CA2rrvLsJZVy7tKDD/uz2vGkBhaUOCH1fJn4z01UcCdpW4NSR7o0GzK5O5Quo9IwafOmtoA2QBfHx4GlEnEm3i9+cX0a1s6YX8qksOyO71om2Nfky6o",
        "nonce":"PfhAsC6Yi4rkAXQJ4UM+nTDF/Hw9ep9s",
        "salt":"yCMmQcBzDv2Rj24QjA6bog==",
        "version":1
    }
}
```
Which can be decrypted with the password `test1`
