### PR TITLE
 Api endpoint URL upon txn submission

### DIFF
--- a/src/cmd/pay.rs
+++ b/src/cmd/pay.rs
@@ -82,14 +82,12 @@ pub struct Multi {
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let payments = self.collect_payments()?;
-
         let password = get_wallet_password(false)?;
         let wallet = load_wallet(opts.files)?;
-
-        let client = new_client(api_url(wallet.public_key.network));
-
+        let base_url: String = api_url(wallet.public_key.network);
+        let client = new_client(base_url.clone());
+        let pending_url = base_url + "/pending_transactions/";
         let keypair = wallet.decrypt(password.as_bytes())?;
-
         let mut txn = BlockchainTxnPaymentV2 {
             fee: 0,
             payments,
@@ -112,7 +110,7 @@ impl Cmd {
 
         let envelope = txn.in_envelope();
         let status = maybe_submit_txn(self.commit(), &client, &envelope).await?;
-        print_txn(&txn, &envelope, &status, opts.format)
+        print_txn(&txn, &envelope, &status, &pending_url, opts.format)
     }
 
     fn collect_payments(&self) -> Result<Vec<Payment>> {
@@ -182,8 +180,10 @@ fn print_txn(
     txn: &BlockchainTxnPaymentV2,
     envelope: &BlockchainTxn,
     status: &Option<PendingTxnStatus>,
+    pending_url: &str,
     format: OutputFormat,
 ) -> Result {
+    let status_endpoint = pending_url.to_owned() + status_str(status);
     match format {
         OutputFormat::Table => {
             let mut table = Table::new();
@@ -212,7 +212,8 @@ fn print_txn(
                 ["Key", "Value"],
                 ["Fee (DC)", txn.fee],
                 ["Nonce", txn.nonce],
-                ["Hash", status_str(status)]
+                ["Hash", status_str(status)],
+                ["Status", status_endpoint]
             );
 
             print_footer(status)
@@ -232,6 +233,7 @@ fn print_txn(
                 "nonce": txn.nonce,
                 "hash": status_json(status),
                 "txn": envelope.to_b64()?,
+                "status": status_endpoint
             });
             print_json(&table)
         }


### PR DESCRIPTION
     This commit adds one row to the last table printed after a txn. The new row provides an api endpoint
     which the user can use to check on the status of the transaction.

    The table has the following form:

    +----------+-------------------------------------------------------------------------------------------+
    | Key      | Value                                                                                     |
    +----------+-------------------------------------------------------------------------------------------+
    | Fee (DC) | 35000                                                                                     |
    +----------+-------------------------------------------------------------------------------------------+
    | Nonce    | 2                                                                                         |
    +----------+-------------------------------------------------------------------------------------------+
    | Hash     | _bPXVKMEmJGMaDXxd_ysiODIft_VZHpputHoD7hBcNw                                               |
    +----------+-------------------------------------------------------------------------------------------+
    | Status   | https://api.helium.io/v1/pending_transactions/_bPXVKMEmJGMaDXxd_ysiODIft_VZHpputHoD7hBcNw |
    +----------+-------------------------------------------------------------------------------------------+