### PR TITLE
update default filter to include padding

### DIFF
--- a/src/cmd/oui/create.rs
+++ b/src/cmd/oui/create.rs
@@ -24,7 +24,7 @@ pub struct Create {
     /// overwrite this at any time.
     #[structopt(
         long,
-        default_value = "wVwCiewtCpEKAAAAAAAAAAAAcCK3fwAAAAAAAAAAAABI7IQOAHAAAAAAAAAAAAAAAQAAADBlAAAAAAAAAAAAADEAAAA2AAAAOgAAAA"
+        default_value = "wVwCiewtCpEKAAAAAAAAAAAAcCK3fwAAAAAAAAAAAABI7IQOAHAAAAAAAAAAAAAAAQAAADBlAAAAAAAAAAAAADEAAAA2AAAAOgAAAA=="
     )]
     filter: String,
 


### PR DESCRIPTION
replaces #303 

The issue is that the filter provided has no padding but base64 _used_ to tolerated lack of padding when expecting padded base64. With the latest base64 release, padded-parsing is no longer tolerant of no-padding.

Instead of changing/mixing the base64 convention, we shall simply update the default filter to provide padding.