### PR TITLE
decode message with base64::STANDARD

### DIFF
--- a/src/b64.rs
+++ b/src/b64.rs
@@ -20,7 +20,7 @@ pub fn decode_message<T>(v: &str) -> Result<T>
 where
     T: Message + Default,
 {
-    let decoded = URL_SAFE_NO_PAD.decode(v)?;
+    let decoded = STANDARD.decode(v)?;
     let message = T::decode(&decoded[..])?;
     Ok(message)
 }


### PR DESCRIPTION
Currently, encode uses the `STANDARD` engine but decode uses `URL_SAFE_NO_PAD`. This was probably a refactoring typo and so this PR changes decode to use `STANDARD` and which seems to match previous behavior: https://github.com/helium/helium-wallet-rs/blob/de49a53435aa43b806cd2784b26b2bc61d34ab48/src/traits/b64.rs