### PR TITLE
remove HST from tranfers command docs

### DIFF
--- a/src/cmd/transfer.rs
+++ b/src/cmd/transfer.rs
@@ -26,7 +26,7 @@ impl Cmd {
 pub enum PayCmd {
     /// Pay a single payee.
     ///
-    /// Note that HNT and HST go to 8 decimals of precision, while MOBILE and
+    /// Note that HNT goes to 8 decimals of precision, while MOBILE and
     /// IOT go to 6 decimals of precision
     One(One),
     /// Pay multiple payees


### PR DESCRIPTION
It looks like `client.transfer` will only work for SPL tokens, therefore, HST (an NFT) is not compatible with this command.