### PR TITLE
Change settings to finalized

### DIFF
--- a/helium-lib/src/hotspot.rs
+++ b/helium-lib/src/hotspot.rs
@@ -185,7 +185,7 @@ pub mod info {
                         &signature,
                         RpcTransactionConfig {
                             encoding: Some(UiTransactionEncoding::JsonParsed),
-                            commitment: Some(CommitmentConfig::confirmed()),
+                            commitment: Some(CommitmentConfig::finalized()),
                             max_supported_transaction_version: Some(0),
                         },
                     )

--- a/helium-lib/src/settings.rs
+++ b/helium-lib/src/settings.rs
@@ -76,14 +76,14 @@ impl Settings {
         Ok(AnchorClient::new_with_options(
             cluster,
             payer,
-            solana_sdk::commitment_config::CommitmentConfig::confirmed(),
+            solana_sdk::commitment_config::CommitmentConfig::finalized(),
         ))
     }
 
     pub fn mk_solana_client(&self) -> CrateResult<SolanaRpcClient> {
         Ok(SolanaRpcClient::new_with_commitment(
             self.to_string(),
-            solana_sdk::commitment_config::CommitmentConfig::confirmed(),
+            solana_sdk::commitment_config::CommitmentConfig::finalized(),
         ))
     }
 


### PR DESCRIPTION
This fixes transactions that look like they succeeded (confirmed) but then don’t actually get finalized.