### PR TITLE
Have `updates` take the account to inspect

### DIFF
--- a/helium-wallet/src/cmd/hotspots/updates.rs
+++ b/helium-wallet/src/cmd/hotspots/updates.rs
@@ -27,7 +27,8 @@ impl Cmd {
             until: self.until,
             ..Default::default()
         };
-        let txns = hotspot::info::updates(&settings, self.subdao, &self.address, params).await?;
+        let info_key = self.subdao.info_key_for_helium_key(&self.address)?;
+        let txns = hotspot::info::updates(&settings, &info_key, params).await?;
         print_json(&txns)
     }
 }


### PR DESCRIPTION
This allows both the info_key for a specific hotspot entity key as well as inspecting all update txns from the entity manager.

Renames ConfirmedHotspotInfoUpdate to CommitttedHotspotInfoUpdate since we’re looking for finalized transactions