### PR TITLE
Fix asset to hotspot conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,7 +1742,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -2448,7 +2447,6 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "serde_with",
  "sha2 0.10.8",
  "solana-program",
  "solana-sdk",
@@ -2737,7 +2735,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -4598,14 +4595,8 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
 dependencies = [
- "base64 0.13.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
  "serde",
- "serde_json",
  "serde_with_macros",
- "time",
 ]
 
 [[package]]

--- a/helium-lib/Cargo.toml
+++ b/helium-lib/Cargo.toml
@@ -36,7 +36,7 @@ solana-program = "*"
 solana-transaction-status = "*"
 serde = {workspace = true}
 serde_json = {workspace = true}
-serde_with = "2"
+# serde_with = "2"
 lazy_static = "1"
 rust_decimal = {workspace = true}
 helium-proto = {workspace= true}

--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -225,7 +225,7 @@ impl AssetProof {
         let canopy_heights = get_canopy_heights().await?;
         let height = canopy_heights
             .get(tree)
-            .ok_or_else(|| anchor_client::ClientError::AccountNotFound)?;
+            .ok_or_else(Error::account_not_found)?;
         self.proof(Some(*height))
     }
 }

--- a/helium-lib/src/dao.rs
+++ b/helium-lib/src/dao.rs
@@ -1,8 +1,5 @@
 use crate::{
-    entity_key::AsEntityKey,
-    keypair::Pubkey,
-    programs::{MPL_BUBBLEGUM_PROGRAM_ID, TOKEN_METADATA_PROGRAM_ID},
-    result::Result,
+    entity_key::AsEntityKey, keypair::Pubkey, programs::TOKEN_METADATA_PROGRAM_ID, result::Result,
     token::Token,
 };
 use helium_anchor_gen::{data_credits, helium_entity_manager, helium_sub_daos, lazy_distributor};
@@ -75,13 +72,13 @@ impl Dao {
 
     pub fn merkle_tree_authority(&self, merkle_tree: &Pubkey) -> Pubkey {
         let (tree_authority, _ta_bump) =
-            Pubkey::find_program_address(&[merkle_tree.as_ref()], &MPL_BUBBLEGUM_PROGRAM_ID);
+            Pubkey::find_program_address(&[merkle_tree.as_ref()], &mpl_bubblegum::ID);
         tree_authority
     }
 
     pub fn bubblegum_signer(&self) -> Pubkey {
         let (bubblegum_signer, _bs_bump) =
-            Pubkey::find_program_address(&[b"collection_cpi"], &MPL_BUBBLEGUM_PROGRAM_ID);
+            Pubkey::find_program_address(&[b"collection_cpi"], &mpl_bubblegum::ID);
         bubblegum_signer
     }
 
@@ -93,7 +90,7 @@ impl Dao {
         key
     }
 
-    pub fn key_to_asset_key<E: AsEntityKey + ?Sized>(&self, entity_key: &E) -> Pubkey {
+    pub fn entity_key_to_kta_key<E: AsEntityKey + ?Sized>(&self, entity_key: &E) -> Pubkey {
         let hash = Sha256::digest(entity_key.as_entity_key());
         let (key, _) = Pubkey::find_program_address(
             &[b"key_to_asset", self.key().as_ref(), hash.as_ref()],
@@ -170,7 +167,7 @@ impl SubDao {
         key
     }
 
-    pub fn escrow_account_key(&self, delegated_dc_key: &Pubkey) -> Pubkey {
+    pub fn escrow_key(&self, delegated_dc_key: &Pubkey) -> Pubkey {
         let (key, _) = Pubkey::find_program_address(
             &[b"escrow_dc_account", delegated_dc_key.as_ref()],
             &data_credits::id(),
@@ -217,12 +214,12 @@ impl SubDao {
         key
     }
 
-    pub fn asset_key_to_receipient_key(&self, asset_key: &Pubkey) -> Pubkey {
+    pub fn receipient_key_from_kta(&self, kta: &helium_entity_manager::KeyToAssetV0) -> Pubkey {
         let (key, _) = Pubkey::find_program_address(
             &[
                 b"recipient",
                 self.lazy_distributor_key().as_ref(),
-                asset_key.as_ref(),
+                kta.asset.as_ref(),
             ],
             &lazy_distributor::id(),
         );

--- a/helium-lib/src/dc.rs
+++ b/helium-lib/src/dc.rs
@@ -91,7 +91,7 @@ pub async fn delegate<C: Clone + Deref<Target = impl Signer> + GetPubkey>(
         sub_dao: subdao.key(),
         owner: keypair.pubkey(),
         from_account: Token::Dc.associated_token_adress(&keypair.pubkey()),
-        escrow_account: subdao.escrow_account_key(&delegated_data_credits),
+        escrow_account: subdao.escrow_key(&delegated_data_credits),
         payer: keypair.pubkey(),
         associated_token_program: anchor_spl::associated_token::ID,
         token_program: anchor_spl::token::ID,

--- a/helium-lib/src/kta.rs
+++ b/helium-lib/src/kta.rs
@@ -1,0 +1,128 @@
+use crate::{
+    dao::Dao,
+    entity_key::AsEntityKey,
+    keypair::{Keypair, Pubkey, VoidKeypair},
+    result::{Error, Result},
+    settings::Settings,
+};
+use anchor_client::anchor_lang::AccountDeserialize;
+use helium_anchor_gen::helium_entity_manager::{self, KeyToAssetV0};
+use itertools::Itertools;
+use std::{
+    collections::HashMap,
+    sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
+
+pub fn init(settings: &Settings) -> Result<()> {
+    let _ = CACHE.set(KtaCache::new(settings)?);
+    Ok(())
+}
+
+pub async fn get(kta_key: &Pubkey) -> Result<KeyToAssetV0> {
+    let cache = CACHE
+        .get()
+        .ok_or_else(|| anchor_client::ClientError::AccountNotFound)?;
+    cache.get(kta_key).await
+}
+
+pub async fn get_many(kta_keys: &[Pubkey]) -> Result<Vec<KeyToAssetV0>> {
+    let cache = CACHE
+        .get()
+        .ok_or_else(|| anchor_client::ClientError::AccountNotFound)?;
+    cache.get_many(kta_keys).await
+}
+
+pub async fn for_entity_key<E>(entity_key: &E) -> Result<KeyToAssetV0>
+where
+    E: AsEntityKey,
+{
+    let kta_key = Dao::Hnt.entity_key_to_kta_key(entity_key);
+    get(&kta_key).await
+}
+
+static CACHE: OnceLock<KtaCache> = OnceLock::new();
+
+type KtaCacheMap = HashMap<Pubkey, KeyToAssetV0>;
+struct KtaCache {
+    program: anchor_client::Program<Arc<VoidKeypair>>,
+    cache: RwLock<KtaCacheMap>,
+}
+
+impl KtaCache {
+    fn new(settings: &Settings) -> Result<Self> {
+        let anchor_client = settings.mk_anchor_client(Keypair::void())?;
+        let program = anchor_client.program(helium_entity_manager::id())?;
+        let cache = RwLock::new(KtaCacheMap::new());
+        Ok(Self { program, cache })
+    }
+
+    fn cache_read(&self) -> RwLockReadGuard<'_, KtaCacheMap> {
+        self.cache.read().expect("cache read lock poisoned")
+    }
+
+    fn cache_write(&self) -> RwLockWriteGuard<'_, KtaCacheMap> {
+        self.cache.write().expect("cache write lock poisoned")
+    }
+
+    async fn get(&self, kta_key: &Pubkey) -> Result<helium_entity_manager::KeyToAssetV0> {
+        if let Some(account) = self.cache_read().get(kta_key) {
+            return Ok(account.clone());
+        }
+
+        let kta = self
+            .program
+            .account::<helium_entity_manager::KeyToAssetV0>(*kta_key)
+            .await?;
+        self.cache_write().insert(*kta_key, kta.clone());
+        Ok(kta)
+    }
+
+    async fn get_many(
+        &self,
+        kta_keys: &[Pubkey],
+    ) -> Result<Vec<helium_entity_manager::KeyToAssetV0>> {
+        let missing_keys: Vec<Pubkey> = {
+            let cache = self.cache_read();
+            kta_keys
+                .iter()
+                .filter(|key| !cache.contains_key(key))
+                .copied()
+                .collect()
+        };
+        let mut missing_accounts = self
+            .program
+            .async_rpc()
+            .get_multiple_accounts(&missing_keys)
+            .await?;
+        {
+            let mut cache = self.cache_write();
+            missing_keys
+                .into_iter()
+                .zip(missing_accounts.iter_mut())
+                .map(|(key, maybe_account)| {
+                    let Some(account) = maybe_account.as_mut() else {
+                        return Err(Error::from(anchor_client::ClientError::AccountNotFound));
+                    };
+                    helium_entity_manager::KeyToAssetV0::try_deserialize(&mut account.data.as_ref())
+                        .map_err(Error::from)
+                        .map(|kta| (key, kta))
+                })
+                .map_ok(|(key, kta)| {
+                    cache.insert(key, kta);
+                })
+                .try_collect()?;
+        }
+        {
+            let cache = self.cache_read();
+            kta_keys
+                .iter()
+                .map(|key| {
+                    cache
+                        .get(key)
+                        .cloned()
+                        .ok_or(anchor_client::ClientError::AccountNotFound.into())
+                })
+                .try_collect()
+        }
+    }
+}

--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -5,6 +5,7 @@ pub mod dc;
 pub mod entity_key;
 pub mod hotspot;
 pub mod keypair;
+pub mod kta;
 pub mod onboarding;
 pub mod priority_fee;
 pub mod programs;
@@ -37,5 +38,5 @@ where
 }
 
 pub fn init(settings: &settings::Settings) -> result::Result<()> {
-    asset::account_cache::init(settings)
+    kta::init(settings)
 }

--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -35,3 +35,7 @@ where
 {
     value == &T::ZERO
 }
+
+pub fn init(settings: &settings::Settings) -> result::Result<()> {
+    asset::account_cache::init(settings)
+}

--- a/helium-lib/src/programs.rs
+++ b/helium-lib/src/programs.rs
@@ -3,9 +3,6 @@ use crate::keypair::{pubkey, Pubkey};
 pub const TOKEN_METADATA_PROGRAM_ID: Pubkey =
     pubkey!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
 
-pub const MPL_BUBBLEGUM_PROGRAM_ID: Pubkey =
-    pubkey!("BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY");
-
 pub const SPL_ACCOUNT_COMPRESSION_PROGRAM_ID: Pubkey =
     pubkey!("cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK");
 

--- a/helium-lib/src/result.rs
+++ b/helium-lib/src/result.rs
@@ -38,6 +38,12 @@ pub enum Error {
     Encode(#[from] EncodeError),
 }
 
+impl Error {
+    pub fn account_not_found() -> Self {
+        anchor_client::ClientError::AccountNotFound.into()
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum EncodeError {
     #[error("proto: {0}")]

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -84,7 +84,7 @@ where
 
     let client = settings.mk_anchor_client(keypair.clone())?;
     let program = client.program(lazy_distributor::id())?;
-    let asset_account = asset::account_for_entity_key(&client, &entity_key).await?;
+    let asset_account = asset::account_for_entity_key(&entity_key).await?;
     let ld_account = lazy_distributor(settings, subdao).await?;
 
     let mut ixs: Vec<Instruction> = rewards
@@ -233,7 +233,7 @@ pub async fn pending(
             let entity_key =
                 entity_key::from_string(entity_key_string.clone(), entity_key_encoding)?;
             let client = settings.mk_anchor_client(Keypair::void())?;
-            let asset_account = asset::account_for_entity_key(&client, &entity_key).await?;
+            let asset_account = asset::account_for_entity_key(&entity_key).await?;
             recipient::for_asset_account(&client, subdao, &asset_account)
                 .and_then(|maybe_recipient| async move {
                     maybe_recipient
@@ -358,7 +358,7 @@ pub mod recipient {
     {
         let client = settings.mk_anchor_client(keypair.clone())?;
         let program = client.program(lazy_distributor::id())?;
-        let asset_account = asset::account_for_entity_key(&client, entity_key).await?;
+        let asset_account = asset::account_for_entity_key(entity_key).await?;
         let (asset, asset_proof) = asset::get_with_proof(settings, &asset_account).await?;
 
         let _args = lazy_distributor::InitializeCompressionRecipientArgsV0 {

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -3,6 +3,7 @@ use crate::{
     dao::SubDao,
     entity_key::{self, AsEntityKey, KeySerialization},
     keypair::{GetPubkey, Keypair, Pubkey},
+    kta,
     programs::SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
     result::{DecodeError, Error, Result},
     settings::Settings,
@@ -84,7 +85,7 @@ where
 
     let client = settings.mk_anchor_client(keypair.clone())?;
     let program = client.program(lazy_distributor::id())?;
-    let asset_account = asset::account_for_entity_key(&entity_key).await?;
+    let kta = kta::for_entity_key(&entity_key).await?;
     let ld_account = lazy_distributor(settings, subdao).await?;
 
     let mut ixs: Vec<Instruction> = rewards
@@ -97,7 +98,7 @@ where
             let accounts = lazy_distributor::accounts::SetCurrentRewardsV0 {
                 lazy_distributor: subdao.lazy_distributor(),
                 payer: program.payer(),
-                recipient: subdao.asset_key_to_receipient_key(&asset_account.asset),
+                recipient: subdao.receipient_key_from_kta(&kta),
                 oracle: oracle_reward.oracle,
                 system_program: solana_sdk::system_program::id(),
             };
@@ -113,7 +114,7 @@ where
         .flatten()
         .collect();
 
-    let (asset, asset_proof) = asset::get_with_proof(settings, &asset_account).await?;
+    let (asset, asset_proof) = asset::for_kta_with_proof(settings, &kta).await?;
 
     let _args = lazy_distributor::DistributeCompressionRewardsArgsV0 {
         data_hash: asset.compression.data_hash,
@@ -134,7 +135,7 @@ where
                 circuit_breaker_program: circuit_breaker::id(),
                 owner: asset.ownership.owner,
                 circuit_breaker: lazy_distributor_circuit_breaker(&ld_account),
-                recipient: subdao.asset_key_to_receipient_key(&asset_account.asset),
+                recipient: subdao.receipient_key_from_kta(&kta),
                 destination_account: subdao
                     .token()
                     .associated_token_adress(&asset.ownership.owner),
@@ -233,8 +234,8 @@ pub async fn pending(
             let entity_key =
                 entity_key::from_string(entity_key_string.clone(), entity_key_encoding)?;
             let client = settings.mk_anchor_client(Keypair::void())?;
-            let asset_account = asset::account_for_entity_key(&entity_key).await?;
-            recipient::for_asset_account(&client, subdao, &asset_account)
+            let kta = kta::for_entity_key(&entity_key).await?;
+            recipient::for_kta(&client, subdao, &kta)
                 .and_then(|maybe_recipient| async move {
                     maybe_recipient
                         .ok_or_else(|| anchor_client::ClientError::AccountNotFound.into())
@@ -330,13 +331,13 @@ async fn bulk_from_oracle(
 pub mod recipient {
     use super::*;
 
-    pub async fn for_asset_account<C: Clone + Deref<Target = impl Signer>>(
+    pub async fn for_kta<C: Clone + Deref<Target = impl Signer>>(
         client: &anchor_client::Client<C>,
         subdao: &SubDao,
-        asset_account: &helium_entity_manager::KeyToAssetV0,
+        kta: &helium_entity_manager::KeyToAssetV0,
     ) -> Result<Option<lazy_distributor::RecipientV0>> {
         let program = client.program(lazy_distributor::id())?;
-        let recipient_key = subdao.asset_key_to_receipient_key(&asset_account.asset);
+        let recipient_key = subdao.receipient_key_from_kta(kta);
         match program
             .account::<lazy_distributor::RecipientV0>(recipient_key)
             .await
@@ -358,8 +359,8 @@ pub mod recipient {
     {
         let client = settings.mk_anchor_client(keypair.clone())?;
         let program = client.program(lazy_distributor::id())?;
-        let asset_account = asset::account_for_entity_key(entity_key).await?;
-        let (asset, asset_proof) = asset::get_with_proof(settings, &asset_account).await?;
+        let kta = kta::for_entity_key(entity_key).await?;
+        let (asset, asset_proof) = asset::for_kta_with_proof(settings, &kta).await?;
 
         let _args = lazy_distributor::InitializeCompressionRecipientArgsV0 {
             data_hash: asset.compression.data_hash,
@@ -371,7 +372,7 @@ pub mod recipient {
         let accounts = lazy_distributor::accounts::InitializeCompressionRecipientV0 {
             payer: program.payer(),
             lazy_distributor: subdao.lazy_distributor(),
-            recipient: subdao.asset_key_to_receipient_key(&asset.id),
+            recipient: subdao.receipient_key_from_kta(&kta),
             merkle_tree: asset.compression.tree,
             owner: asset.ownership.owner,
             delegate: asset.ownership.owner,

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -237,8 +237,7 @@ pub async fn pending(
             let kta = kta::for_entity_key(&entity_key).await?;
             recipient::for_kta(&client, subdao, &kta)
                 .and_then(|maybe_recipient| async move {
-                    maybe_recipient
-                        .ok_or_else(|| anchor_client::ClientError::AccountNotFound.into())
+                    maybe_recipient.ok_or_else(Error::account_not_found)
                 })
                 .map_ok(|recipient| {
                     for_entity_key(&bulk_rewards, entity_key_string).map(|mut oracle_reward| {

--- a/helium-wallet/src/cmd/router/balance.rs
+++ b/helium-wallet/src/cmd/router/balance.rs
@@ -14,7 +14,7 @@ impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let settings = opts.try_into()?;
         let delegated_dc_key = self.subdao.delegated_dc_key(&self.router_key);
-        let escrow_key = self.subdao.escrow_account_key(&delegated_dc_key);
+        let escrow_key = self.subdao.escrow_key(&delegated_dc_key);
         let balance = token::balance_for_address(&settings, &escrow_key)
             .await?
             .map(|balance| balance.amount);

--- a/helium-wallet/src/main.rs
+++ b/helium-wallet/src/main.rs
@@ -44,6 +44,7 @@ async fn main() -> Result {
 }
 
 async fn run(cli: Cli) -> Result {
+    helium_lib::init(&cli.opts.clone().try_into()?)?;
     match cli.cmd {
         Cmd::Info(cmd) => cmd.run(cli.opts).await,
         Cmd::Balance(cmd) => cmd.run(cli.opts).await,


### PR DESCRIPTION
Asset convertion to a Hotspot was relying on a metadata field that may take over 24 hours to get populated, and is only to be used for non critical purposes.

This PR introduces a KeyToAsset cache that is used to cache asset accounts based on the asset key. The cache is then used for Asset->Hotspot conversion to get the entity key (back)

Fixes #366 

Both bugs reported in #366 are fixed by this PR. It fixes metadata issues and update transaction construction