### PR TITLE
Ignore failed update transactions

### DIFF
--- a/helium-lib/src/hotspot.rs
+++ b/helium-lib/src/hotspot.rs
@@ -256,6 +256,12 @@ pub mod info {
         fn from_transaction(
             txn: EncodedConfirmedTransactionWithStatusMeta,
         ) -> Result<Option<Self>, DecodeError> {
+            // don't handle failed transactions
+            if let Some(meta) = txn.transaction.meta {
+                if meta.err.is_some() {
+                    return Ok(None);
+                }
+            }
             let EncodedTransaction::Json(ui_txn) = txn.transaction.transaction else {
                 return Err(DecodeError::other("not a json encoded transaction"));
             };


### PR DESCRIPTION
The hotspots::updates call should look for finalized _and_ successful transactions.