### PR TITLE
add name field as optional to asset metadata response

### DIFF
--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -266,6 +266,7 @@ pub struct AssetContent {
 pub struct AssetMetadata {
     #[serde(default)]
     pub attributes: Vec<AssetMetadataAttribute>,
+    pub name: Option<String>,
     pub symbol: String,
 }
 

--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -266,7 +266,7 @@ pub struct AssetContent {
 pub struct AssetMetadata {
     #[serde(default)]
     pub attributes: Vec<AssetMetadataAttribute>,
-    pub name: Option<String>,
+    pub name: String,
     pub symbol: String,
 }
 

--- a/helium-wallet/src/wallet.rs
+++ b/helium-wallet/src/wallet.rs
@@ -482,7 +482,7 @@ mod tests {
     fn sharded_from_builder() {
         let path = Path::new(".test-sharded.key");
         // Delete Any existing test wallet in case prev error
-        let _ = clean_up_shards(&path, 3);
+        clean_up_shards(path, 3);
 
         let password = String::from("password");
         let shard_config = ShardConfig {
@@ -496,7 +496,7 @@ mod tests {
 
         let wallet = Wallet::builder()
             .password(&password)
-            .output(&path)
+            .output(path)
             .seed_phrase(Some(seed_words.clone()))
             .shard(Some(shard_config))
             .create()
@@ -508,7 +508,7 @@ mod tests {
         assert_eq!(from_keypair, to_keypair);
 
         // clean up
-        let _ = clean_up_shards(&path, 3);
+        clean_up_shards(path, 3);
     }
 
     fn clean_up_shards(path: &Path, shards: u8) {


### PR DESCRIPTION
This seems like it should _reliably_ be possible to set as a `String` instead of `Option<String>` when fetching the asset from the chain, as the value is reliably being set to the angry purple tiger name in the case of iot and mobile hotspots and to the "Carrier Name <Leaf Id>" in the case of subscribers, but setting as an option here to guard against relying too heavily on metadata content/structure