### PR TITLE
add asset grouping to getAsset response struct

### DIFF
--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -147,6 +147,7 @@ pub struct Asset {
     pub creators: Vec<AssetCreator>,
     pub ownership: AssetOwnership,
     pub content: AssetContent,
+    pub grouping: Vec<AssetGroup>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -174,6 +175,13 @@ impl AssetCompression {
     pub fn leaf_id(&self) -> StdResult<u32, DecodeError> {
         self.leaf_id.try_into().map_err(DecodeError::from)
     }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct AssetGroup {
+    pub group_key: String,
+    #[serde(with = "serde_pubkey")]
+    pub group_value: Pubkey,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
This is another standard field component of the `getAsset` DAS read api that is used in hash generation for validating the NFT as input to further programs that link that NFT.

See the documentation and an example here:
https://www.quicknode.com/docs/solana/getAsset
```
curl --request POST --url "https://api.mainnet-beta.solana.com" --header 'Content-Type: application/json' --data '{
    "jsonrpc": "2.0",
    "method": "getAsset",
    "params": [
      "646k4uaZqBZrKHAhpwyjSfRgsEzHesLvNRGiuPLvMhE7"
    ],
    "id": 0
}'
```