### PR TITLE
make asset creator fields public like asset fields

### DIFF
--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -153,9 +153,9 @@ pub struct Asset {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AssetCreator {
     #[serde(with = "serde_pubkey")]
-    address: Pubkey,
-    share: u8,
-    verified: bool,
+    pub address: Pubkey,
+    pub share: u8,
+    pub verified: bool,
 }
 
 pub type Hash = [u8; 32];


### PR DESCRIPTION
The `AssetCreator` fields are the only struct fields in the `asset` module that are not currently public; setting them to public to allow converting _into_ and from an `AssetCreator` since many anchor-gen derived interfaces to anchor contracts re-wrap native structs for ease of use, making it difficult to develop custom trait impls from them and requiring direct access to the fields