### PR TITLE
upgrade helium-anchor-gen without upgrading other deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "circuit-breaker"
 version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -1927,8 +1927,8 @@ dependencies = [
 
 [[package]]
 name = "data-credits"
-version = "0.2.1"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+version = "0.2.2"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -2238,7 +2238,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "fanout"
 version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -2598,7 +2598,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helium-anchor-gen"
 version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -2644,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "helium-entity-manager"
 version = "0.3.1"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -2718,8 +2718,8 @@ dependencies = [
 
 [[package]]
 name = "helium-sub-daos"
-version = "0.1.5"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+version = "0.1.8"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -2782,8 +2782,8 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hexboosting"
-version = "0.0.5"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+version = "0.1.0"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -3163,8 +3163,8 @@ dependencies = [
 
 [[package]]
 name = "lazy-distributor"
-version = "0.1.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+version = "0.2.0"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -3173,7 +3173,7 @@ dependencies = [
 [[package]]
 name = "lazy-transactions"
 version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -3386,8 +3386,8 @@ dependencies = [
 
 [[package]]
 name = "mobile-entity-manager"
-version = "0.1.2"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+version = "0.1.3"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -3933,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "price-oracle"
 version = "0.2.1"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -4427,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "rewards-oracle"
 version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -6702,7 +6702,7 @@ dependencies = [
 [[package]]
 name = "treasury-management"
 version = "0.2.0"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",
@@ -6887,8 +6887,8 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "voter-stake-registry"
-version = "0.3.1"
-source = "git+https://github.com/helium/helium-anchor-gen.git#fe60ed1d49e9255bd779a99bdd7928f278c07256"
+version = "0.3.3"
+source = "git+https://github.com/helium/helium-anchor-gen.git#54392f522436bc8a8c8b8c0a0b4ec407a28f66ed"
 dependencies = [
  "anchor-gen",
  "anchor-lang 0.30.1",


### PR DESCRIPTION
Updating `helium-achnor-gen` without updating underlying deps. 

The original splitting out of deps happened https://github.com/helium/helium-wallet-rs/pull/321/files and `anchor-gen@0.30.1` was used.

