### PR TITLE
remove repeated transaction creation into a common function

### DIFF
--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -6,7 +6,7 @@ use crate::{
     error::{DecodeError, Error},
     helium_entity_manager,
     keypair::{serde_opt_pubkey, serde_pubkey, Keypair, Pubkey},
-    kta,
+    kta, mk_transaction_with_blockhash,
     priority_fee::{compute_budget_instruction, compute_price_instruction_for_accounts},
     programs::{SPL_ACCOUNT_COMPRESSION_PROGRAM_ID, SPL_NOOP_PROGRAM_ID},
     solana_sdk::{instruction::AccountMeta, transaction::Transaction},
@@ -193,13 +193,7 @@ pub async fn transfer_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
         transfer_ix,
     ];
 
-    let mut tx = Transaction::new_with_payer(ixs, Some(&asset.ownership.owner));
-    let solana_client = AsRef::<SolanaRpcClient>::as_ref(client);
-    let (latest_blockhash, latest_block_height) = solana_client
-        .get_latest_blockhash_with_commitment(solana_client.commitment())
-        .await?;
-    tx.message.recent_blockhash = latest_blockhash;
-    Ok((tx, latest_block_height))
+    mk_transaction_with_blockhash(client, ixs, &asset.ownership.owner).await
 }
 
 pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
@@ -260,13 +254,7 @@ pub async fn burn_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
         ix,
     ];
 
-    let mut tx = Transaction::new_with_payer(ixs, Some(&asset.ownership.owner));
-    let solana_client = AsRef::<SolanaRpcClient>::as_ref(client);
-    let (latest_blockhash, latest_block_height) = solana_client
-        .get_latest_blockhash_with_commitment(solana_client.commitment())
-        .await?;
-    tx.message.recent_blockhash = latest_blockhash;
-    Ok((tx, latest_block_height))
+    mk_transaction_with_blockhash(client, ixs, &asset.ownership.owner).await
 }
 
 pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(

--- a/helium-lib/src/hotspot/dataonly.rs
+++ b/helium-lib/src/hotspot/dataonly.rs
@@ -9,7 +9,7 @@ use crate::{
     helium_entity_manager, helium_sub_daos, hotspot,
     hotspot::{HotspotInfoUpdate, ECC_VERIFIER},
     keypair::{Keypair, Pubkey},
-    kta, priority_fee,
+    kta, mk_transaction_with_blockhash, priority_fee,
     programs::{
         SPL_ACCOUNT_COMPRESSION_PROGRAM_ID, SPL_NOOP_PROGRAM_ID, TOKEN_METADATA_PROGRAM_ID,
     },
@@ -33,7 +33,7 @@ mod iot {
         assertion: HotspotInfoUpdate,
         owner: &Pubkey,
         opts: &TransactionOpts,
-    ) -> Result<Transaction, Error> {
+    ) -> Result<(Transaction, u64), Error> {
         fn mk_accounts(
             config_account: helium_entity_manager::DataOnlyConfigV0,
             owner: Pubkey,
@@ -105,8 +105,7 @@ mod iot {
             onboard_ix,
         ];
 
-        let tx = Transaction::new_with_payer(ixs, Some(owner));
-        Ok(tx)
+        mk_transaction_with_blockhash(client, ixs, owner).await
     }
 }
 
@@ -121,7 +120,7 @@ mod mobile {
         assertion: HotspotInfoUpdate,
         owner: &Pubkey,
         opts: &TransactionOpts,
-    ) -> Result<Transaction, Error> {
+    ) -> Result<(Transaction, u64), Error> {
         fn mk_accounts(
             config_account: helium_entity_manager::DataOnlyConfigV0,
             owner: Pubkey,
@@ -194,8 +193,7 @@ mod mobile {
             onboard_ix,
         ];
 
-        let tx = Transaction::new_with_payer(ixs, Some(owner));
-        Ok(tx)
+        mk_transaction_with_blockhash(client, ixs, owner).await
     }
 }
 
@@ -209,18 +207,12 @@ pub async fn onboard_transaction<
     owner: &Pubkey,
     opts: &TransactionOpts,
 ) -> Result<(Transaction, u64), Error> {
-    let mut tx = match subdao {
+    match subdao {
         SubDao::Iot => iot::onboard_transaction(client, hotspot_key, assertion, owner, opts).await,
         SubDao::Mobile => {
             mobile::onboard_transaction(client, hotspot_key, assertion, owner, opts).await
         }
-    }?;
-    let solana_client = AsRef::<SolanaRpcClient>::as_ref(client);
-    let (latest_blockhash, latest_block_height) = solana_client
-        .get_latest_blockhash_with_commitment(solana_client.commitment())
-        .await?;
-    tx.message.recent_blockhash = latest_blockhash;
-    Ok((tx, latest_block_height))
+    }
 }
 
 pub async fn onboard<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
@@ -309,12 +301,8 @@ pub async fn issue_transaction<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
         .await?,
         issue_ix,
     ];
-    let mut txn = Transaction::new_with_payer(ixs, Some(&owner));
-    let solana_client = AsRef::<SolanaRpcClient>::as_ref(client);
-    let (latest_blockhash, latest_block_height) = solana_client
-        .get_latest_blockhash_with_commitment(solana_client.commitment())
-        .await?;
-    txn.message.recent_blockhash = latest_blockhash;
+
+    let (txn, latest_block_height) = mk_transaction_with_blockhash(client, ixs, &owner).await?;
 
     let sig = add_tx.gateway_signature.clone();
     add_tx.gateway_signature = vec![];

--- a/helium-lib/src/hotspot/mod.rs
+++ b/helium-lib/src/hotspot/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{DecodeError, EncodeError, Error},
     helium_entity_manager, is_zero,
     keypair::{pubkey, serde_pubkey, Keypair, Pubkey},
-    kta, onboarding, priority_fee,
+    kta, mk_transaction_with_blockhash, onboarding, priority_fee,
     programs::SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
     solana_client::rpc_client::SerializableTransaction,
     solana_sdk::{
@@ -212,13 +212,7 @@ pub async fn direct_update_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClie
         ix,
     ];
 
-    let mut txn = Transaction::new_with_payer(ixs, Some(owner));
-    let solana_client = AsRef::<SolanaRpcClient>::as_ref(client);
-    let (latest_blockhash, latest_block_height) = solana_client
-        .get_latest_blockhash_with_commitment(solana_client.commitment())
-        .await?;
-    txn.message.recent_blockhash = latest_blockhash;
-    Ok((txn, latest_block_height))
+    mk_transaction_with_blockhash(client, ixs, owner).await
 }
 
 pub async fn direct_update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(

--- a/helium-lib/src/memo.rs
+++ b/helium-lib/src/memo.rs
@@ -2,7 +2,7 @@ use crate::{
     client::SolanaRpcClient,
     error::Error,
     keypair::{Keypair, Pubkey},
-    priority_fee,
+    mk_transaction_with_blockhash, priority_fee,
     solana_client::rpc_client::SerializableTransaction,
     solana_sdk::{signer::Signer, transaction::Transaction},
     TransactionOpts,
@@ -25,13 +25,8 @@ pub async fn memo_transaction<C: AsRef<SolanaRpcClient>>(
         .await?,
         ix,
     ];
-    let mut txn = Transaction::new_with_payer(ixs, Some(pubkey));
-    let solana_client = AsRef::<SolanaRpcClient>::as_ref(client);
-    let (latest_blockhash, latest_block_height) = solana_client
-        .get_latest_blockhash_with_commitment(solana_client.commitment())
-        .await?;
-    txn.message.recent_blockhash = latest_blockhash;
-    Ok((txn, latest_block_height))
+
+    mk_transaction_with_blockhash(client, ixs, pubkey).await
 }
 
 pub async fn memo<C: AsRef<SolanaRpcClient>>(

--- a/helium-wallet/src/cmd/burn.rs
+++ b/helium-wallet/src/cmd/burn.rs
@@ -20,7 +20,7 @@ impl Cmd {
         let client = opts.client()?;
 
         let token_amount = token::TokenAmount::from_f64(self.subdao.token(), self.amount);
-        let tx = token::burn(&client, &token_amount, &keypair).await?;
+        let (tx, _) = token::burn(&client, &token_amount, &keypair).await?;
         print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/dc/burn.rs
+++ b/helium-wallet/src/cmd/dc/burn.rs
@@ -17,8 +17,9 @@ impl Cmd {
         let password = get_wallet_password(false)?;
         let keypair = opts.load_keypair(password.as_bytes())?;
         let client = opts.client()?;
+        let transaction_opts = self.commit.transaction_opts();
 
-        let tx = dc::burn(&client, self.dc, &keypair).await?;
+        let (tx, _) = dc::burn(&client, self.dc, &keypair, &transaction_opts).await?;
         print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/dc/delegate.rs
+++ b/helium-wallet/src/cmd/dc/delegate.rs
@@ -24,7 +24,16 @@ impl Cmd {
         let keypair = opts.load_keypair(password.as_bytes())?;
 
         let client = opts.client()?;
-        let tx = dc::delegate(&client, self.subdao, &self.payer, self.dc, &keypair).await?;
+        let transaction_opts = self.commit.transaction_opts();
+        let (tx, _) = dc::delegate(
+            &client,
+            self.subdao,
+            &self.payer,
+            self.dc,
+            &keypair,
+            &transaction_opts,
+        )
+        .await?;
         print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/dc/mint.rs
+++ b/helium-wallet/src/cmd/dc/mint.rs
@@ -41,9 +41,10 @@ impl Cmd {
             (None, Some(dc)) => TokenAmount::from_u64(Token::Dc, dc),
             _ => return Err(anyhow!("Must specify either HNT or DC")),
         };
+        let transaction_opts = self.commit.transaction_opts();
 
         let keypair = wallet.decrypt(password.as_bytes())?;
-        let tx = dc::mint(&client, amount, payee, &keypair).await?;
+        let (tx, _) = dc::mint(&client, amount, payee, &keypair, &transaction_opts).await?;
         print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/transfer.rs
+++ b/helium-wallet/src/cmd/transfer.rs
@@ -88,7 +88,7 @@ impl PayCmd {
         let keypair = opts.load_keypair(password.as_bytes())?;
 
         let client = opts.client()?;
-        let tx = token::transfer(&client, &payments, &keypair).await?;
+        let (tx, _) = token::transfer(&client, &payments, &keypair).await?;
 
         print_json(&self.commit().maybe_commit(&tx, &client).await?.to_json())
     }


### PR DESCRIPTION
Introduces mk_transaction_with_blockhash which returns an unsigned transation with the expected (Transaction, height) tuple. This removes all the boiler plate in the *_transaction functions.

Also adjust dc mod to include priority fees for burn, mint, delegate, burn_delegated.