### PR TITLE
Add TransactionWithBlockhash

### DIFF
--- a/helium-lib/Cargo.toml
+++ b/helium-lib/Cargo.toml
@@ -10,25 +10,23 @@ mnemonic = ["helium-mnemonic"]
 
 [dependencies]
 hex = "0.4"
-chrono = {version = "0", features = ["serde"]}
+chrono = { version = "0", features = ["serde"] }
 thiserror = "1"
 async-trait = "0"
-anchor-client = {version = "0.29.0", features = ["async"] }
+anchor-client = { version = "0.29.0", features = ["async"] }
 anchor-spl = { version = "0.29.0", features = ["mint", "token"] }
-url = {version = "2", features = ["serde"]}
-h3o = {version = "0", features = ["serde"]}
-helium-crypto = {workspace = true}
+url = { version = "2", features = ["serde"] }
+h3o = { version = "0", features = ["serde"] }
+helium-crypto = { workspace = true }
 itertools = "0.10"
-jsonrpc_client = {version = "0.7", features = ["reqwest"]}
+jsonrpc_client = { version = "0.7", features = ["reqwest"] }
 futures = "*"
 tracing = "0"
-base64 = {workspace = true}
+base64 = { workspace = true }
 solana-sdk = "1.18"
 bincode = "1.3.3"
-reqwest = { version = "0", default-features = false, features = [
-    "rustls-tls",
-] }
-helium-anchor-gen = {git = "https://github.com/helium/helium-anchor-gen.git" }
+reqwest = { version = "0", default-features = false, features = ["rustls-tls"] }
+helium-anchor-gen = { git = "https://github.com/helium/helium-anchor-gen.git" }
 spl-associated-token-account = { version = "*", features = ["no-entrypoint"] }
 spl-account-compression = { version = "0.3", features = ["no-entrypoint"] }
 spl-memo = "4"
@@ -37,14 +35,14 @@ mpl-bubblegum = "1"
 solana-program = ">=1.18,<2"
 pyth-solana-receiver-sdk = { git = "https://github.com/madninja/pyth-crosschain.git", branch = "madninja/cap_solana_dep" }
 solana-transaction-status = "*"
-serde = {workspace = true}
-serde_json = {workspace = true}
+serde = { workspace = true }
+serde_json = { workspace = true }
 lazy_static = "1"
-rust_decimal = {workspace = true}
-helium-proto = {workspace= true}
+rust_decimal = { workspace = true }
+helium-proto = { workspace = true }
 angry-purple-tiger = "0"
-sha2 = {workspace = true}
-clap = {workspace = true, optional = true}
+sha2 = { workspace = true }
+clap = { workspace = true, optional = true }
 helium-mnemonic = { path = "../helium-mnemonic", optional = true }
 
 [dev-dependencies]

--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -10,7 +10,7 @@ use crate::{
     priority_fee::{compute_budget_instruction, compute_price_instruction_for_accounts},
     programs::{SPL_ACCOUNT_COMPRESSION_PROGRAM_ID, SPL_NOOP_PROGRAM_ID},
     solana_sdk::instruction::AccountMeta,
-    Transaction, TransactionOpts,
+    TransactionOpts, TransactionWithBlockhash,
 };
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -153,7 +153,7 @@ pub async fn transfer_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     pubkey: &Pubkey,
     recipient: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let (asset, asset_proof) = get_with_proof(client, pubkey).await?;
 
     let leaf_delegate = asset.ownership.delegate.unwrap_or(asset.ownership.owner);
@@ -202,7 +202,7 @@ pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     recipient: &Pubkey,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let mut tx = transfer_transaction(client, pubkey, recipient, opts).await?;
     tx.try_sign(&[keypair])?;
     Ok(tx)
@@ -213,7 +213,7 @@ pub async fn burn_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     pubkey: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let (asset, asset_proof) = get_with_proof(client, pubkey).await?;
 
     let leaf_delegate = asset.ownership.delegate.unwrap_or(asset.ownership.owner);
@@ -261,7 +261,7 @@ pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     pubkey: &Pubkey,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let mut tx = burn_transaction(client, pubkey, opts).await?;
     tx.try_sign(&[keypair])?;
     Ok(tx)

--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -9,8 +9,8 @@ use crate::{
     kta, mk_transaction_with_blockhash,
     priority_fee::{compute_budget_instruction, compute_price_instruction_for_accounts},
     programs::{SPL_ACCOUNT_COMPRESSION_PROGRAM_ID, SPL_NOOP_PROGRAM_ID},
-    solana_sdk::{instruction::AccountMeta, transaction::Transaction},
-    TransactionOpts,
+    solana_sdk::instruction::AccountMeta,
+    Transaction, TransactionOpts,
 };
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -153,7 +153,7 @@ pub async fn transfer_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     pubkey: &Pubkey,
     recipient: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     let (asset, asset_proof) = get_with_proof(client, pubkey).await?;
 
     let leaf_delegate = asset.ownership.delegate.unwrap_or(asset.ownership.owner);
@@ -202,11 +202,10 @@ pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     recipient: &Pubkey,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
-    let (mut tx, latest_block_height) =
-        transfer_transaction(client, pubkey, recipient, opts).await?;
-    tx.try_sign(&[keypair], tx.message.recent_blockhash)?;
-    Ok((tx, latest_block_height))
+) -> Result<Transaction, Error> {
+    let mut tx = transfer_transaction(client, pubkey, recipient, opts).await?;
+    tx.try_sign(&[keypair])?;
+    Ok(tx)
 }
 
 /// Get an unsigned burn transaction for an asset
@@ -214,7 +213,7 @@ pub async fn burn_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     pubkey: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     let (asset, asset_proof) = get_with_proof(client, pubkey).await?;
 
     let leaf_delegate = asset.ownership.delegate.unwrap_or(asset.ownership.owner);
@@ -262,10 +261,10 @@ pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     pubkey: &Pubkey,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
-    let (mut tx, latest_block_height) = burn_transaction(client, pubkey, opts).await?;
-    tx.try_sign(&[keypair], tx.message.recent_blockhash)?;
-    Ok((tx, latest_block_height))
+) -> Result<Transaction, Error> {
+    let mut tx = burn_transaction(client, pubkey, opts).await?;
+    tx.try_sign(&[keypair])?;
+    Ok(tx)
 }
 
 #[derive(Deserialize, Serialize, Clone)]

--- a/helium-lib/src/boosting.rs
+++ b/helium-lib/src/boosting.rs
@@ -2,13 +2,11 @@ use crate::{
     anchor_lang::{InstructionData, ToAccountMetas},
     client::SolanaRpcClient,
     error::Error,
-    hexboosting,
-    hexboosting::accounts::StartBoostV0,
+    hexboosting::{self, accounts::StartBoostV0},
     keypair::{Keypair, Pubkey},
     mk_transaction_with_blockhash, priority_fee,
-    solana_client::rpc_client::SerializableTransaction,
-    solana_sdk::{instruction::Instruction, signer::Signer, transaction::Transaction},
-    TransactionOpts,
+    solana_sdk::{instruction::Instruction, signer::Signer},
+    Transaction, TransactionOpts,
 };
 use chrono::{DateTime, Utc};
 
@@ -24,7 +22,7 @@ pub async fn start_boost_transaction<C: AsRef<SolanaRpcClient>>(
     keypair: &Keypair,
     updates: impl IntoIterator<Item = impl StartBoostingHex>,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     fn mk_accounts(
         start_authority: Pubkey,
         boost_config: Pubkey,
@@ -79,9 +77,8 @@ pub async fn start_boost<C: AsRef<SolanaRpcClient>>(
     updates: impl IntoIterator<Item = impl StartBoostingHex>,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
-    let (mut txn, latest_block_height) =
-        start_boost_transaction(client, keypair, updates, opts).await?;
-    txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
-    Ok((txn, latest_block_height))
+) -> Result<Transaction, Error> {
+    let mut txn = start_boost_transaction(client, keypair, updates, opts).await?;
+    txn.try_sign(&[keypair])?;
+    Ok(txn)
 }

--- a/helium-lib/src/boosting.rs
+++ b/helium-lib/src/boosting.rs
@@ -6,7 +6,7 @@ use crate::{
     keypair::{Keypair, Pubkey},
     mk_transaction_with_blockhash, priority_fee,
     solana_sdk::{instruction::Instruction, signer::Signer},
-    Transaction, TransactionOpts,
+    TransactionOpts, TransactionWithBlockhash,
 };
 use chrono::{DateTime, Utc};
 
@@ -22,7 +22,7 @@ pub async fn start_boost_transaction<C: AsRef<SolanaRpcClient>>(
     keypair: &Keypair,
     updates: impl IntoIterator<Item = impl StartBoostingHex>,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     fn mk_accounts(
         start_authority: Pubkey,
         boost_config: Pubkey,
@@ -77,7 +77,7 @@ pub async fn start_boost<C: AsRef<SolanaRpcClient>>(
     updates: impl IntoIterator<Item = impl StartBoostingHex>,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let mut txn = start_boost_transaction(client, keypair, updates, opts).await?;
     txn.try_sign(&[keypair])?;
     Ok(txn)

--- a/helium-lib/src/dc.rs
+++ b/helium-lib/src/dc.rs
@@ -9,7 +9,7 @@ use crate::{
     mk_transaction_with_blockhash, priority_fee,
     solana_sdk::{instruction::Instruction, signer::Signer},
     token::{Token, TokenAmount},
-    Transaction, TransactionOpts,
+    TransactionOpts, TransactionWithBlockhash,
 };
 use helium_anchor_gen::{
     data_credits::accounts::BurnDelegatedDataCreditsV0,
@@ -22,7 +22,7 @@ pub async fn mint_transaction<C: AsRef<SolanaRpcClient>>(
     payee: &Pubkey,
     payer: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     fn token_amount_to_mint_args(
         amount: TokenAmount,
     ) -> Result<data_credits::MintDataCreditsArgsV0, DecodeError> {
@@ -95,7 +95,7 @@ pub async fn mint<C: AsRef<SolanaRpcClient>>(
     payee: &Pubkey,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let mut txn = mint_transaction(client, amount, payee, &keypair.pubkey(), opts).await?;
     txn.try_sign(&[keypair])?;
     Ok(txn)
@@ -108,7 +108,7 @@ pub async fn delegate_transaction<C: AsRef<SolanaRpcClient>>(
     amount: u64,
     owner: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     fn mk_accounts(delegated_dc_key: Pubkey, subdao: SubDao, owner: Pubkey) -> impl ToAccountMetas {
         data_credits::accounts::DelegateDataCreditsV0 {
             delegated_data_credits: delegated_dc_key,
@@ -159,7 +159,7 @@ pub async fn delegate<C: AsRef<SolanaRpcClient>>(
     amount: u64,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let mut txn =
         delegate_transaction(client, subdao, payer_key, amount, &keypair.pubkey(), opts).await?;
     txn.try_sign(&[keypair])?;
@@ -171,7 +171,7 @@ pub async fn burn_transaction<C: AsRef<SolanaRpcClient>>(
     amount: u64,
     owner: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     fn mk_accounts(owner: Pubkey) -> impl ToAccountMetas {
         data_credits::accounts::BurnWithoutTrackingV0 {
             BurnWithoutTrackingV0burn_accounts:
@@ -214,7 +214,7 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
     amount: u64,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let mut txn = burn_transaction(client, amount, &keypair.pubkey(), opts).await?;
     txn.try_sign(&[keypair])?;
     Ok(txn)
@@ -227,7 +227,7 @@ pub async fn burn_delegated_transaction<C: AsRef<SolanaRpcClient>>(
     router_key: Pubkey,
     payer: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     fn mk_accounts(
         sub_dao: SubDao,
         router_key: Pubkey,
@@ -297,7 +297,7 @@ pub async fn burn_delegated<C: AsRef<SolanaRpcClient>>(
     amount: u64,
     router_key: Pubkey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let mut txn =
         burn_delegated_transaction(client, sub_dao, amount, router_key, &keypair.pubkey(), opts)
             .await?;

--- a/helium-lib/src/dc.rs
+++ b/helium-lib/src/dc.rs
@@ -1,6 +1,5 @@
 use crate::{
-    anchor_lang::AccountDeserialize,
-    anchor_lang::{InstructionData, ToAccountMetas},
+    anchor_lang::{AccountDeserialize, InstructionData, ToAccountMetas},
     anchor_spl, circuit_breaker,
     client::{GetAnchorAccount, SolanaRpcClient},
     dao::{Dao, SubDao},
@@ -8,10 +7,9 @@ use crate::{
     error::{DecodeError, Error},
     keypair::{Keypair, Pubkey},
     mk_transaction_with_blockhash, priority_fee,
-    solana_client::rpc_client::SerializableTransaction,
-    solana_sdk::{instruction::Instruction, signer::Signer, transaction::Transaction},
+    solana_sdk::{instruction::Instruction, signer::Signer},
     token::{Token, TokenAmount},
-    TransactionOpts,
+    Transaction, TransactionOpts,
 };
 use helium_anchor_gen::{
     data_credits::accounts::BurnDelegatedDataCreditsV0,
@@ -24,7 +22,7 @@ pub async fn mint_transaction<C: AsRef<SolanaRpcClient>>(
     payee: &Pubkey,
     payer: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     fn token_amount_to_mint_args(
         amount: TokenAmount,
     ) -> Result<data_credits::MintDataCreditsArgsV0, DecodeError> {
@@ -97,11 +95,10 @@ pub async fn mint<C: AsRef<SolanaRpcClient>>(
     payee: &Pubkey,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
-    let (mut txn, latest_block_height) =
-        mint_transaction(client, amount, payee, &keypair.pubkey(), opts).await?;
-    txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
-    Ok((txn, latest_block_height))
+) -> Result<Transaction, Error> {
+    let mut txn = mint_transaction(client, amount, payee, &keypair.pubkey(), opts).await?;
+    txn.try_sign(&[keypair])?;
+    Ok(txn)
 }
 
 pub async fn delegate_transaction<C: AsRef<SolanaRpcClient>>(
@@ -111,7 +108,7 @@ pub async fn delegate_transaction<C: AsRef<SolanaRpcClient>>(
     amount: u64,
     owner: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     fn mk_accounts(delegated_dc_key: Pubkey, subdao: SubDao, owner: Pubkey) -> impl ToAccountMetas {
         data_credits::accounts::DelegateDataCreditsV0 {
             delegated_data_credits: delegated_dc_key,
@@ -162,11 +159,11 @@ pub async fn delegate<C: AsRef<SolanaRpcClient>>(
     amount: u64,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
-    let (mut txn, latest_block_height) =
+) -> Result<Transaction, Error> {
+    let mut txn =
         delegate_transaction(client, subdao, payer_key, amount, &keypair.pubkey(), opts).await?;
-    txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
-    Ok((txn, latest_block_height))
+    txn.try_sign(&[keypair])?;
+    Ok(txn)
 }
 
 pub async fn burn_transaction<C: AsRef<SolanaRpcClient>>(
@@ -174,7 +171,7 @@ pub async fn burn_transaction<C: AsRef<SolanaRpcClient>>(
     amount: u64,
     owner: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     fn mk_accounts(owner: Pubkey) -> impl ToAccountMetas {
         data_credits::accounts::BurnWithoutTrackingV0 {
             BurnWithoutTrackingV0burn_accounts:
@@ -217,11 +214,10 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
     amount: u64,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
-    let (mut txn, latest_block_height) =
-        burn_transaction(client, amount, &keypair.pubkey(), opts).await?;
-    txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
-    Ok((txn, latest_block_height))
+) -> Result<Transaction, Error> {
+    let mut txn = burn_transaction(client, amount, &keypair.pubkey(), opts).await?;
+    txn.try_sign(&[keypair])?;
+    Ok(txn)
 }
 
 pub async fn burn_delegated_transaction<C: AsRef<SolanaRpcClient>>(
@@ -231,7 +227,7 @@ pub async fn burn_delegated_transaction<C: AsRef<SolanaRpcClient>>(
     router_key: Pubkey,
     payer: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     fn mk_accounts(
         sub_dao: SubDao,
         router_key: Pubkey,
@@ -301,10 +297,10 @@ pub async fn burn_delegated<C: AsRef<SolanaRpcClient>>(
     amount: u64,
     router_key: Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
-    let (mut txn, latest_block_height) =
+) -> Result<Transaction, Error> {
+    let mut txn =
         burn_delegated_transaction(client, sub_dao, amount, router_key, &keypair.pubkey(), opts)
             .await?;
-    txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
-    Ok((txn, latest_block_height))
+    txn.try_sign(&[keypair])?;
+    Ok(txn)
 }

--- a/helium-lib/src/hotspot/dataonly.rs
+++ b/helium-lib/src/hotspot/dataonly.rs
@@ -15,14 +15,13 @@ use crate::{
     },
     solana_sdk::{instruction::Instruction, signature::Signer},
     token::Token,
-    Transaction, TransactionOpts,
+    TransactionOpts, TransactionWithBlockhash,
 };
 use helium_crypto::{PublicKey, Sign};
 use helium_proto::{BlockchainTxn, BlockchainTxnAddGatewayV1, Message, Txn};
 use serde::{Deserialize, Serialize};
 
 mod iot {
-    use crate::Transaction;
 
     use super::*;
 
@@ -34,7 +33,7 @@ mod iot {
         assertion: HotspotInfoUpdate,
         owner: &Pubkey,
         opts: &TransactionOpts,
-    ) -> Result<Transaction, Error> {
+    ) -> Result<TransactionWithBlockhash, Error> {
         fn mk_accounts(
             config_account: helium_entity_manager::DataOnlyConfigV0,
             owner: Pubkey,
@@ -111,7 +110,6 @@ mod iot {
 }
 
 mod mobile {
-    use crate::Transaction;
 
     use super::*;
 
@@ -123,7 +121,7 @@ mod mobile {
         assertion: HotspotInfoUpdate,
         owner: &Pubkey,
         opts: &TransactionOpts,
-    ) -> Result<Transaction, Error> {
+    ) -> Result<TransactionWithBlockhash, Error> {
         fn mk_accounts(
             config_account: helium_entity_manager::DataOnlyConfigV0,
             owner: Pubkey,
@@ -209,7 +207,7 @@ pub async fn onboard_transaction<
     assertion: HotspotInfoUpdate,
     owner: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     match subdao {
         SubDao::Iot => iot::onboard_transaction(client, hotspot_key, assertion, owner, opts).await,
         SubDao::Mobile => {
@@ -225,7 +223,7 @@ pub async fn onboard<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAcc
     assertion: HotspotInfoUpdate,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let mut txn = onboard_transaction(
         client,
         subdao,
@@ -245,7 +243,7 @@ pub async fn issue_transaction<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
     add_tx: &mut BlockchainTxnAddGatewayV1,
     owner: Pubkey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     fn mk_accounts(
         config_account: helium_entity_manager::DataOnlyConfigV0,
         owner: Pubkey,
@@ -372,7 +370,7 @@ pub async fn issue<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
     add_tx: &mut BlockchainTxnAddGatewayV1,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let mut txn = issue_transaction(client, verifier, add_tx, keypair.pubkey(), opts).await?;
     txn.try_partial_sign(&[keypair])?;
     Ok(txn)
@@ -382,8 +380,8 @@ async fn verify_helium_key(
     verifier: &str,
     msg: &[u8],
     signature: &[u8],
-    tx: Transaction,
-) -> Result<Transaction, Error> {
+    tx: TransactionWithBlockhash,
+) -> Result<TransactionWithBlockhash, Error> {
     #[derive(Deserialize, Serialize, Default)]
     struct VerifyRequest<'a> {
         // hex encoded solana transaction

--- a/helium-lib/src/hotspot/dataonly.rs
+++ b/helium-lib/src/hotspot/dataonly.rs
@@ -6,23 +6,24 @@ use crate::{
     data_credits,
     entity_key::AsEntityKey,
     error::{DecodeError, EncodeError, Error},
-    helium_entity_manager, helium_sub_daos, hotspot,
-    hotspot::{HotspotInfoUpdate, ECC_VERIFIER},
+    helium_entity_manager, helium_sub_daos,
+    hotspot::{self, HotspotInfoUpdate, ECC_VERIFIER},
     keypair::{Keypair, Pubkey},
     kta, mk_transaction_with_blockhash, priority_fee,
     programs::{
         SPL_ACCOUNT_COMPRESSION_PROGRAM_ID, SPL_NOOP_PROGRAM_ID, TOKEN_METADATA_PROGRAM_ID,
     },
-    solana_client::rpc_client::SerializableTransaction,
-    solana_sdk::{instruction::Instruction, signature::Signer, transaction::Transaction},
+    solana_sdk::{instruction::Instruction, signature::Signer},
     token::Token,
-    TransactionOpts,
+    Transaction, TransactionOpts,
 };
 use helium_crypto::{PublicKey, Sign};
 use helium_proto::{BlockchainTxn, BlockchainTxnAddGatewayV1, Message, Txn};
 use serde::{Deserialize, Serialize};
 
 mod iot {
+    use crate::Transaction;
+
     use super::*;
 
     pub async fn onboard_transaction<
@@ -33,7 +34,7 @@ mod iot {
         assertion: HotspotInfoUpdate,
         owner: &Pubkey,
         opts: &TransactionOpts,
-    ) -> Result<(Transaction, u64), Error> {
+    ) -> Result<Transaction, Error> {
         fn mk_accounts(
             config_account: helium_entity_manager::DataOnlyConfigV0,
             owner: Pubkey,
@@ -110,6 +111,8 @@ mod iot {
 }
 
 mod mobile {
+    use crate::Transaction;
+
     use super::*;
 
     pub async fn onboard_transaction<
@@ -120,7 +123,7 @@ mod mobile {
         assertion: HotspotInfoUpdate,
         owner: &Pubkey,
         opts: &TransactionOpts,
-    ) -> Result<(Transaction, u64), Error> {
+    ) -> Result<Transaction, Error> {
         fn mk_accounts(
             config_account: helium_entity_manager::DataOnlyConfigV0,
             owner: Pubkey,
@@ -206,7 +209,7 @@ pub async fn onboard_transaction<
     assertion: HotspotInfoUpdate,
     owner: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     match subdao {
         SubDao::Iot => iot::onboard_transaction(client, hotspot_key, assertion, owner, opts).await,
         SubDao::Mobile => {
@@ -222,8 +225,8 @@ pub async fn onboard<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAcc
     assertion: HotspotInfoUpdate,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
-    let (mut txn, latest_block_height) = onboard_transaction(
+) -> Result<Transaction, Error> {
+    let mut txn = onboard_transaction(
         client,
         subdao,
         hotspot_key,
@@ -232,8 +235,8 @@ pub async fn onboard<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAcc
         opts,
     )
     .await?;
-    txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
-    Ok((txn, latest_block_height))
+    txn.try_sign(&[keypair])?;
+    Ok(txn)
 }
 
 pub async fn issue_transaction<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
@@ -242,7 +245,7 @@ pub async fn issue_transaction<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
     add_tx: &mut BlockchainTxnAddGatewayV1,
     owner: Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     fn mk_accounts(
         config_account: helium_entity_manager::DataOnlyConfigV0,
         owner: Pubkey,
@@ -302,14 +305,14 @@ pub async fn issue_transaction<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
         issue_ix,
     ];
 
-    let (txn, latest_block_height) = mk_transaction_with_blockhash(client, ixs, &owner).await?;
+    let txn = mk_transaction_with_blockhash(client, ixs, &owner).await?;
 
     let sig = add_tx.gateway_signature.clone();
     add_tx.gateway_signature = vec![];
     let msg = add_tx.encode_to_vec();
 
     let signed_txn = verify_helium_key(verifier, &msg, &sig, txn).await?;
-    Ok((signed_txn, latest_block_height))
+    Ok(signed_txn)
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -369,12 +372,10 @@ pub async fn issue<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
     add_tx: &mut BlockchainTxnAddGatewayV1,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
-    let (mut txn, block_height) =
-        issue_transaction(client, verifier, add_tx, keypair.pubkey(), opts).await?;
-    let blockhash = txn.message.recent_blockhash;
-    txn.try_partial_sign(&[keypair], blockhash)?;
-    Ok((txn, block_height))
+) -> Result<Transaction, Error> {
+    let mut txn = issue_transaction(client, verifier, add_tx, keypair.pubkey(), opts).await?;
+    txn.try_partial_sign(&[keypair])?;
+    Ok(txn)
 }
 
 async fn verify_helium_key(
@@ -398,7 +399,7 @@ async fn verify_helium_key(
         pub transaction: String,
     }
     let client = reqwest::Client::new();
-    let serialized_tx = hex::encode(bincode::serialize(&tx).map_err(EncodeError::from)?);
+    let serialized_tx = hex::encode(bincode::serialize(&tx.inner).map_err(EncodeError::from)?);
     let response = client
         .post(format!("{}/verify", verifier))
         .json(&VerifyRequest {
@@ -413,7 +414,7 @@ async fn verify_helium_key(
     let signed_tx =
         bincode::deserialize(&hex::decode(response.transaction).map_err(DecodeError::from)?)
             .map_err(DecodeError::from)?;
-    Ok(signed_tx)
+    Ok(tx.with_signed_transaction(signed_tx))
 }
 
 #[cfg(test)]

--- a/helium-lib/src/hotspot/mod.rs
+++ b/helium-lib/src/hotspot/mod.rs
@@ -14,7 +14,7 @@ use crate::{
         signer::Signer,
     },
     token::Token,
-    Transaction, TransactionOpts,
+    TransactionOpts, TransactionWithBlockhash,
 };
 use angry_purple_tiger::AnimalName;
 use chrono::Utc;
@@ -113,7 +113,7 @@ pub async fn direct_update_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClie
     update: HotspotInfoUpdate,
     owner: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     fn mk_accounts(
         subdao: SubDao,
         kta: &helium_entity_manager::KeyToAssetV0,
@@ -219,7 +219,7 @@ pub async fn direct_update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     update: HotspotInfoUpdate,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let mut txn =
         direct_update_transaction(client, hotspot, update, &keypair.pubkey(), opts).await?;
     txn.try_sign(&[keypair])?;
@@ -233,7 +233,7 @@ pub async fn update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     update: HotspotInfoUpdate,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let public_key = keypair.pubkey();
     if let Some(server) = onboarding_server {
         let onboarding_client = onboarding::Client::new(&server);
@@ -258,7 +258,7 @@ pub async fn transfer_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     hotspot_key: &helium_crypto::PublicKey,
     recipient: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let kta = kta::for_entity_key(hotspot_key).await?;
     asset::transfer_transaction(client, &kta.asset, recipient, opts).await
 }
@@ -269,7 +269,7 @@ pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     recipient: &Pubkey,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let kta = kta::for_entity_key(hotspot_key).await?;
     asset::transfer(client, &kta.asset, recipient, keypair, opts).await
 }
@@ -278,7 +278,7 @@ pub async fn burn_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot_key: &helium_crypto::PublicKey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let kta = kta::for_entity_key(hotspot_key).await?;
     asset::burn_transaction(client, &kta.asset, opts).await
 }
@@ -288,7 +288,7 @@ pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     hotspot_key: &helium_crypto::PublicKey,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let kta = kta::for_entity_key(hotspot_key).await?;
     asset::burn(client, &kta.asset, keypair, opts).await
 }

--- a/helium-lib/src/hotspot/mod.rs
+++ b/helium-lib/src/hotspot/mod.rs
@@ -9,14 +9,12 @@ use crate::{
     keypair::{pubkey, serde_pubkey, Keypair, Pubkey},
     kta, mk_transaction_with_blockhash, onboarding, priority_fee,
     programs::SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
-    solana_client::rpc_client::SerializableTransaction,
     solana_sdk::{
         instruction::{AccountMeta, Instruction},
         signer::Signer,
-        transaction::Transaction,
     },
     token::Token,
-    TransactionOpts,
+    Transaction, TransactionOpts,
 };
 use angry_purple_tiger::AnimalName;
 use chrono::Utc;
@@ -115,7 +113,7 @@ pub async fn direct_update_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClie
     update: HotspotInfoUpdate,
     owner: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     fn mk_accounts(
         subdao: SubDao,
         kta: &helium_entity_manager::KeyToAssetV0,
@@ -221,11 +219,11 @@ pub async fn direct_update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     update: HotspotInfoUpdate,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
-    let (mut txn, latest_block_height) =
+) -> Result<Transaction, Error> {
+    let mut txn =
         direct_update_transaction(client, hotspot, update, &keypair.pubkey(), opts).await?;
-    txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
-    Ok((txn, latest_block_height))
+    txn.try_sign(&[keypair])?;
+    Ok(txn)
 }
 
 pub async fn update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
@@ -243,9 +241,10 @@ pub async fn update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
             .get_update_txn(hotspot, &public_key, update)
             .await?;
         tx.try_partial_sign(&[keypair], tx.message.recent_blockhash)?;
-        return Ok(tx);
+        todo!("thread through helium-lib Transaction")
+        // return Ok(tx);
     };
-    let (tx, _) = direct_update(client, hotspot, update, keypair, opts).await?;
+    let tx = direct_update(client, hotspot, update, keypair, opts).await?;
     Ok(tx)
 }
 
@@ -259,7 +258,7 @@ pub async fn transfer_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     hotspot_key: &helium_crypto::PublicKey,
     recipient: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     let kta = kta::for_entity_key(hotspot_key).await?;
     asset::transfer_transaction(client, &kta.asset, recipient, opts).await
 }
@@ -270,7 +269,7 @@ pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     recipient: &Pubkey,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     let kta = kta::for_entity_key(hotspot_key).await?;
     asset::transfer(client, &kta.asset, recipient, keypair, opts).await
 }
@@ -279,7 +278,7 @@ pub async fn burn_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot_key: &helium_crypto::PublicKey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     let kta = kta::for_entity_key(hotspot_key).await?;
     asset::burn_transaction(client, &kta.asset, opts).await
 }
@@ -289,7 +288,7 @@ pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     hotspot_key: &helium_crypto::PublicKey,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     let kta = kta::for_entity_key(hotspot_key).await?;
     asset::burn(client, &kta.asset, keypair, opts).await
 }

--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -84,6 +84,10 @@ pub struct TransactionWithBlockhash {
 }
 
 impl TransactionWithBlockhash {
+    pub fn inner_txn(&self) -> &solana_sdk::transaction::Transaction {
+        &self.inner
+    }
+
     pub fn get_signature(&self) -> &Signature {
         self.inner.get_signature()
     }

--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -92,6 +92,10 @@ impl TransactionWithBlockhash {
         self.inner.get_signature()
     }
 
+    pub fn get_sent_block_height(&self) -> u64 {
+        self.block_height
+    }
+
     pub fn try_sign<T: solana_sdk::signers::Signers + ?Sized>(
         &mut self,
         keypairs: &T,

--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -19,6 +19,7 @@ pub mod token;
 
 pub use anchor_client;
 pub use anchor_client::solana_client;
+use anchor_client::solana_client::rpc_client::SerializableTransaction;
 pub use anchor_spl;
 pub use helium_anchor_gen::{
     anchor_lang, circuit_breaker, data_credits, helium_entity_manager, helium_sub_daos,
@@ -57,7 +58,7 @@ where
 use client::SolanaRpcClient;
 use error::Error;
 use keypair::Pubkey;
-use solana_sdk::{instruction::Instruction, transaction::Transaction};
+use solana_sdk::instruction::Instruction;
 use std::sync::Arc;
 
 pub fn init(solana_client: Arc<client::SolanaRpcClient>) -> Result<(), error::Error> {
@@ -76,16 +77,51 @@ impl Default for TransactionOpts {
     }
 }
 
+pub struct Transaction {
+    pub inner: solana_sdk::transaction::Transaction,
+    pub block_height: u64,
+}
+
+impl Transaction {
+    pub fn try_sign<T: solana_sdk::signers::Signers + ?Sized>(
+        &mut self,
+        keypairs: &T,
+    ) -> Result<(), solana_sdk::signer::SignerError> {
+        let recent_blockhash = self.inner.get_recent_blockhash();
+        self.inner.try_sign(keypairs, *recent_blockhash)?;
+        Ok(())
+    }
+
+    pub fn try_partial_sign<T: solana_sdk::signers::Signers + ?Sized>(
+        &mut self,
+        keypairs: &T,
+    ) -> Result<(), solana_sdk::signer::SignerError> {
+        let recent_blockhash = self.inner.get_recent_blockhash();
+        self.inner.try_partial_sign(keypairs, *recent_blockhash)?;
+        Ok(())
+    }
+
+    pub fn with_signed_transaction(self, txn: solana_sdk::transaction::Transaction) -> Self {
+        Self {
+            inner: txn,
+            block_height: self.block_height,
+        }
+    }
+}
+
 pub async fn mk_transaction_with_blockhash<C: AsRef<SolanaRpcClient>>(
     client: &C,
     ixs: &[Instruction],
     payer: &Pubkey,
-) -> Result<(Transaction, u64), Error> {
-    let mut txn = Transaction::new_with_payer(ixs, Some(payer));
+) -> Result<Transaction, Error> {
+    let mut txn = solana_sdk::transaction::Transaction::new_with_payer(ixs, Some(payer));
     let solana_client = AsRef::<SolanaRpcClient>::as_ref(client);
     let (latest_blockhash, latest_block_height) = solana_client
         .get_latest_blockhash_with_commitment(solana_client.commitment())
         .await?;
     txn.message.recent_blockhash = latest_blockhash;
-    Ok((txn, latest_block_height))
+    Ok(Transaction {
+        inner: txn,
+        block_height: latest_block_height,
+    })
 }

--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -59,6 +59,7 @@ use client::SolanaRpcClient;
 use error::Error;
 use keypair::Pubkey;
 use solana_sdk::instruction::Instruction;
+use solana_sdk::signature::Signature;
 use std::sync::Arc;
 
 pub fn init(solana_client: Arc<client::SolanaRpcClient>) -> Result<(), error::Error> {
@@ -83,6 +84,10 @@ pub struct TransactionWithBlockhash {
 }
 
 impl TransactionWithBlockhash {
+    pub fn get_signature(&self) -> &Signature {
+        self.inner.get_signature()
+    }
+
     pub fn try_sign<T: solana_sdk::signers::Signers + ?Sized>(
         &mut self,
         keypairs: &T,

--- a/helium-lib/src/memo.rs
+++ b/helium-lib/src/memo.rs
@@ -4,7 +4,7 @@ use crate::{
     keypair::{Keypair, Pubkey},
     mk_transaction_with_blockhash, priority_fee,
     solana_sdk::signer::Signer,
-    Transaction, TransactionOpts,
+    TransactionOpts, TransactionWithBlockhash,
 };
 
 pub async fn memo_transaction<C: AsRef<SolanaRpcClient>>(
@@ -12,7 +12,7 @@ pub async fn memo_transaction<C: AsRef<SolanaRpcClient>>(
     data: &str,
     pubkey: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let ix = spl_memo::build_memo(data.as_bytes(), &[pubkey]);
     let ixs = &[
         priority_fee::compute_budget_instruction(200_000),
@@ -33,7 +33,7 @@ pub async fn memo<C: AsRef<SolanaRpcClient>>(
     data: &str,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let mut txn = memo_transaction(client, data, &keypair.pubkey(), opts).await?;
     txn.try_sign(&[keypair])?;
     Ok(txn)

--- a/helium-lib/src/memo.rs
+++ b/helium-lib/src/memo.rs
@@ -3,9 +3,8 @@ use crate::{
     error::Error,
     keypair::{Keypair, Pubkey},
     mk_transaction_with_blockhash, priority_fee,
-    solana_client::rpc_client::SerializableTransaction,
-    solana_sdk::{signer::Signer, transaction::Transaction},
-    TransactionOpts,
+    solana_sdk::signer::Signer,
+    Transaction, TransactionOpts,
 };
 
 pub async fn memo_transaction<C: AsRef<SolanaRpcClient>>(
@@ -13,7 +12,7 @@ pub async fn memo_transaction<C: AsRef<SolanaRpcClient>>(
     data: &str,
     pubkey: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     let ix = spl_memo::build_memo(data.as_bytes(), &[pubkey]);
     let ixs = &[
         priority_fee::compute_budget_instruction(200_000),
@@ -34,9 +33,8 @@ pub async fn memo<C: AsRef<SolanaRpcClient>>(
     data: &str,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
-    let (mut txn, latest_block_height) =
-        memo_transaction(client, data, &keypair.pubkey(), opts).await?;
-    txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
-    Ok((txn, latest_block_height))
+) -> Result<Transaction, Error> {
+    let mut txn = memo_transaction(client, data, &keypair.pubkey(), opts).await?;
+    txn.try_sign(&[keypair])?;
+    Ok(txn)
 }

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -12,7 +12,7 @@ use crate::{
     rewards_oracle,
     solana_sdk::instruction::Instruction,
     token::{Token, TokenAmount},
-    Transaction, TransactionOpts,
+    TransactionOpts, TransactionWithBlockhash,
 };
 use chrono::Utc;
 use futures::{
@@ -248,7 +248,7 @@ pub async fn claim<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccou
     encoded_entity_key: &entity_key::EncodedEntityKey,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Option<Transaction>, Error> {
+) -> Result<Option<TransactionWithBlockhash>, Error> {
     let Some(mut txn) = claim_transaction(
         client,
         token,
@@ -433,7 +433,10 @@ pub async fn lifetime<C: GetAnchorAccount>(
         .await
 }
 
-async fn oracle_sign(oracle: &str, txn: Transaction) -> Result<Transaction, Error> {
+async fn oracle_sign(
+    oracle: &str,
+    txn: TransactionWithBlockhash,
+) -> Result<TransactionWithBlockhash, Error> {
     #[derive(Debug, Serialize, Deserialize)]
     struct Data {
         data: Vec<u8>,
@@ -581,7 +584,7 @@ pub mod recipient {
         entity_key: &E,
         keypair: &Keypair,
         opts: &TransactionOpts,
-    ) -> Result<Transaction, Error> {
+    ) -> Result<TransactionWithBlockhash, Error> {
         let kta = kta::for_entity_key(entity_key).await?;
         let (asset, asset_proof) = asset::for_kta_with_proof(client, &kta).await?;
 

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -12,7 +12,7 @@ use crate::{
     rewards_oracle,
     solana_sdk::instruction::Instruction,
     token::{Token, TokenAmount},
-    TransactionOpts, TransactionWithBlockhash,
+    TransactionWithBlockhash, TransactionOpts,
 };
 use chrono::Utc;
 use futures::{
@@ -273,7 +273,7 @@ pub async fn claim_transaction<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + Ge
     encoded_entity_key: &entity_key::EncodedEntityKey,
     payer: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<Option<Transaction>, Error> {
+) -> Result<Option<TransactionWithBlockhash>, Error> {
     let entity_key_string = encoded_entity_key.to_string();
     let pending = pending(
         client,
@@ -433,10 +433,7 @@ pub async fn lifetime<C: GetAnchorAccount>(
         .await
 }
 
-async fn oracle_sign(
-    oracle: &str,
-    txn: TransactionWithBlockhash,
-) -> Result<TransactionWithBlockhash, Error> {
+async fn oracle_sign(oracle: &str, txn: TransactionWithBlockhash) -> Result<TransactionWithBlockhash, Error> {
     #[derive(Debug, Serialize, Deserialize)]
     struct Data {
         data: Vec<u8>,

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -12,7 +12,7 @@ use crate::{
     rewards_oracle,
     solana_sdk::instruction::Instruction,
     token::{Token, TokenAmount},
-    TransactionWithBlockhash, TransactionOpts,
+    TransactionOpts, TransactionWithBlockhash,
 };
 use chrono::Utc;
 use futures::{
@@ -433,7 +433,10 @@ pub async fn lifetime<C: GetAnchorAccount>(
         .await
 }
 
-async fn oracle_sign(oracle: &str, txn: TransactionWithBlockhash) -> Result<TransactionWithBlockhash, Error> {
+async fn oracle_sign(
+    oracle: &str,
+    txn: TransactionWithBlockhash,
+) -> Result<TransactionWithBlockhash, Error> {
     #[derive(Debug, Serialize, Deserialize)]
     struct Data {
         data: Vec<u8>,

--- a/helium-lib/src/token.rs
+++ b/helium-lib/src/token.rs
@@ -5,11 +5,8 @@ use crate::{
     error::{DecodeError, Error},
     keypair::{serde_pubkey, Keypair, Pubkey},
     mk_transaction_with_blockhash,
-    solana_client::rpc_client::SerializableTransaction,
-    solana_sdk::{
-        commitment_config::CommitmentConfig, signer::Signer, system_instruction,
-        transaction::Transaction,
-    },
+    solana_sdk::{commitment_config::CommitmentConfig, signer::Signer, system_instruction},
+    Transaction,
 };
 use chrono::{DateTime, Duration, Utc};
 use futures::stream::{self, StreamExt, TryStreamExt};
@@ -43,7 +40,7 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
     client: &C,
     token_amount: &TokenAmount,
     keypair: &Keypair,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     let wallet_pubkey = keypair.pubkey();
     let ix = match token_amount.token.mint() {
         spl_mint if spl_mint == Token::Sol.mint() => {
@@ -63,17 +60,16 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
         }
     };
 
-    let (mut txn, latest_block_height) =
-        mk_transaction_with_blockhash(client, &[ix], &wallet_pubkey).await?;
-    txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
-    Ok((txn, latest_block_height))
+    let mut txn = mk_transaction_with_blockhash(client, &[ix], &wallet_pubkey).await?;
+    txn.try_sign(&[keypair])?;
+    Ok(txn)
 }
 
 pub async fn transfer<C: AsRef<SolanaRpcClient>>(
     client: &C,
     transfers: &[(Pubkey, TokenAmount)],
     keypair: &Keypair,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<Transaction, Error> {
     let wallet_public_key = keypair.pubkey();
 
     let mut ixs = vec![];
@@ -112,10 +108,9 @@ pub async fn transfer<C: AsRef<SolanaRpcClient>>(
         }
     }
 
-    let (mut txn, latest_block_height) =
-        mk_transaction_with_blockhash(client, &ixs, &wallet_public_key).await?;
-    txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
-    Ok((txn, latest_block_height))
+    let mut txn = mk_transaction_with_blockhash(client, &ixs, &wallet_public_key).await?;
+    txn.try_sign(&[keypair])?;
+    Ok(txn)
 }
 
 pub async fn balance_for_address<C: AsRef<SolanaRpcClient>>(

--- a/helium-lib/src/token.rs
+++ b/helium-lib/src/token.rs
@@ -6,7 +6,7 @@ use crate::{
     keypair::{serde_pubkey, Keypair, Pubkey},
     mk_transaction_with_blockhash,
     solana_sdk::{commitment_config::CommitmentConfig, signer::Signer, system_instruction},
-    Transaction,
+    TransactionWithBlockhash,
 };
 use chrono::{DateTime, Duration, Utc};
 use futures::stream::{self, StreamExt, TryStreamExt};
@@ -40,7 +40,7 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
     client: &C,
     token_amount: &TokenAmount,
     keypair: &Keypair,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let wallet_pubkey = keypair.pubkey();
     let ix = match token_amount.token.mint() {
         spl_mint if spl_mint == Token::Sol.mint() => {
@@ -69,7 +69,7 @@ pub async fn transfer<C: AsRef<SolanaRpcClient>>(
     client: &C,
     transfers: &[(Pubkey, TokenAmount)],
     keypair: &Keypair,
-) -> Result<Transaction, Error> {
+) -> Result<TransactionWithBlockhash, Error> {
     let wallet_public_key = keypair.pubkey();
 
     let mut ixs = vec![];

--- a/helium-mnemonic/Cargo.toml
+++ b/helium-mnemonic/Cargo.toml
@@ -5,10 +5,10 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-bitvec = "*" # inherits from elliptic-curve crate
+bitvec = "*"                # inherits from elliptic-curve crate
 thiserror = "1"
 lazy_static = "1"
-sha2 = {workspace = true}
+sha2 = { workspace = true }
 
 [dev-dependencies]
 bs58 = "0"

--- a/helium-wallet/Cargo.toml
+++ b/helium-wallet/Cargo.toml
@@ -16,7 +16,7 @@ doc = false
 
 [dependencies]
 anyhow = "1"
-sha2 = {workspace = true}
+sha2 = { workspace = true }
 byteorder = "1.3.2"
 rand = "0.8"
 dialoguer = "0.8"
@@ -24,13 +24,13 @@ pbkdf2 = "0.12"
 sodiumoxide = "~0.2"
 aes-gcm = "0"
 shamirsecretsharing = { version = "0.1.5", features = ["have_libsodium"] }
-serde = {workspace = true}
-serde_json = {workspace = true}
+serde = { workspace = true }
+serde_json = { workspace = true }
 clap = { workspace = true }
 qr2term = "0.2"
-rust_decimal = {workspace = true}
-tokio = {version = "1.0", features = ["full"]}
+rust_decimal = { workspace = true }
+tokio = { version = "1.0", features = ["full"] }
 helium-lib = { path = "../helium-lib", features = ["clap", "mnemonic"] }
 helium-mnemonic = { path = "../helium-mnemonic" }
-helium-proto = {workspace = true}
-helium-crypto = {workspace = true, features = ["multisig", "solana"] }
+helium-proto = { workspace = true }
+helium-crypto = { workspace = true, features = ["multisig", "solana"] }

--- a/helium-wallet/src/cmd/assets/burn.rs
+++ b/helium-wallet/src/cmd/assets/burn.rs
@@ -20,7 +20,7 @@ impl Cmd {
         let password = get_wallet_password(false)?;
         let keypair = opts.load_keypair(password.as_bytes())?;
         let asset = asset::for_entity_key(&client, &self.entity_key.as_entity_key()?).await?;
-        let (tx, _) = asset::burn(
+        let tx = asset::burn(
             &client,
             &asset.id,
             &keypair,

--- a/helium-wallet/src/cmd/assets/rewards.rs
+++ b/helium-wallet/src/cmd/assets/rewards.rs
@@ -60,7 +60,7 @@ impl ClaimCmd {
         let token_amount = self
             .amount
             .map(|amount| TokenAmount::from_f64(self.token.into(), amount).amount);
-        let Some((tx, _)) = reward::claim(
+        let Some(tx) = reward::claim(
             &client,
             self.token,
             token_amount,

--- a/helium-wallet/src/cmd/assets/rewards.rs
+++ b/helium-wallet/src/cmd/assets/rewards.rs
@@ -72,7 +72,6 @@ impl ClaimCmd {
         else {
             bail!("No rewards to claim")
         };
-
         let claim_response = self
             .commit
             .maybe_commit(&tx, &client)

--- a/helium-wallet/src/cmd/burn.rs
+++ b/helium-wallet/src/cmd/burn.rs
@@ -20,7 +20,7 @@ impl Cmd {
         let client = opts.client()?;
 
         let token_amount = token::TokenAmount::from_f64(self.subdao.token(), self.amount);
-        let (tx, _) = token::burn(&client, &token_amount, &keypair).await?;
+        let tx = token::burn(&client, &token_amount, &keypair).await?;
         print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/dc/burn.rs
+++ b/helium-wallet/src/cmd/dc/burn.rs
@@ -19,7 +19,7 @@ impl Cmd {
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts();
 
-        let (tx, _) = dc::burn(&client, self.dc, &keypair, &transaction_opts).await?;
+        let tx = dc::burn(&client, self.dc, &keypair, &transaction_opts).await?;
         print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/dc/delegate.rs
+++ b/helium-wallet/src/cmd/dc/delegate.rs
@@ -25,7 +25,7 @@ impl Cmd {
 
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts();
-        let (tx, _) = dc::delegate(
+        let tx = dc::delegate(
             &client,
             self.subdao,
             &self.payer,

--- a/helium-wallet/src/cmd/dc/mint.rs
+++ b/helium-wallet/src/cmd/dc/mint.rs
@@ -44,7 +44,7 @@ impl Cmd {
         let transaction_opts = self.commit.transaction_opts();
 
         let keypair = wallet.decrypt(password.as_bytes())?;
-        let (tx, _) = dc::mint(&client, amount, payee, &keypair, &transaction_opts).await?;
+        let tx = dc::mint(&client, amount, payee, &keypair, &transaction_opts).await?;
         print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/hotspots/add.rs
+++ b/helium-wallet/src/cmd/hotspots/add.rs
@@ -108,9 +108,8 @@ async fn perform_add(
     let transaction_opts = &commit.transaction_opts();
 
     if !hotspot_issued {
-        let (tx, _) =
-            hotspot::dataonly::issue(&client, verifier, &mut txn, &keypair, transaction_opts)
-                .await?;
+        let tx = hotspot::dataonly::issue(&client, verifier, &mut txn, &keypair, transaction_opts)
+            .await?;
         let response = commit.maybe_commit(&tx, &client).await?;
         print_json(&response.to_json())?;
     }
@@ -119,7 +118,7 @@ async fn perform_add(
     // Without this, the command will always fail for brand new hotspots when --commit is not
     // enabled, as it cannot find the key_to_asset account or asset account.
     if hotspot_issued || commit.commit {
-        let (tx, _) = hotspot::dataonly::onboard(
+        let tx = hotspot::dataonly::onboard(
             &client,
             subdao,
             &gateway,

--- a/helium-wallet/src/cmd/hotspots/burn.rs
+++ b/helium-wallet/src/cmd/hotspots/burn.rs
@@ -18,7 +18,7 @@ impl Cmd {
         let client = opts.client()?;
         let password = get_wallet_password(false)?;
         let keypair = opts.load_keypair(password.as_bytes())?;
-        let (tx, _) = hotspot::burn(
+        let tx = hotspot::burn(
             &client,
             &self.address,
             &keypair,

--- a/helium-wallet/src/cmd/hotspots/transfer.rs
+++ b/helium-wallet/src/cmd/hotspots/transfer.rs
@@ -25,7 +25,7 @@ impl Cmd {
         }
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts();
-        let (tx, _) = hotspot::transfer(
+        let tx = hotspot::transfer(
             &client,
             &self.address,
             &self.recipient,

--- a/helium-wallet/src/cmd/memo.rs
+++ b/helium-wallet/src/cmd/memo.rs
@@ -19,7 +19,7 @@ impl Cmd {
         let keypair = wallet.decrypt(password.as_bytes())?;
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts();
-        let (tx, _) =
+        let tx =
             helium_lib::memo::memo(&client, &self.message, &keypair, &transaction_opts).await?;
         print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
     }

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -98,7 +98,7 @@ pub struct CommitOpts {
 impl CommitOpts {
     pub async fn maybe_commit<C: AsRef<client::SolanaRpcClient>>(
         &self,
-        tx: &helium_lib::solana_sdk::transaction::Transaction,
+        tx: &helium_lib::Transaction,
         client: &C,
     ) -> Result<CommitResponse> {
         fn context_err(client_err: solana_client::client_error::ClientError) -> Error {
@@ -137,14 +137,14 @@ impl CommitOpts {
             };
             client
                 .as_ref()
-                .send_transaction_with_config(tx, config)
+                .send_transaction_with_config(&tx.inner, config)
                 .await
                 .map(Into::into)
                 .map_err(context_err)
         } else {
             client
                 .as_ref()
-                .simulate_transaction(tx)
+                .simulate_transaction(&tx.inner)
                 .await
                 .map_err(context_err)?
                 .value

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -98,7 +98,7 @@ pub struct CommitOpts {
 impl CommitOpts {
     pub async fn maybe_commit<C: AsRef<client::SolanaRpcClient>>(
         &self,
-        tx: &helium_lib::Transaction,
+        tx: &helium_lib::TransactionWithBlockhash,
         client: &C,
     ) -> Result<CommitResponse> {
         fn context_err(client_err: solana_client::client_error::ClientError) -> Error {

--- a/helium-wallet/src/cmd/transfer.rs
+++ b/helium-wallet/src/cmd/transfer.rs
@@ -88,7 +88,7 @@ impl PayCmd {
         let keypair = opts.load_keypair(password.as_bytes())?;
 
         let client = opts.client()?;
-        let (tx, _) = token::transfer(&client, &payments, &keypair).await?;
+        let tx = token::transfer(&client, &payments, &keypair).await?;
 
         print_json(&self.commit().maybe_commit(&tx, &client).await?.to_json())
     }


### PR DESCRIPTION
Converts all the places where `(solana_sdk::transaction::Transaction, u64)` was used to a `helium-lib` provided struct `TransactionWithBlockhash`.