### PR TITLE
Change seed->wallet to allocate less, borrow more.

### DIFF
--- a/helium-lib/src/keypair.rs
+++ b/helium-lib/src/keypair.rs
@@ -135,7 +135,7 @@ impl Keypair {
     }
 
     #[cfg(feature = "mnemonic")]
-    pub fn from_words(words: Vec<String>) -> Result<Arc<Self>, Error> {
+    pub fn from_words(words: &[&str]) -> Result<Arc<Self>, Error> {
         let entropy_bytes = helium_mnemonic::mnemonic_to_entropy(words)?;
         let keypair = solana_sdk::signer::keypair::keypair_from_seed(&entropy_bytes)
             .map_err(|_| DecodeError::other("invalid words"))?;

--- a/helium-mnemonic/src/lib.rs
+++ b/helium-mnemonic/src/lib.rs
@@ -54,7 +54,7 @@ impl Index<usize> for Language {
 
 /// Converts a 12 or 24 word mnemonic to entropy that can be used to
 /// generate a keypair
-pub fn mnemonic_to_entropy(words: Vec<String>) -> Result<[u8; 32], MnmemonicError> {
+pub fn mnemonic_to_entropy(words: &[&str]) -> Result<[u8; 32], MnmemonicError> {
     const MAX_ENTROPY_BITS: usize = 256;
     const BITS_PER_WORD: usize = 11;
     const CHECKSUM_BITS_PER_WORD: usize = 3;
@@ -70,11 +70,11 @@ pub fn mnemonic_to_entropy(words: Vec<String>) -> Result<[u8; 32], MnmemonicErro
     let language = Language::English;
     let word_bits =
         words
-            .into_iter()
+            .iter()
             .try_fold(BitVec::with_capacity(MAX_ENTROPY_BITS), |mut acc, w| {
                 language
-                    .find_word(&w)
-                    .ok_or(MnmemonicError::NoSuchWord(w))
+                    .find_word(w)
+                    .ok_or(MnmemonicError::NoSuchWord(w.to_string()))
                     .map(|idx| {
                         let idx_bits = &idx.view_bits::<Msb0>();
                         acc.extend_from_bitslice(&idx_bits[idx_bits.len() - BITS_PER_WORD..]);
@@ -184,8 +184,8 @@ mod tests {
             .into_vec()
             .expect("decoded entropy");
 
-        let word_list = words.split_whitespace().map(|w| w.to_string()).collect();
-        let entropy = mnemonic_to_entropy(word_list).expect("entropy");
+        let word_list: Vec<&str> = words.split_whitespace().collect();
+        let entropy = mnemonic_to_entropy(&word_list).expect("entropy");
         assert_eq!(expected_entropy, entropy);
     }
 
@@ -197,8 +197,8 @@ mod tests {
             .into_vec()
             .expect("decoded entropy");
 
-        let word_list = words.split_whitespace().map(|w| w.to_string()).collect();
-        let entropy = mnemonic_to_entropy(word_list).expect("entropy");
+        let word_list: Vec<&str> = words.split_whitespace().collect();
+        let entropy = mnemonic_to_entropy(&word_list).expect("entropy");
         assert_eq!(expected_entropy, entropy);
     }
 
@@ -206,20 +206,18 @@ mod tests {
     fn encode_mobile_12_words() {
         // This test starts with zero-checksum 12 word phrase from the helium-hotspot-app, turns it into
         // entropy, then decodes that entropy back into a 12 word phrase with a proper checksum.
-        let hotspot_app_word_list =
+        let hotspot_app_word_list: Vec<&str> =
             "catch poet clog intact scare jacket throw palm illegal buyer allow figure"
                 .split_whitespace()
-                .map(|w| w.to_string())
                 .collect();
-        let bip39_words_list: Vec<String> =
+        let bip39_words_list: Vec<&str> =
             "catch poet clog intact scare jacket throw palm illegal buyer allow firm"
                 .split_whitespace()
-                .map(|w| w.to_string())
                 .collect();
 
         let hotspot_app_entropy =
-            mnemonic_to_entropy(hotspot_app_word_list).expect("hotspot_app_entropy");
-        let bip39_entropy = mnemonic_to_entropy(bip39_words_list.to_vec()).expect("bip39_entropy");
+            mnemonic_to_entropy(&hotspot_app_word_list).expect("hotspot_app_entropy");
+        let bip39_entropy = mnemonic_to_entropy(&bip39_words_list).expect("bip39_entropy");
 
         let expected_entropy = bs58::decode("3RrA1FDa6mdw5JwKbUxEbZbMcJgSyWjhNwxsbX5pSos8")
             .into_vec()
@@ -248,8 +246,8 @@ mod tests {
             .into_vec()
             .expect("decoded entropy");
 
-        let word_list = words.split_whitespace().map(|w| w.to_string()).collect();
-        let entropy = mnemonic_to_entropy(word_list).expect("entropy");
+        let word_list: Vec<&str> = words.split_whitespace().collect();
+        let entropy = mnemonic_to_entropy(&word_list).expect("entropy");
         assert_eq!(expected_entropy, entropy);
     }
 
@@ -267,8 +265,8 @@ mod tests {
             .into_vec()
             .expect("decoded entropy");
 
-        let word_list = words.split_whitespace().map(|w| w.to_string()).collect();
-        let entropy = mnemonic_to_entropy(word_list).expect("entropy");
+        let word_list: Vec<&str> = words.split_whitespace().collect();
+        let entropy = mnemonic_to_entropy(&word_list).expect("entropy");
         assert_eq!(expected_entropy, entropy);
     }
 
@@ -298,8 +296,8 @@ mod tests {
             .into_vec()
             .expect("decoded entropy");
 
-        let word_list = words.split_whitespace().map(|w| w.to_string()).collect();
-        let entropy = mnemonic_to_entropy(word_list).expect("entropy");
+        let word_list: Vec<&str> = words.split_whitespace().collect();
+        let entropy = mnemonic_to_entropy(&word_list).expect("entropy");
         assert_eq!(expected_entropy, entropy);
     }
 
@@ -316,8 +314,8 @@ mod tests {
             .into_vec()
             .expect("decoded entropy");
 
-        let word_list = words.split_whitespace().map(|w| w.to_string()).collect();
-        let entropy = mnemonic_to_entropy(word_list).expect("entropy");
+        let word_list: Vec<&str> = words.split_whitespace().collect();
+        let entropy = mnemonic_to_entropy(&word_list).expect("entropy");
         assert_eq!(expected_entropy, entropy);
     }
 

--- a/helium-wallet/src/cmd/create.rs
+++ b/helium-wallet/src/cmd/create.rs
@@ -175,7 +175,7 @@ impl Keypair {
 
 fn get_seed_entropy() -> Result<Vec<u8>> {
     fn secret_from_phrase(s: &str) -> Result<Vec<u8>> {
-        let entropy = helium_mnemonic::mnemonic_to_entropy(phrase_to_words(s))?.to_vec();
+        let entropy = helium_mnemonic::mnemonic_to_entropy(&phrase_to_words(s))?.to_vec();
         Ok(entropy)
     }
 

--- a/helium-wallet/src/cmd/export.rs
+++ b/helium-wallet/src/cmd/export.rs
@@ -150,7 +150,7 @@ mod tests {
     const SEED_PWD: &str = "h3l1Um";
 
     fn create_test_keypair() -> Keypair {
-        let entropy = helium_mnemonic::mnemonic_to_entropy(phrase_to_words(MNEMONIC_PHRASE))
+        let entropy = helium_mnemonic::mnemonic_to_entropy(&phrase_to_words(MNEMONIC_PHRASE))
             .expect("mnemonic");
         Keypair::generate_from_entropy(&entropy).expect("keypair")
     }

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -279,8 +279,8 @@ pub fn print_simulation_response(
     }))
 }
 
-pub fn phrase_to_words(phrase: &str) -> Vec<String> {
-    phrase.split_whitespace().map(|w| w.to_string()).collect()
+pub fn phrase_to_words(phrase: &str) -> Vec<&str> {
+    phrase.split_whitespace().collect()
 }
 
 pub trait ToJson {

--- a/helium-wallet/src/wallet.rs
+++ b/helium-wallet/src/wallet.rs
@@ -464,8 +464,8 @@ mod tests {
             "drill toddler tongue laundry access silly few faint glove birth crumble add",
         );
 
-        let from_keypair = Keypair::from_words(seed_words.clone()).expect("to generate a keypair");
-        let entropy = helium_mnemonic::mnemonic_to_entropy(seed_words)
+        let from_keypair = Keypair::from_words(&seed_words).expect("to generate a keypair");
+        let entropy = helium_mnemonic::mnemonic_to_entropy(&seed_words)
             .expect("entropy from mnemonic")
             .to_vec();
 
@@ -499,8 +499,8 @@ mod tests {
 
         let seed_words = phrase_to_words(
             "moment case dirt ski tool dynamic sort ugly pluck drop kiwi knee jar easy verb canal nuclear survey before dwarf prosper cave pottery target");
-        let from_keypair = Keypair::from_words(seed_words.clone()).expect("to generate a keypair");
-        let entropy = helium_mnemonic::mnemonic_to_entropy(seed_words)
+        let from_keypair = Keypair::from_words(&seed_words).expect("to generate a keypair");
+        let entropy = helium_mnemonic::mnemonic_to_entropy(&seed_words)
             .expect("entropy from mnemonic")
             .to_vec();
 


### PR DESCRIPTION
Change the import-from-seed functions to use borrowed slices rather than full String vectors, requiring callers to allocate less when using the API.