### PR TITLE
Use claimable token instead of rewardable dao

### DIFF
--- a/helium-lib/src/dao.rs
+++ b/helium-lib/src/dao.rs
@@ -1,31 +1,9 @@
 use crate::{
     data_credits, entity_key::AsEntityKey, helium_entity_manager, helium_sub_daos, keypair::Pubkey,
-    lazy_distributor, programs::TOKEN_METADATA_PROGRAM_ID, rewards_oracle, token::Token,
+    programs::TOKEN_METADATA_PROGRAM_ID, rewards_oracle, token::Token,
 };
 use chrono::Timelike;
 use sha2::{Digest, Sha256};
-
-pub trait RewardableDao {
-    fn token(&self) -> Token;
-    fn lazy_distributor_key(&self) -> Pubkey {
-        let (key, _) = Pubkey::find_program_address(
-            &[b"lazy_distributor", self.token().mint().as_ref()],
-            &lazy_distributor::id(),
-        );
-        key
-    }
-    fn receipient_key_from_kta(&self, kta: &helium_entity_manager::KeyToAssetV0) -> Pubkey {
-        let (key, _) = Pubkey::find_program_address(
-            &[
-                b"recipient",
-                self.lazy_distributor_key().as_ref(),
-                kta.asset.as_ref(),
-            ],
-            &lazy_distributor::id(),
-        );
-        key
-    }
-}
 
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize, Default,
@@ -141,12 +119,6 @@ impl Dao {
     }
 }
 
-impl RewardableDao for Dao {
-    fn token(&self) -> Token {
-        Token::Hnt
-    }
-}
-
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "lowercase")]
@@ -176,6 +148,13 @@ impl SubDao {
             &helium_sub_daos::id(),
         );
         subdao_key
+    }
+
+    pub fn token(&self) -> Token {
+        match self {
+            Self::Iot => Token::Iot,
+            Self::Mobile => Token::Mobile,
+        }
     }
 
     pub fn delegated_dc_key(&self, router_key: &str) -> Pubkey {
@@ -246,20 +225,5 @@ impl SubDao {
             &helium_sub_daos::ID,
         );
         key
-    }
-}
-
-impl RewardableDao for SubDao {
-    fn token(&self) -> Token {
-        match self {
-            Self::Iot => Token::Iot,
-            Self::Mobile => Token::Mobile,
-        }
-    }
-}
-
-impl RewardableDao for Option<SubDao> {
-    fn token(&self) -> Token {
-        self.map(|subdao| subdao.token()).unwrap_or(Token::Hnt)
     }
 }

--- a/helium-wallet/src/cmd/burn.rs
+++ b/helium-wallet/src/cmd/burn.rs
@@ -1,8 +1,5 @@
 use crate::cmd::*;
-use helium_lib::{
-    dao::{RewardableDao, SubDao},
-    token,
-};
+use helium_lib::{dao::SubDao, token};
 
 #[derive(Debug, Clone, clap::Args)]
 /// Burn tokens


### PR DESCRIPTION
This replaces 339b24405c88f421f47e4193811a17490e9cb4f3 with a cleaner ClaimableToken for the rewards module.

As a result the wallet rewards and hotspots cli commands will also go back to specifying the token explicitly in their pending, claim and lifetime commands