### PR TITLE
Upgrade to using solana v0 messages and txns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3690,7 +3690,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.95",

--- a/helium-lib/src/client.rs
+++ b/helium-lib/src/client.rs
@@ -25,6 +25,10 @@ pub static SOLANA_URL_DEVNET_ENV: &str = "SOLANA_DEVNET_URL";
 
 pub use solana_client::nonblocking::rpc_client::RpcClient as SolanaRpcClient;
 
+pub fn is_devnet(url: &str) -> bool {
+    url == "d" || url.starts_with("devnet") || url.contains("test-helium")
+}
+
 #[derive(Clone)]
 pub struct Client {
     pub solana_client: Arc<SolanaRpcClient>,

--- a/helium-lib/src/error.rs
+++ b/helium-lib/src/error.rs
@@ -29,6 +29,10 @@ pub enum Error {
     Program(#[from] solana_program::program_error::ProgramError),
     #[error("solana: {0}")]
     Solana(Box<solana_client::client_error::ClientError>),
+    #[error("instruction: {0}")]
+    Instruction(#[from] solana_sdk::instruction::InstructionError),
+    #[error("message: {0}")]
+    Cmopile(#[from] solana_sdk::message::CompileError),
     #[error("signing: {0}")]
     Signing(#[from] solana_sdk::signer::SignerError),
     #[error("crypto: {0}")]

--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -11,6 +11,7 @@ pub mod hotspot;
 pub mod keypair;
 pub mod kta;
 pub mod memo;
+pub mod message;
 pub mod onboarding;
 pub mod priority_fee;
 pub mod programs;
@@ -66,12 +67,14 @@ pub fn init(solana_client: Arc<client::SolanaRpcClient>) -> Result<(), error::Er
 
 pub struct TransactionOpts {
     pub min_priority_fee: u64,
+    pub lut_addresses: Vec<Pubkey>,
 }
 
 impl Default for TransactionOpts {
     fn default() -> Self {
         Self {
             min_priority_fee: priority_fee::MIN_PRIORITY_FEE,
+            lut_addresses: vec![message::COMMON_LUT],
         }
     }
 }

--- a/helium-lib/src/memo.rs
+++ b/helium-lib/src/memo.rs
@@ -2,18 +2,17 @@ use crate::{
     client::SolanaRpcClient,
     error::Error,
     keypair::{Keypair, Pubkey},
-    mk_transaction_with_blockhash, priority_fee,
-    solana_client::rpc_client::SerializableTransaction,
-    solana_sdk::{signer::Signer, transaction::Transaction},
+    message, priority_fee,
+    solana_sdk::{signer::Signer, transaction::VersionedTransaction},
     TransactionOpts,
 };
 
-pub async fn memo_transaction<C: AsRef<SolanaRpcClient>>(
+pub async fn memo_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     data: &str,
     pubkey: &Pubkey,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
+) -> Result<(message::VersionedMessage, u64), Error> {
     let ix = spl_memo::build_memo(data.as_bytes(), &[pubkey]);
     let ixs = &[
         priority_fee::compute_budget_instruction(200_000),
@@ -26,7 +25,7 @@ pub async fn memo_transaction<C: AsRef<SolanaRpcClient>>(
         ix,
     ];
 
-    mk_transaction_with_blockhash(client, ixs, pubkey).await
+    message::mk_message(client, ixs, &opts.lut_addresses, pubkey).await
 }
 
 pub async fn memo<C: AsRef<SolanaRpcClient>>(
@@ -34,9 +33,8 @@ pub async fn memo<C: AsRef<SolanaRpcClient>>(
     data: &str,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<(Transaction, u64), Error> {
-    let (mut txn, latest_block_height) =
-        memo_transaction(client, data, &keypair.pubkey(), opts).await?;
-    txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
-    Ok((txn, latest_block_height))
+) -> Result<(VersionedTransaction, u64), Error> {
+    let (msg, block_height) = memo_message(client, data, &keypair.pubkey(), opts).await?;
+    let txn = VersionedTransaction::try_new(msg, &[keypair])?;
+    Ok((txn, block_height))
 }

--- a/helium-lib/src/message.rs
+++ b/helium-lib/src/message.rs
@@ -1,0 +1,56 @@
+use crate::{
+    client::SolanaRpcClient,
+    keypair::pubkey,
+    solana_sdk::{
+        address_lookup_table::{state::AddressLookupTable, AddressLookupTableAccount},
+        instruction::Instruction,
+        message::v0,
+    },
+    Error, Pubkey,
+};
+
+pub const COMMON_LUT_DEVNET: Pubkey = pubkey!("FnqYkQ6ZKnVKdkvYCGsEeiP5qgGqVbcFUkGduy2ta4gA");
+pub const COMMON_LUT: Pubkey = pubkey!("43eY9L2spbM2b1MPDFFBStUiFGt29ziZ1nc1xbpzsfVt");
+
+pub use solana_sdk::message::VersionedMessage;
+
+pub async fn get_lut_accounts<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    addresses: &[Pubkey],
+) -> Result<Vec<AddressLookupTableAccount>, Error> {
+    use futures::{stream, StreamExt, TryStreamExt};
+    let solana_client = AsRef::<SolanaRpcClient>::as_ref(client);
+    stream::iter(addresses)
+        .map(Ok)
+        .map_ok(|address| async move {
+            let raw = solana_client.get_account(address).await?;
+            let lut = AddressLookupTable::deserialize(&raw.data).map_err(Error::from)?;
+            Ok(AddressLookupTableAccount {
+                key: *address,
+                addresses: lut.addresses.to_vec(),
+            })
+        })
+        .try_buffered(addresses.len().min(5))
+        .try_collect()
+        .await
+}
+
+pub async fn mk_message<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    ixs: &[Instruction],
+    lut_accounts: &[Pubkey],
+    payer: &Pubkey,
+) -> Result<(VersionedMessage, u64), Error> {
+    let solana_client = AsRef::<SolanaRpcClient>::as_ref(client);
+    let lut_accounts = get_lut_accounts(client, lut_accounts).await?;
+    let (recent_blockhash, recent_blockheight) = solana_client
+        .get_latest_blockhash_with_commitment(solana_client.commitment())
+        .await?;
+    let msg = VersionedMessage::V0(v0::Message::try_compile(
+        payer,
+        ixs,
+        &lut_accounts,
+        recent_blockhash,
+    )?);
+    Ok((msg, recent_blockheight))
+}

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -7,14 +7,18 @@ use crate::{
     error::{DecodeError, EncodeError, Error},
     helium_entity_manager,
     keypair::{Keypair, Pubkey},
-    kta, lazy_distributor, mk_transaction_with_blockhash, priority_fee,
+    kta, lazy_distributor, message, mk_transaction_with_blockhash, priority_fee,
     programs::SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
     rewards_oracle,
-    solana_sdk::{instruction::Instruction, transaction::Transaction},
+    solana_client::rpc_client::SerializableTransaction,
+    solana_sdk::{
+        instruction::Instruction,
+        signer::Signer,
+        transaction::{Transaction, VersionedTransaction},
+    },
     token::{Token, TokenAmount},
     TransactionOpts,
 };
-use anchor_client::solana_client::rpc_client::SerializableTransaction;
 use chrono::Utc;
 use futures::{
     stream::{self, StreamExt, TryStreamExt},
@@ -22,7 +26,6 @@ use futures::{
 };
 use itertools::{izip, Itertools};
 use serde::{Deserialize, Serialize};
-use solana_sdk::signer::Signer;
 use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Clone)]
@@ -198,11 +201,15 @@ pub async fn distribute_rewards_instruction<C: AsRef<DasClient> + GetAnchorAccou
     client: &C,
     token: ClaimableToken,
     kta: &helium_entity_manager::KeyToAssetV0,
+    _recipient: &Pubkey,
     asset: &asset::Asset,
     asset_proof: &asset::AssetProof,
     payer: Pubkey,
 ) -> Result<Instruction, Error> {
     let ld_account = lazy_distributor(client, token).await?;
+    // TODO: Use recipient.destination != Pubkey::default() to construct
+    // a a custom distribute rewards v0 once it's exported from the
+    // lazy-distributor IDL
     let accounts = lazy_distributor::accounts::DistributeCompressionRewardsV0 {
         DistributeCompressionRewardsV0common:
             lazy_distributor::accounts::DistributeCompressionRewardsV0Common {
@@ -249,7 +256,7 @@ pub async fn claim<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccou
     encoded_entity_key: &entity_key::EncodedEntityKey,
     keypair: &Keypair,
     opts: &TransactionOpts,
-) -> Result<Option<(Transaction, u64)>, Error> {
+) -> Result<Option<(VersionedTransaction, u64)>, Error> {
     let Some((mut txn, block_height)) = claim_transaction(
         client,
         token,
@@ -264,7 +271,7 @@ pub async fn claim<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccou
     };
 
     txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
-    Ok(Some((txn, block_height)))
+    Ok(Some((txn.into(), block_height)))
 }
 
 pub async fn claim_transaction<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
@@ -312,16 +319,29 @@ pub async fn claim_transaction<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + Ge
     let kta = kta::for_entity_key(&entity_key).await?;
     let (asset, asset_proof) = asset::for_kta_with_proof(client, &kta).await?;
 
-    let (init_ix, init_budget) = if recipient::for_kta(client, token, &kta).await?.is_none() {
-        let ix = recipient::init_instruction(token, &kta, &asset, &asset_proof, payer).await?;
-        (Some(ix), recipient::INIT_INSTRUCTION_BUDGET)
-    } else {
-        (None, 1)
-    };
+    let (init_ix, init_budget, recipient) =
+        if let Some(recipient) = recipient::for_kta(client, token, &kta).await? {
+            (None, 1, recipient.destination)
+        } else {
+            let ix = recipient::init_instruction(token, &kta, &asset, &asset_proof, payer).await?;
+            (
+                Some(ix),
+                recipient::INIT_INSTRUCTION_BUDGET,
+                Pubkey::default(),
+            )
+        };
     let set_current_ix =
         set_current_rewards_instruction(token, kta_key, &kta, &lifetime_rewards).await?;
-    let distribute_ix =
-        distribute_rewards_instruction(client, token, &kta, &asset, &asset_proof, *payer).await?;
+    let distribute_ix = distribute_rewards_instruction(
+        client,
+        token,
+        &kta,
+        &recipient,
+        &asset,
+        &asset_proof,
+        *payer,
+    )
+    .await?;
     let mut ixs_accounts = vec![];
     if let Some(ix) = &init_ix {
         ixs_accounts.extend_from_slice(&ix.accounts);
@@ -576,17 +596,17 @@ pub mod recipient {
 
     pub const INIT_INSTRUCTION_BUDGET: u32 = 150_000;
 
-    pub async fn init<E: AsEntityKey, C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
+    pub async fn init_message<E: AsEntityKey, C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
         client: &C,
         token: ClaimableToken,
         entity_key: &E,
-        keypair: &Keypair,
+        payer: &Pubkey,
         opts: &TransactionOpts,
-    ) -> Result<(Transaction, u64), Error> {
+    ) -> Result<(message::VersionedMessage, u64), Error> {
         let kta = kta::for_entity_key(entity_key).await?;
         let (asset, asset_proof) = asset::for_kta_with_proof(client, &kta).await?;
 
-        let ix = init_instruction(token, &kta, &asset, &asset_proof, &keypair.pubkey()).await?;
+        let ix = init_instruction(token, &kta, &asset, &asset_proof, payer).await?;
         let ixs = &[
             priority_fee::compute_budget_instruction(INIT_INSTRUCTION_BUDGET),
             priority_fee::compute_price_instruction_for_accounts(
@@ -597,9 +617,19 @@ pub mod recipient {
             .await?,
             ix,
         ];
-        let (mut txn, block_height) =
-            mk_transaction_with_blockhash(client, ixs, &keypair.pubkey()).await?;
-        txn.try_sign(&[keypair], *txn.get_recent_blockhash())?;
+        message::mk_message(client, ixs, &opts.lut_addresses, payer).await
+    }
+
+    pub async fn init<E: AsEntityKey, C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
+        client: &C,
+        token: ClaimableToken,
+        entity_key: &E,
+        keypair: &Keypair,
+        opts: &TransactionOpts,
+    ) -> Result<(VersionedTransaction, u64), Error> {
+        let (msg, block_height) =
+            init_message(client, token, entity_key, &keypair.pubkey(), opts).await?;
+        let txn = VersionedTransaction::try_new(msg, &[keypair])?;
         Ok((txn, block_height))
     }
 }

--- a/helium-wallet/src/cmd/assets/burn.rs
+++ b/helium-wallet/src/cmd/assets/burn.rs
@@ -24,10 +24,10 @@ impl Cmd {
             &client,
             &asset.id,
             &keypair,
-            &self.commit.transaction_opts(),
+            &self.commit.transaction_opts(&client),
         )
         .await?;
 
-        print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
+        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/assets/rewards.rs
+++ b/helium-wallet/src/cmd/assets/rewards.rs
@@ -55,7 +55,7 @@ impl ClaimCmd {
         let password = get_wallet_password(false)?;
         let keypair = opts.load_keypair(password.as_bytes())?;
         let client = opts.client()?;
-        let transaction_opts = self.commit.transaction_opts();
+        let transaction_opts = self.commit.transaction_opts(&client);
 
         let token_amount = self
             .amount
@@ -75,7 +75,7 @@ impl ClaimCmd {
 
         let claim_response = self
             .commit
-            .maybe_commit(&tx, &client)
+            .maybe_commit(tx, &client)
             .await
             .context("while claiming rewards")?;
         print_json(&claim_response.to_json())

--- a/helium-wallet/src/cmd/burn.rs
+++ b/helium-wallet/src/cmd/burn.rs
@@ -18,9 +18,10 @@ impl Cmd {
         let password = get_wallet_password(false)?;
         let keypair = opts.load_keypair(password.as_bytes())?;
         let client = opts.client()?;
+        let txn_opts = self.commit.transaction_opts(&client);
 
         let token_amount = token::TokenAmount::from_f64(self.subdao.token(), self.amount);
-        let (tx, _) = token::burn(&client, &token_amount, &keypair).await?;
-        print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
+        let (tx, _) = token::burn(&client, &token_amount, &keypair, &txn_opts).await?;
+        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/dc/burn.rs
+++ b/helium-wallet/src/cmd/dc/burn.rs
@@ -17,9 +17,9 @@ impl Cmd {
         let password = get_wallet_password(false)?;
         let keypair = opts.load_keypair(password.as_bytes())?;
         let client = opts.client()?;
-        let transaction_opts = self.commit.transaction_opts();
+        let transaction_opts = self.commit.transaction_opts(&client);
 
         let (tx, _) = dc::burn(&client, self.dc, &keypair, &transaction_opts).await?;
-        print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
+        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/dc/delegate.rs
+++ b/helium-wallet/src/cmd/dc/delegate.rs
@@ -24,7 +24,7 @@ impl Cmd {
         let keypair = opts.load_keypair(password.as_bytes())?;
 
         let client = opts.client()?;
-        let transaction_opts = self.commit.transaction_opts();
+        let transaction_opts = self.commit.transaction_opts(&client);
         let (tx, _) = dc::delegate(
             &client,
             self.subdao,
@@ -34,6 +34,6 @@ impl Cmd {
             &transaction_opts,
         )
         .await?;
-        print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
+        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/dc/mint.rs
+++ b/helium-wallet/src/cmd/dc/mint.rs
@@ -41,10 +41,10 @@ impl Cmd {
             (None, Some(dc)) => TokenAmount::from_u64(Token::Dc, dc),
             _ => return Err(anyhow!("Must specify either HNT or DC")),
         };
-        let transaction_opts = self.commit.transaction_opts();
+        let transaction_opts = self.commit.transaction_opts(&client);
 
         let keypair = wallet.decrypt(password.as_bytes())?;
         let (tx, _) = dc::mint(&client, amount, payee, &keypair, &transaction_opts).await?;
-        print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
+        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/hotspots/add.rs
+++ b/helium-wallet/src/cmd/hotspots/add.rs
@@ -105,13 +105,13 @@ async fn perform_add(
         "d" | "devnet" => VERIFIER_URL_DEVNET,
         url => url,
     };
-    let transaction_opts = &commit.transaction_opts();
+    let transaction_opts = &commit.transaction_opts(&client);
 
     if !hotspot_issued {
         let (tx, _) =
             hotspot::dataonly::issue(&client, verifier, &mut txn, &keypair, transaction_opts)
                 .await?;
-        let response = commit.maybe_commit(&tx, &client).await?;
+        let response = commit.maybe_commit(tx, &client).await?;
         print_json(&response.to_json())?;
     }
     // Only assert the Hotspot if either (a) it has already been issued before this cli
@@ -128,7 +128,7 @@ async fn perform_add(
             transaction_opts,
         )
         .await?;
-        print_json(&commit.maybe_commit(&tx, &client).await?.to_json())
+        print_json(&commit.maybe_commit(tx, &client).await?.to_json())
     } else {
         Ok(())
     }

--- a/helium-wallet/src/cmd/hotspots/burn.rs
+++ b/helium-wallet/src/cmd/hotspots/burn.rs
@@ -22,10 +22,10 @@ impl Cmd {
             &client,
             &self.address,
             &keypair,
-            &self.commit.transaction_opts(),
+            &self.commit.transaction_opts(&client),
         )
         .await?;
 
-        print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
+        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/hotspots/transfer.rs
+++ b/helium-wallet/src/cmd/hotspots/transfer.rs
@@ -24,7 +24,7 @@ impl Cmd {
             bail!("recipient already owner of hotspot");
         }
         let client = opts.client()?;
-        let transaction_opts = self.commit.transaction_opts();
+        let transaction_opts = self.commit.transaction_opts(&client);
         let (tx, _) = hotspot::transfer(
             &client,
             &self.address,
@@ -33,6 +33,6 @@ impl Cmd {
             &transaction_opts,
         )
         .await?;
-        print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
+        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/hotspots/update.rs
+++ b/helium-wallet/src/cmd/hotspots/update.rs
@@ -79,7 +79,7 @@ impl Cmd {
             .set_geo(self.lat, self.lon)?;
 
         let client = opts.client()?;
-        let transaction_opts = self.commit.transaction_opts();
+        let transaction_opts = self.commit.transaction_opts(&client);
         let tx = hotspot::update(
             &client,
             server,
@@ -90,6 +90,6 @@ impl Cmd {
         )
         .await?;
 
-        print_json(&self.commit.maybe_commit(&tx, &client).await.to_json())
+        print_json(&self.commit.maybe_commit(tx, &client).await.to_json())
     }
 }

--- a/helium-wallet/src/cmd/memo.rs
+++ b/helium-wallet/src/cmd/memo.rs
@@ -18,9 +18,9 @@ impl Cmd {
         let wallet = opts.load_wallet()?;
         let keypair = wallet.decrypt(password.as_bytes())?;
         let client = opts.client()?;
-        let transaction_opts = self.commit.transaction_opts();
+        let transaction_opts = self.commit.transaction_opts(&client);
         let (tx, _) =
             helium_lib::memo::memo(&client, &self.message, &keypair, &transaction_opts).await?;
-        print_json(&self.commit.maybe_commit(&tx, &client).await?.to_json())
+        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -3,13 +3,15 @@ use crate::{
     wallet::Wallet,
 };
 use helium_lib::{
-    b64, client,
+    b64,
+    client::{self, SolanaRpcClient},
     keypair::Keypair,
-    priority_fee,
+    message, priority_fee,
     solana_client::{
         self, rpc_config::RpcSendTransactionConfig, rpc_request::RpcResponseErrorData,
         rpc_response::RpcSimulateTransactionResult,
     },
+    solana_sdk::transaction::VersionedTransaction,
     TransactionOpts,
 };
 use serde_json::json;
@@ -96,9 +98,9 @@ pub struct CommitOpts {
 }
 
 impl CommitOpts {
-    pub async fn maybe_commit<C: AsRef<client::SolanaRpcClient>>(
+    pub async fn maybe_commit<C: AsRef<client::SolanaRpcClient>, T: Into<VersionedTransaction>>(
         &self,
-        tx: &helium_lib::solana_sdk::transaction::Transaction,
+        tx: T,
         client: &C,
     ) -> Result<CommitResponse> {
         fn context_err(client_err: solana_client::client_error::ClientError) -> Error {
@@ -130,6 +132,7 @@ impl CommitOpts {
             mapped
         }
 
+        let versioned_tx = tx.into();
         if self.commit {
             let config = RpcSendTransactionConfig {
                 skip_preflight: self.skip_preflight,
@@ -137,14 +140,14 @@ impl CommitOpts {
             };
             client
                 .as_ref()
-                .send_transaction_with_config(tx, config)
+                .send_transaction_with_config(&versioned_tx, config)
                 .await
                 .map(Into::into)
                 .map_err(context_err)
         } else {
             client
                 .as_ref()
-                .simulate_transaction(tx)
+                .simulate_transaction(&versioned_tx)
                 .await
                 .map_err(context_err)?
                 .value
@@ -152,9 +155,14 @@ impl CommitOpts {
         }
     }
 
-    pub fn transaction_opts(&self) -> TransactionOpts {
+    pub fn transaction_opts<C: AsRef<SolanaRpcClient>>(&self, client: &C) -> TransactionOpts {
         TransactionOpts {
             min_priority_fee: self.min_priority_fee,
+            lut_addresses: if client::is_devnet(&client.as_ref().url()) {
+                vec![message::COMMON_LUT_DEVNET]
+            } else {
+                vec![message::COMMON_LUT]
+            },
         }
     }
 }

--- a/helium-wallet/src/cmd/transfer.rs
+++ b/helium-wallet/src/cmd/transfer.rs
@@ -86,11 +86,12 @@ impl PayCmd {
         let payments = self.collect_payments()?;
         let password = get_wallet_password(false)?;
         let keypair = opts.load_keypair(password.as_bytes())?;
-
         let client = opts.client()?;
-        let (tx, _) = token::transfer(&client, &payments, &keypair).await?;
+        let txn_opts = self.commit().transaction_opts(&client);
 
-        print_json(&self.commit().maybe_commit(&tx, &client).await?.to_json())
+        let (tx, _) = token::transfer(&client, &payments, &keypair, &txn_opts).await?;
+
+        print_json(&self.commit().maybe_commit(tx, &client).await?.to_json())
     }
 
     fn collect_payments(&self) -> Result<Vec<(Pubkey, TokenAmount)>> {


### PR DESCRIPTION
Note that this excludes claiming and onboarding txns in this PR:

* claiming requires an update to helium_anchor_gen to make CustomDesitination args public
* both claming and onboarding require non versioned txns to be sent to a signing oracle.