### PR TITLE
burning delegate dc take router key as String

### DIFF
--- a/helium-lib/src/dao.rs
+++ b/helium-lib/src/dao.rs
@@ -156,8 +156,8 @@ impl SubDao {
         }
     }
 
-    pub fn delegated_dc_key(&self, router_key: &str) -> Pubkey {
-        let hash = Sha256::digest(router_key);
+    pub fn delegated_dc_key<E: AsEntityKey>(&self, router_key: &E) -> Pubkey {
+        let hash = Sha256::digest(router_key.as_entity_key());
         let (key, _) = Pubkey::find_program_address(
             &[b"delegated_data_credits", self.key().as_ref(), &hash],
             &data_credits::id(),

--- a/helium-lib/src/dc.rs
+++ b/helium-lib/src/dc.rs
@@ -225,17 +225,17 @@ pub async fn burn_delegated_message<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     client: &C,
     sub_dao: SubDao,
     amount: u64,
-    router_key: E,
+    router_key: &E,
     payer: &Pubkey,
     opts: &TransactionOpts,
 ) -> Result<(message::VersionedMessage, u64), Error> {
     fn mk_accounts<E: AsEntityKey>(
         sub_dao: SubDao,
-        router_key: E,
+        router_key: &E,
         dc_burn_authority: Pubkey,
         registrar: Pubkey,
     ) -> BurnDelegatedDataCreditsV0 {
-        let delegated_data_credits = sub_dao.delegated_dc_key(&router_key);
+        let delegated_data_credits = sub_dao.delegated_dc_key(router_key);
         let escrow_account = sub_dao.escrow_key(&delegated_data_credits);
 
         BurnDelegatedDataCreditsV0 {
@@ -296,7 +296,7 @@ pub async fn burn_delegated<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     sub_dao: SubDao,
     keypair: &Keypair,
     amount: u64,
-    router_key: E,
+    router_key: &E,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (msg, block_height) =

--- a/helium-lib/src/dc.rs
+++ b/helium-lib/src/dc.rs
@@ -225,17 +225,17 @@ pub async fn burn_delegated_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     sub_dao: SubDao,
     amount: u64,
-    router_key: Pubkey,
+    router_key: String,
     payer: &Pubkey,
     opts: &TransactionOpts,
 ) -> Result<(message::VersionedMessage, u64), Error> {
     fn mk_accounts(
         sub_dao: SubDao,
-        router_key: Pubkey,
+        router_key: String,
         dc_burn_authority: Pubkey,
         registrar: Pubkey,
     ) -> BurnDelegatedDataCreditsV0 {
-        let delegated_data_credits = sub_dao.delegated_dc_key(&router_key.to_string());
+        let delegated_data_credits = sub_dao.delegated_dc_key(&router_key);
         let escrow_account = sub_dao.escrow_key(&delegated_data_credits);
 
         BurnDelegatedDataCreditsV0 {
@@ -296,7 +296,7 @@ pub async fn burn_delegated<C: AsRef<SolanaRpcClient>>(
     sub_dao: SubDao,
     keypair: &Keypair,
     amount: u64,
-    router_key: Pubkey,
+    router_key: String,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (msg, block_height) =

--- a/helium-lib/src/dc.rs
+++ b/helium-lib/src/dc.rs
@@ -1,10 +1,10 @@
 use crate::{
-    anchor_lang::AccountDeserialize,
-    anchor_lang::{InstructionData, ToAccountMetas},
+    anchor_lang::{AccountDeserialize, InstructionData, ToAccountMetas},
     anchor_spl, circuit_breaker,
     client::{GetAnchorAccount, SolanaRpcClient},
     dao::{Dao, SubDao},
     data_credits,
+    entity_key::AsEntityKey,
     error::{DecodeError, Error},
     keypair::{Keypair, Pubkey},
     message, priority_fee,
@@ -127,7 +127,7 @@ pub async fn delegate_message<C: AsRef<SolanaRpcClient>>(
         }
     }
 
-    let delegated_dc_key = subdao.delegated_dc_key(payer_key);
+    let delegated_dc_key = subdao.delegated_dc_key(&payer_key);
     let ix = Instruction {
         program_id: data_credits::id(),
         accounts: mk_accounts(delegated_dc_key, subdao, *owner).to_account_metas(None),
@@ -221,17 +221,17 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
-pub async fn burn_delegated_message<C: AsRef<SolanaRpcClient>>(
+pub async fn burn_delegated_message<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     client: &C,
     sub_dao: SubDao,
     amount: u64,
-    router_key: String,
+    router_key: E,
     payer: &Pubkey,
     opts: &TransactionOpts,
 ) -> Result<(message::VersionedMessage, u64), Error> {
-    fn mk_accounts(
+    fn mk_accounts<E: AsEntityKey>(
         sub_dao: SubDao,
-        router_key: String,
+        router_key: E,
         dc_burn_authority: Pubkey,
         registrar: Pubkey,
     ) -> BurnDelegatedDataCreditsV0 {
@@ -291,12 +291,12 @@ pub async fn burn_delegated_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, ixs, &opts.lut_addresses, payer).await
 }
 
-pub async fn burn_delegated<C: AsRef<SolanaRpcClient>>(
+pub async fn burn_delegated<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     client: &C,
     sub_dao: SubDao,
     keypair: &Keypair,
     amount: u64,
-    router_key: String,
+    router_key: E,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (msg, block_height) =

--- a/helium-lib/src/entity_key.rs
+++ b/helium-lib/src/entity_key.rs
@@ -39,6 +39,12 @@ impl AsEntityKey for helium_crypto::PublicKey {
     }
 }
 
+impl AsEntityKey for helium_crypto::PublicKeyBinary {
+    fn as_entity_key(&self) -> Vec<u8> {
+        self.clone().into()
+    }
+}
+
 pub use helium_anchor_gen::helium_entity_manager::KeySerialization;
 
 pub fn from_str(str: &str, encoding: KeySerialization) -> Result<Vec<u8>, DecodeError> {

--- a/helium-lib/src/entity_key.rs
+++ b/helium-lib/src/entity_key.rs
@@ -41,7 +41,7 @@ impl AsEntityKey for helium_crypto::PublicKey {
 
 impl AsEntityKey for helium_crypto::PublicKeyBinary {
     fn as_entity_key(&self) -> Vec<u8> {
-        self.clone().into()
+        self.to_string().as_entity_key()
     }
 }
 

--- a/helium-lib/src/keypair.rs
+++ b/helium-lib/src/keypair.rs
@@ -99,6 +99,12 @@ impl TryFrom<&[u8; 64]> for Keypair {
     }
 }
 
+impl From<solana_sdk::signer::keypair::Keypair> for Keypair {
+    fn from(value: solana_sdk::signer::keypair::Keypair) -> Self {
+        Self(value)
+    }
+}
+
 impl Keypair {
     pub fn generate() -> Self {
         Keypair(solana_sdk::signer::keypair::Keypair::new())


### PR DESCRIPTION
Oracles PR :: https://github.com/helium/helium-wallet-rs/pull/457

ecc_compact keys cannot be turned into solana pubkeys, but they can still be used to derive escrow accounts.