### PR TITLE
bump pyth, rewards token default, clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ version = "0.31.1"
 source = "git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey#1dfe80386037379325c30095dcdb51e152c1e3c5"
 dependencies = [
  "anchor-syn",
- "borsh-derive-internal 0.10.4",
+ "borsh-derive-internal",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -913,22 +913,12 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
-dependencies = [
- "borsh-derive 0.9.3",
- "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "borsh"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -943,25 +933,12 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
-dependencies = [
- "borsh-derive-internal 0.9.3",
- "borsh-schema-derive-internal 0.9.3",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831213f80d9423998dd696e2c5345aba6be7a0bd8cd19e31c5243e13df1cef89"
 dependencies = [
- "borsh-derive-internal 0.10.4",
- "borsh-schema-derive-internal 0.10.4",
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
@@ -982,31 +959,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65d6ba50644c98714aa2a70d13d7df3cd75cd2b523a2b452bf010443800976b3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1794,12 +1749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
-
-[[package]]
 name = "eager"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2353,15 +2302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.8",
 ]
 
 [[package]]
@@ -3481,7 +3421,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -3924,22 +3864,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyth-sdk"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c805ba3dfb5b7ed6a8ffa62ec38391f485a79c7cf6b3b11d3bd44fb0325824"
-dependencies = [
- "borsh 0.9.3",
- "borsh-derive 0.9.3",
- "hex",
- "schemars",
- "serde",
-]
-
-[[package]]
 name = "pyth-solana-receiver-sdk"
-version = "0.6.0"
-source = "git+https://github.com/madninja/pyth-crosschain.git?branch=madninja%2Ffix_solana#60835e87dd14f690f7470e297db92053846822ae"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb47105ed00f2ac09d9a297b5e4e1879981324d8633a177c4d6b0958a5a63d7b"
 dependencies = [
  "anchor-lang",
  "bytemuck_derive",
@@ -3951,7 +3879,8 @@ dependencies = [
 [[package]]
 name = "pythnet-sdk"
 version = "2.3.1"
-source = "git+https://github.com/madninja/pyth-crosschain.git?branch=madninja%2Ffix_solana#60835e87dd14f690f7470e297db92053846822ae"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498d20fd330277697aaee92f341bdabdb4695b10e05f054157a18ad8b7746a17"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -3960,7 +3889,6 @@ dependencies = [
  "byteorder",
  "fast-math",
  "hex",
- "pyth-sdk",
  "rustc_version",
  "serde",
  "sha3",
@@ -4614,30 +4542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4745,17 +4649,6 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/helium-lib/Cargo.toml
+++ b/helium-lib/Cargo.toml
@@ -37,7 +37,7 @@ reqwest = { version = "0.11", default-features = false, features = [
 spl-associated-token-account = { version = "6", features = ["no-entrypoint"] }
 spl-memo = "6"
 tonic = { version = "0.10", features = ["tls", "tls-roots"] }
-pyth-solana-receiver-sdk = { git = "https://github.com/madninja/pyth-crosschain.git", branch = "madninja/fix_solana" }
+pyth-solana-receiver-sdk = "^0.6"
 serde = { workspace = true }
 serde_json = { workspace = true }
 lazy_static = "1"

--- a/helium-lib/src/entity_key.rs
+++ b/helium-lib/src/entity_key.rs
@@ -51,7 +51,7 @@ pub fn from_str(str: &str, encoding: KeySerialization) -> Result<Vec<u8>, Decode
         KeySerialization::UTF8 => str.as_entity_key(),
         KeySerialization::B58 => bs58::decode(str)
             .into_vec()
-            .map_err(|_| DecodeError::other(format!("invalid entity key {}", str)))?,
+            .map_err(|_| DecodeError::other(format!("invalid entity key {str}")))?,
     };
     Ok(entity_key)
 }

--- a/helium-lib/src/hotspot/dataonly.rs
+++ b/helium-lib/src/hotspot/dataonly.rs
@@ -423,7 +423,7 @@ async fn verify_helium_key(
     let client = reqwest::Client::new();
     let serialized_tx = hex::encode(bincode::serialize(&tx).map_err(EncodeError::from)?);
     let response = client
-        .post(format!("{}/verify", verifier))
+        .post(format!("{verifier}/verify"))
         .json(&VerifyRequest {
             transaction: &serialized_tx,
             msg: &hex::encode(msg),

--- a/helium-lib/src/onboarding.rs
+++ b/helium-lib/src/onboarding.rs
@@ -20,7 +20,7 @@ impl Client {
     where
         T: 'static + DeserializeOwned + Send,
     {
-        let url = format!("{}{}", &self.base_url, path);
+        let url = format!("{}{path}", &self.base_url);
         let resp = self.inner.get(&url).send().await?;
         let onboarding_resp = resp.json::<OnboardingResponse<T>>().await?;
         if !onboarding_resp.success {
@@ -34,7 +34,7 @@ impl Client {
         T: 'static + DeserializeOwned + Send,
         P: Serialize + ?Sized,
     {
-        let url = format!("{}{}", &self.base_url, path);
+        let url = format!("{}{path}", &self.base_url);
         let resp = self.inner.post(&url).json(&params).send().await?;
         let onboarding_resp = resp.json::<OnboardingResponse<T>>().await?;
         if !onboarding_resp.success {
@@ -47,7 +47,7 @@ impl Client {
         &self,
         hotspot: &helium_crypto::PublicKey,
     ) -> Result<Hotspot, OnboardingError> {
-        self.get::<Hotspot>(&format!("/hotspots/{}", hotspot)).await
+        self.get::<Hotspot>(&format!("/hotspots/{hotspot}")).await
     }
 
     pub async fn get_update_txn(

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -21,7 +21,7 @@ use chrono::Utc;
 use futures::{stream, StreamExt, TryFutureExt, TryStreamExt};
 use itertools::{izip, Itertools};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 #[derive(Debug, Serialize, Clone)]
 pub struct Oracle {
@@ -46,13 +46,27 @@ pub struct OracleReward {
     pub reward: TokenAmount,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize, Default,
+)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "lowercase")]
 pub enum ClaimableToken {
     Iot,
     Mobile,
+    #[default]
     Hnt,
+}
+
+impl Display for ClaimableToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            Self::Iot => "iot",
+            Self::Mobile => "mobile",
+            Self::Hnt => "hnt",
+        };
+        f.write_str(str)
+    }
 }
 
 impl From<ClaimableToken> for Token {

--- a/helium-wallet/src/cmd/assets/rewards.rs
+++ b/helium-wallet/src/cmd/assets/rewards.rs
@@ -39,6 +39,7 @@ impl RewardsCommand {
 #[derive(Debug, Clone, clap::Args)]
 pub struct ClaimCmd {
     /// Token for command
+    #[clap(long, default_value_t)]
     pub token: ClaimableToken,
     #[clap(flatten)]
     pub entity_key: entity_key::EncodedEntityKey,
@@ -88,6 +89,7 @@ impl ClaimCmd {
 #[derive(Debug, Clone, clap::Args)]
 pub struct RecipientCmd {
     /// Token for command
+    #[clap(long, default_value_t)]
     pub token: ClaimableToken,
     /// The asset to get or set the reward recipient for
     #[clap(flatten)]
@@ -139,6 +141,7 @@ impl RecipientCmd {
 /// decayed amount bed on previous claims
 pub struct MaxClaimCmd {
     /// Token for command
+    #[clap(long, default_value_t)]
     token: ClaimableToken,
 }
 
@@ -154,6 +157,7 @@ impl MaxClaimCmd {
 /// List claimable pending rewards for a given asset
 pub struct PendingCmd {
     /// Token for command
+    #[clap(long, default_value_t)]
     token: ClaimableToken,
     #[clap(flatten)]
     entity_key: entity_key::EncodedEntityKey,
@@ -174,6 +178,7 @@ impl PendingCmd {
 /// This includes both claimed and unclaimed rewards
 pub struct LifetimeCmd {
     /// Token for command
+    #[clap(long, default_value_t)]
     token: ClaimableToken,
     #[clap(flatten)]
     entity_key: entity_key::EncodedEntityKey,

--- a/helium-wallet/src/cmd/hotspots/rewards.rs
+++ b/helium-wallet/src/cmd/hotspots/rewards.rs
@@ -56,6 +56,7 @@ async fn collect_hotspots<C: AsRef<DasClient>>(
 /// List pending rewards for given Hotspots
 pub struct PendingCmd {
     /// Token for command
+    #[clap(long, default_value_t)]
     token: reward::ClaimableToken,
     /// Hotspots to lookup
     hotspots: Option<Vec<helium_crypto::PublicKey>>,
@@ -87,6 +88,7 @@ impl PendingCmd {
 /// This includes both claimed and unclaimed rewards
 pub struct LifetimeCmd {
     /// Token for command
+    #[clap(long, default_value_t)]
     token: reward::ClaimableToken,
     /// Hotspots to lookup
     hotspots: Option<Vec<helium_crypto::PublicKey>>,
@@ -116,6 +118,7 @@ impl LifetimeCmd {
 /// Claim rewards for one or all Hotspots in a wallet
 pub struct ClaimCmd {
     /// Token for command
+    #[clap(long, default_value_t)]
     token: reward::ClaimableToken,
     /// Hotspot public key to send claim for
     hotspot: helium_crypto::PublicKey,
@@ -151,6 +154,7 @@ impl ClaimCmd {
 #[derive(Debug, Clone, clap::Args)]
 pub struct RecipientCmd {
     /// Token for command
+    #[clap(long, default_value_t)]
     pub token: reward::ClaimableToken,
     /// The hotspot to get or set the reward recipient for
     pub hotspot: helium_crypto::PublicKey,


### PR DESCRIPTION
* Makes the hotspots rewards and assets rewards commands “token” argument an optional long argument with hnt as the default
* Bump pyth since they applied our patch
* Pacify nightly clippy
