### PR TITLE
Oracles update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,10 +402,12 @@ dependencies = [
 
 [[package]]
 name = "angry-purple-tiger"
-version = "0.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c749eb8b90a5c85a879ac35bba5374ba18ff41d609878d7d37dd2ac0122a3c"
+checksum = "7556be6f2b0d82376c1ece1fda4dffd728816ac53bee2c285f3f74269ddc4a97"
 dependencies = [
+ "anyhow",
+ "clap",
  "md5",
 ]
 

--- a/helium-lib/Cargo.toml
+++ b/helium-lib/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = { workspace = true }
 lazy_static = "1"
 rust_decimal = { workspace = true }
 helium-proto = { workspace = true }
-angry-purple-tiger = "0"
+angry-purple-tiger = "1"
 sha2 = { workspace = true }
 clap = { workspace = true, optional = true }
 helium-mnemonic = { path = "../helium-mnemonic", optional = true }

--- a/helium-lib/src/programs.rs
+++ b/helium-lib/src/programs.rs
@@ -15,3 +15,5 @@ declare_program!(hexboosting);
 declare_program!(rewards_oracle);
 declare_program!(spl_account_compression);
 declare_program!(bubblegum);
+declare_program!(mobile_entity_manager);
+declare_program!(price_oracle);


### PR DESCRIPTION
- Update `angry-purple-tiger` to use the same `helium-crypto@0.9` `PublicKeyBinary`.
- Export `mobile_entity_manager` and `price_oracle`