### PR TITLE
update sqlx 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,8 +2362,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helium-crypto"
-version = "0.9.0"
-source = "git+https://github.com/helium/helium-crypto-rs?branch=jg%2Fsqlx-update#3a3747d05bd928c26d98380c2f40833e8e6edf3f"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688f69ca15100f29ce9ab8ee7c5701afeabf8c8b003b0b85b06249159ffc953b"
 dependencies = [
  "base64 0.21.7",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,10 +2363,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helium-crypto"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333dfb5467550fdd77fc6f419a725775ef909746250d3519138a2ddcb08a73d7"
+source = "git+https://github.com/helium/helium-crypto-rs?branch=jg%2Fsqlx-update#3a3747d05bd928c26d98380c2f40833e8e6edf3f"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "bs58",
  "byteorder",
  "ed25519-compact",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0", features = ["serde"] }
 serde = "1"
 serde_json = "1"
 rust_decimal = { version = "1", features = ["serde-float"] }
-helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", branch = "jg/sqlx-update" }
+helium-crypto = { version = "0.9" }
 helium-proto = { git = "https://github.com/helium/proto", branch = "master", features = [
   "services",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0", features = ["serde"] }
 serde = "1"
 serde_json = "1"
 rust_decimal = { version = "1", features = ["serde-float"] }
-helium-crypto = { version = "0.9" }
+helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", branch = "jg/sqlx-update" }
 helium-proto = { git = "https://github.com/helium/proto", branch = "master", features = [
   "services",
 ] }


### PR DESCRIPTION
transitive update to pull in the enforced update to sqlx-postgres 0.8 support in the postgres feature of helium-crypto