### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/helium-wallet/src/cmd/assets/rewards.rs
+++ b/helium-wallet/src/cmd/assets/rewards.rs
@@ -85,7 +85,7 @@ impl ClaimCmd {
     }
 }
 
-/// Get or set the the recipient for rewards
+/// Get or set the recipient for rewards
 #[derive(Debug, Clone, clap::Args)]
 pub struct RecipientCmd {
     /// Token for command

--- a/helium-wallet/src/cmd/hotspots/rewards.rs
+++ b/helium-wallet/src/cmd/hotspots/rewards.rs
@@ -148,7 +148,7 @@ impl ClaimCmd {
     }
 }
 
-/// Get or set the the recipient for hotspot rewards
+/// Get or set the recipient for hotspot rewards
 #[derive(Debug, Clone, clap::Args)]
 pub struct RecipientCmd {
     /// Token for command


### PR DESCRIPTION
remove redundant word in comment