### PR TITLE
feat: add Jupiter V6 swap support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,6 +2391,7 @@ dependencies = [
  "chrono",
  "clap",
  "dialoguer",
+ "futures",
  "helium-crypto",
  "helium-lib",
  "helium-mnemonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ helium-proto = { git = "https://github.com/helium/proto", branch = "master", fea
 ] }
 clap = { version = "4", features = ["derive"] }
 thiserror = "2.0.17"
+futures = "0"
 prost = "0.14.1"
 msg-signature = { git = "https://github.com/helium/proto", branch = "master" }
 

--- a/helium-lib/Cargo.toml
+++ b/helium-lib/Cargo.toml
@@ -26,7 +26,7 @@ h3o = { version = "0", features = ["serde"] }
 helium-crypto = { workspace = true }
 itertools = "0.14"
 jsonrpc_client = { version = "0.7", features = ["reqwest"] }
-futures = "*"
+futures.workspace = true
 futures-timer = "3"
 tracing = "0"
 base64 = { workspace = true }

--- a/helium-lib/src/error.rs
+++ b/helium-lib/src/error.rs
@@ -1,4 +1,6 @@
-use crate::{anchor_client, anchor_lang, client, hotspot::cert, onboarding, solana_client, token};
+use crate::{
+    anchor_client, anchor_lang, client, hotspot::cert, jupiter, onboarding, solana_client, token,
+};
 use solana_sdk::signature::Signature;
 use std::{array::TryFromSliceError, num::TryFromIntError, time::Duration};
 use thiserror::Error;
@@ -52,6 +54,8 @@ pub enum Error {
     Encode(#[from] EncodeError),
     #[error("tuktuk: {0}")]
     Tuktuk(#[from] tuktuk_sdk::error::Error),
+    #[error("jupiter: {0}")]
+    Jupiter(#[from] jupiter::JupiterError),
 }
 
 impl From<solana_client::client_error::ClientError> for Error {

--- a/helium-lib/src/jupiter.rs
+++ b/helium-lib/src/jupiter.rs
@@ -7,7 +7,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde::{Deserialize, Serialize};
 use solana_sdk::signer::Signer;
 
-pub const DEFAULT_API_URL: &str = "https://api.jup.ag/swap/v6";
+pub const DEFAULT_API_URL: &str = "https://api.jup.ag/swap/v2";
 pub const DEFAULT_SLIPPAGE_BPS: u16 = 100;
 const MAX_ERROR_BODY_LEN: usize = 200;
 
@@ -17,6 +17,8 @@ pub enum JupiterError {
     Request(#[from] reqwest::Error),
     #[error("Jupiter API error (HTTP {status}): {message}")]
     Api { status: u16, message: String },
+    #[error("Jupiter swap error: {0}")]
+    SwapError(String),
     #[error("Jupiter quote returned no routes for {input_mint} → {output_mint}")]
     NoRoutes {
         input_mint: String,
@@ -50,7 +52,9 @@ impl JupiterError {
     }
 
     fn api(status: u16, body: String) -> Self {
-        let message = if body.len() > MAX_ERROR_BODY_LEN {
+        let message = if body.is_empty() {
+            format!("empty response (HTTP {status})")
+        } else if body.len() > MAX_ERROR_BODY_LEN {
             format!("{}…", &body[..MAX_ERROR_BODY_LEN])
         } else {
             body
@@ -59,7 +63,7 @@ impl JupiterError {
     }
 }
 
-/// Jupiter V6 swap API client.
+/// Jupiter swap API client (V2).
 ///
 /// Works with or without an API key:
 /// - Without key: keyless access at 0.5 RPS (suitable for CLI use)
@@ -108,7 +112,7 @@ impl Client {
     /// Create a client from environment variables.
     ///
     /// `JUP_API_KEY` is optional — omit for keyless access (0.5 RPS).
-    /// `JUP_API_URL` defaults to `https://api.jup.ag/swap/v6`.
+    /// `JUP_API_URL` defaults to `https://api.jup.ag/swap/v2`.
     /// `JUP_SLIPPAGE_BPS` defaults to 100 (1%).
     pub fn from_env() -> Result<Self, JupiterError> {
         let api_key = std::env::var("JUP_API_KEY").ok();
@@ -134,13 +138,19 @@ impl Client {
         }
     }
 
-    /// Get a swap quote from Jupiter.
-    pub async fn quote(
+    /// Get a swap order from Jupiter: quote + assembled transaction in one call.
+    ///
+    /// Returns an `OrderResponse` containing the quote data and a base64-encoded
+    /// transaction ready to be decoded, signed, and sent.
+    ///
+    /// The `taker` is the wallet public key that will sign and pay for the swap.
+    pub async fn order(
         &self,
         input_mint: &Pubkey,
         output_mint: &Pubkey,
         amount: u64,
-    ) -> Result<QuoteResponse, JupiterError> {
+        taker: &Pubkey,
+    ) -> Result<OrderResponse, JupiterError> {
         if amount == 0 {
             return Err(JupiterError::config(
                 "swap amount must be greater than zero",
@@ -152,25 +162,30 @@ impl Client {
             ));
         }
 
-        let url = format!("{}/quote", self.base_url);
+        let url = format!("{}/order", self.base_url);
         let req = self.client.get(&url).query(&[
             ("inputMint", input_mint.to_string()),
             ("outputMint", output_mint.to_string()),
             ("amount", amount.to_string()),
             ("slippageBps", self.slippage_bps.to_string()),
+            ("taker", taker.to_string()),
         ]);
         let resp = self.apply_auth(req).send().await?;
 
         match resp.status().as_u16() {
             200 => {
-                let quote: QuoteResponse = resp.json().await?;
-                if quote.route_plan.is_empty() {
+                let order: OrderResponse = resp.json().await?;
+                // Check for inline error from Jupiter
+                if let Some(error_msg) = &order.error_message {
+                    return Err(JupiterError::SwapError(error_msg.clone()));
+                }
+                if order.route_plan.is_empty() {
                     return Err(JupiterError::NoRoutes {
                         input_mint: input_mint.to_string(),
                         output_mint: output_mint.to_string(),
                     });
                 }
-                Ok(quote)
+                Ok(order)
             }
             status => {
                 let body = resp
@@ -182,48 +197,37 @@ impl Client {
         }
     }
 
-    /// Get a swap transaction from Jupiter, deserialize it, update the
-    /// blockhash, and sign with the provided keypair.
+    /// Get a swap order and build a signed transaction ready to send.
     ///
-    /// Returns a ready-to-send `VersionedTransaction` and the last valid
-    /// block height, matching the helium-lib convention for transaction
-    /// builders (`token::transfer`, `token::burn`, etc.).
+    /// Combines `order()` with transaction decoding, blockhash update, and signing.
+    /// Returns the signed transaction, last valid block height, and the order
+    /// response (for quote data like amounts, rate, price impact).
     ///
-    /// Note: the transaction's compute budget is set by Jupiter's
-    /// simulation — `TransactionOpts` is intentionally not accepted here,
-    /// unlike other helium-lib transaction builders.
+    /// Note: the transaction's compute budget is set by Jupiter's simulation —
+    /// `TransactionOpts` is intentionally not accepted here.
     pub async fn swap<C: AsRef<SolanaRpcClient>>(
         &self,
         client: &C,
-        quote: &QuoteResponse,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+        amount: u64,
         keypair: &Keypair,
-    ) -> Result<(VersionedTransaction, u64), JupiterError> {
-        let swap_request = SwapRequest {
-            user_public_key: keypair.pubkey().to_string(),
-            quote_response: quote.clone(),
-            wrap_and_unwrap_sol: true,
-        };
-
-        let url = format!("{}/swap", self.base_url);
-        let resp = self
-            .apply_auth(self.client.post(&url).json(&swap_request))
-            .send()
+    ) -> Result<(VersionedTransaction, u64, OrderResponse), JupiterError> {
+        let order = self
+            .order(input_mint, output_mint, amount, &keypair.pubkey())
             .await?;
 
-        let swap_response: SwapResponse = match resp.status().as_u16() {
-            200 => resp.json().await?,
-            status => {
-                let body = resp
-                    .text()
-                    .await
-                    .unwrap_or_else(|_| "unknown error".to_string());
-                return Err(JupiterError::api(status, body));
-            }
-        };
+        if order.transaction.is_empty() {
+            return Err(JupiterError::SwapError(
+                order
+                    .error_message
+                    .unwrap_or_else(|| "no transaction returned".to_string()),
+            ));
+        }
 
         // Decode base64 → bincode → VersionedTransaction
         let tx_bytes = BASE64
-            .decode(&swap_response.swap_transaction)
+            .decode(&order.transaction)
             .map_err(JupiterError::transaction_decode)?;
         let mut txn: VersionedTransaction =
             bincode::deserialize(&tx_bytes).map_err(JupiterError::transaction_decode)?;
@@ -238,29 +242,20 @@ impl Client {
         let txn = VersionedTransaction::try_new(txn.message, &[keypair])
             .map_err(JupiterError::signing)?;
 
-        Ok((txn, last_valid_block_height))
+        Ok((txn, last_valid_block_height, order))
     }
 }
 
-// ---- Jupiter API request/response types ----
+// ---- Jupiter API response types ----
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct SwapRequest {
-    user_public_key: String,
-    quote_response: QuoteResponse,
-    wrap_and_unwrap_sol: bool,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct SwapResponse {
-    swap_transaction: String,
-}
-
+/// Response from the Jupiter V2 `/order` endpoint.
+///
+/// Contains both the quote data (amounts, route, price impact) and the
+/// assembled transaction. The transaction may be empty if there was an
+/// error (check `error_message`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct QuoteResponse {
+pub struct OrderResponse {
     pub input_mint: String,
     pub output_mint: String,
     pub in_amount: String,
@@ -269,7 +264,15 @@ pub struct QuoteResponse {
     pub slippage_bps: u16,
     #[serde(default)]
     pub(crate) route_plan: Vec<RoutePlan>,
-    /// All other fields are captured for pass-through to the /swap endpoint.
+    #[serde(default)]
+    pub transaction: String,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub error_code: Option<i32>,
+    #[serde(default)]
+    pub error_message: Option<String>,
+    /// All other fields captured for forward compatibility.
     #[serde(flatten)]
     pub extra: serde_json::Value,
 }
@@ -362,7 +365,18 @@ mod tests {
     }
 
     #[test]
-    fn test_quote_response_deserialization() {
+    fn test_empty_error_body() {
+        let err = JupiterError::api(404, String::new());
+        match err {
+            JupiterError::Api { message, .. } => {
+                assert!(message.contains("empty response"));
+            }
+            _ => panic!("expected Api variant"),
+        }
+    }
+
+    #[test]
+    fn test_order_response_deserialization() {
         let json = serde_json::json!({
             "inputMint": "hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux",
             "inAmount": "100000000",
@@ -372,6 +386,7 @@ mod tests {
             "swapMode": "ExactIn",
             "slippageBps": 100,
             "priceImpactPct": "0.01",
+            "transaction": "base64encodedtx",
             "routePlan": [{
                 "swapInfo": {
                     "ammKey": "abc123",
@@ -379,31 +394,39 @@ mod tests {
                     "inputMint": "hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux",
                     "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
                     "inAmount": "100000000",
-                    "outAmount": "450000",
-                    "feeAmount": "100",
-                    "feeMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                    "outAmount": "450000"
                 },
                 "percent": 100
             }]
         });
 
-        let quote: QuoteResponse = serde_json::from_value(json).unwrap();
-        assert_eq!(
-            quote.input_mint,
-            "hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux"
-        );
-        assert_eq!(
-            quote.output_mint,
-            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
-        );
-        assert_eq!(quote.in_amount, "100000000");
-        assert_eq!(quote.out_amount, "450000");
-        assert_eq!(quote.slippage_bps, 100);
-        assert_eq!(quote.route_plan.len(), 1);
-        assert_eq!(quote.route_plan[0].swap_info.label.as_deref(), Some("Orca"));
-        assert_eq!(quote.route_plan[0].percent, 100);
-        // Extra fields are captured
-        assert!(quote.extra.get("swapMode").is_some());
-        assert!(quote.extra.get("otherAmountThreshold").is_some());
+        let order: OrderResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(order.in_amount, "100000000");
+        assert_eq!(order.out_amount, "450000");
+        assert_eq!(order.slippage_bps, 100);
+        assert_eq!(order.transaction, "base64encodedtx");
+        assert_eq!(order.route_plan.len(), 1);
+        assert!(order.error_message.is_none());
+    }
+
+    #[test]
+    fn test_order_response_with_error() {
+        let json = serde_json::json!({
+            "inputMint": "abc",
+            "outputMint": "def",
+            "inAmount": "100",
+            "outAmount": "0",
+            "priceImpactPct": "0",
+            "slippageBps": 100,
+            "transaction": "",
+            "routePlan": [],
+            "error": "Insufficient funds",
+            "errorCode": 1,
+            "errorMessage": "Insufficient funds"
+        });
+
+        let order: OrderResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(order.error_message.as_deref(), Some("Insufficient funds"));
+        assert!(order.transaction.is_empty());
     }
 }

--- a/helium-lib/src/jupiter.rs
+++ b/helium-lib/src/jupiter.rs
@@ -61,12 +61,16 @@ impl JupiterError {
 
 /// Jupiter V6 swap API client.
 ///
+/// Works with or without an API key:
+/// - Without key: keyless access at 0.5 RPS (suitable for CLI use)
+/// - With `JUP_API_KEY`: higher rate limits per your plan (required for automated/production use)
+///
 /// NOTE: intentionally no `Debug` derive — `api_key` is a secret.
 #[derive(Clone)]
 pub struct Client {
     client: reqwest::Client,
     base_url: String,
-    api_key: String,
+    api_key: Option<String>,
     slippage_bps: u16,
 }
 
@@ -74,25 +78,40 @@ impl std::fmt::Debug for Client {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)
-            .field("api_key", &"[redacted]")
+            .field(
+                "api_key",
+                &if self.api_key.is_some() {
+                    "[redacted]"
+                } else {
+                    "[none]"
+                },
+            )
             .field("slippage_bps", &self.slippage_bps)
             .finish()
     }
 }
 
 impl Client {
-    pub fn new(api_key: impl Into<String>, base_url: impl Into<String>, slippage_bps: u16) -> Self {
+    pub fn new(
+        api_key: Option<impl Into<String>>,
+        base_url: impl Into<String>,
+        slippage_bps: u16,
+    ) -> Self {
         Self {
             client: reqwest::Client::new(),
             base_url: base_url.into(),
-            api_key: api_key.into(),
+            api_key: api_key.map(Into::into),
             slippage_bps,
         }
     }
 
+    /// Create a client from environment variables.
+    ///
+    /// `JUP_API_KEY` is optional — omit for keyless access (0.5 RPS).
+    /// `JUP_API_URL` defaults to `https://api.jup.ag/swap/v6`.
+    /// `JUP_SLIPPAGE_BPS` defaults to 100 (1%).
     pub fn from_env() -> Result<Self, JupiterError> {
-        let api_key = std::env::var("JUP_API_KEY")
-            .map_err(|_| JupiterError::config("JUP_API_KEY not configured"))?;
+        let api_key = std::env::var("JUP_API_KEY").ok();
         let base_url = std::env::var("JUP_API_URL").unwrap_or_else(|_| DEFAULT_API_URL.to_string());
         let slippage_bps = match std::env::var("JUP_SLIPPAGE_BPS") {
             Ok(v) => v.parse::<u16>().map_err(|_| {
@@ -101,6 +120,18 @@ impl Client {
             Err(_) => DEFAULT_SLIPPAGE_BPS,
         };
         Ok(Self::new(api_key, base_url, slippage_bps))
+    }
+
+    /// Whether this client has an API key configured.
+    pub fn has_api_key(&self) -> bool {
+        self.api_key.is_some()
+    }
+
+    fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.api_key {
+            Some(key) => req.header("x-api-key", key),
+            None => req,
+        }
     }
 
     /// Get a swap quote from Jupiter.
@@ -122,18 +153,13 @@ impl Client {
         }
 
         let url = format!("{}/quote", self.base_url);
-        let resp = self
-            .client
-            .get(&url)
-            .query(&[
-                ("inputMint", input_mint.to_string()),
-                ("outputMint", output_mint.to_string()),
-                ("amount", amount.to_string()),
-                ("slippageBps", self.slippage_bps.to_string()),
-            ])
-            .header("x-api-key", &self.api_key)
-            .send()
-            .await?;
+        let req = self.client.get(&url).query(&[
+            ("inputMint", input_mint.to_string()),
+            ("outputMint", output_mint.to_string()),
+            ("amount", amount.to_string()),
+            ("slippageBps", self.slippage_bps.to_string()),
+        ]);
+        let resp = self.apply_auth(req).send().await?;
 
         match resp.status().as_u16() {
             200 => {
@@ -180,10 +206,7 @@ impl Client {
 
         let url = format!("{}/swap", self.base_url);
         let resp = self
-            .client
-            .post(&url)
-            .header("x-api-key", &self.api_key)
-            .json(&swap_request)
+            .apply_auth(self.client.post(&url).json(&swap_request))
             .send()
             .await?;
 
@@ -273,31 +296,57 @@ pub(crate) struct SwapInfo {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_from_env_missing_api_key() {
-        std::env::remove_var("JUP_API_KEY");
-        let result = Client::from_env();
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), JupiterError::Config(_)));
-    }
+    /// Mutex to serialize env-dependent tests (env vars are process-global).
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-    #[test]
-    fn test_from_env_invalid_slippage() {
-        std::env::set_var("JUP_API_KEY", "test-key");
-        std::env::set_var("JUP_SLIPPAGE_BPS", "not-a-number");
-        let result = Client::from_env();
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), JupiterError::Config(_)));
+    fn clean_env() {
         std::env::remove_var("JUP_API_KEY");
+        std::env::remove_var("JUP_API_URL");
         std::env::remove_var("JUP_SLIPPAGE_BPS");
     }
 
     #[test]
+    fn test_from_env_no_api_key_succeeds() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clean_env();
+        let client = Client::from_env().unwrap();
+        assert!(!client.has_api_key());
+    }
+
+    #[test]
+    fn test_from_env_with_api_key() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clean_env();
+        std::env::set_var("JUP_API_KEY", "test-key");
+        let client = Client::from_env().unwrap();
+        assert!(client.has_api_key());
+        clean_env();
+    }
+
+    #[test]
+    fn test_from_env_invalid_slippage() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clean_env();
+        std::env::set_var("JUP_SLIPPAGE_BPS", "not-a-number");
+        let result = Client::from_env();
+        clean_env();
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), JupiterError::Config(_)));
+    }
+
+    #[test]
     fn test_debug_redacts_api_key() {
-        let client = Client::new("secret-key-123", DEFAULT_API_URL, 100);
+        let client = Client::new(Some("secret-key-123"), DEFAULT_API_URL, 100);
         let debug = format!("{client:?}");
         assert!(!debug.contains("secret-key-123"));
         assert!(debug.contains("[redacted]"));
+    }
+
+    #[test]
+    fn test_debug_no_api_key() {
+        let client = Client::new(None::<String>, DEFAULT_API_URL, 100);
+        let debug = format!("{client:?}");
+        assert!(debug.contains("[none]"));
     }
 
     #[test]

--- a/helium-lib/src/jupiter.rs
+++ b/helium-lib/src/jupiter.rs
@@ -1,16 +1,15 @@
 use crate::{
     client::SolanaRpcClient,
-    error::Error,
     keypair::{Keypair, Pubkey},
     transaction::VersionedTransaction,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use solana_sdk::signer::Signer;
 
 pub const DEFAULT_API_URL: &str = "https://api.jup.ag/swap/v6";
 pub const DEFAULT_SLIPPAGE_BPS: u16 = 100;
+const MAX_ERROR_BODY_LEN: usize = 200;
 
 #[derive(Debug, thiserror::Error)]
 pub enum JupiterError {
@@ -25,6 +24,10 @@ pub enum JupiterError {
     },
     #[error("Failed to decode swap transaction: {0}")]
     TransactionDecode(String),
+    #[error("Solana RPC error: {0}")]
+    Solana(String),
+    #[error("Transaction signing failed: {0}")]
+    Signing(String),
     #[error("Jupiter configuration error: {0}")]
     Config(String),
 }
@@ -37,14 +40,44 @@ impl JupiterError {
     pub fn transaction_decode(msg: impl std::fmt::Display) -> Self {
         Self::TransactionDecode(msg.to_string())
     }
+
+    pub fn solana(msg: impl std::fmt::Display) -> Self {
+        Self::Solana(msg.to_string())
+    }
+
+    pub fn signing(msg: impl std::fmt::Display) -> Self {
+        Self::Signing(msg.to_string())
+    }
+
+    fn api(status: u16, body: String) -> Self {
+        let message = if body.len() > MAX_ERROR_BODY_LEN {
+            format!("{}…", &body[..MAX_ERROR_BODY_LEN])
+        } else {
+            body
+        };
+        Self::Api { status, message }
+    }
 }
 
-#[derive(Debug, Clone)]
+/// Jupiter V6 swap API client.
+///
+/// NOTE: intentionally no `Debug` derive — `api_key` is a secret.
+#[derive(Clone)]
 pub struct Client {
     client: reqwest::Client,
     base_url: String,
     api_key: String,
     slippage_bps: u16,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("api_key", &"[redacted]")
+            .field("slippage_bps", &self.slippage_bps)
+            .finish()
+    }
 }
 
 impl Client {
@@ -61,10 +94,12 @@ impl Client {
         let api_key = std::env::var("JUP_API_KEY")
             .map_err(|_| JupiterError::config("JUP_API_KEY not configured"))?;
         let base_url = std::env::var("JUP_API_URL").unwrap_or_else(|_| DEFAULT_API_URL.to_string());
-        let slippage_bps = std::env::var("JUP_SLIPPAGE_BPS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(DEFAULT_SLIPPAGE_BPS);
+        let slippage_bps = match std::env::var("JUP_SLIPPAGE_BPS") {
+            Ok(v) => v.parse::<u16>().map_err(|_| {
+                JupiterError::config(format!("JUP_SLIPPAGE_BPS={v:?} is not a valid u16"))
+            })?,
+            Err(_) => DEFAULT_SLIPPAGE_BPS,
+        };
         Ok(Self::new(api_key, base_url, slippage_bps))
     }
 
@@ -75,6 +110,17 @@ impl Client {
         output_mint: &Pubkey,
         amount: u64,
     ) -> Result<QuoteResponse, JupiterError> {
+        if amount == 0 {
+            return Err(JupiterError::config(
+                "swap amount must be greater than zero",
+            ));
+        }
+        if input_mint == output_mint {
+            return Err(JupiterError::config(
+                "input and output tokens must be different",
+            ));
+        }
+
         let url = format!("{}/quote", self.base_url);
         let resp = self
             .client
@@ -101,11 +147,11 @@ impl Client {
                 Ok(quote)
             }
             status => {
-                let message = resp
+                let body = resp
                     .text()
                     .await
                     .unwrap_or_else(|_| "unknown error".to_string());
-                Err(JupiterError::Api { status, message })
+                Err(JupiterError::api(status, body))
             }
         }
     }
@@ -116,12 +162,16 @@ impl Client {
     /// Returns a ready-to-send `VersionedTransaction` and the last valid
     /// block height, matching the helium-lib convention for transaction
     /// builders (`token::transfer`, `token::burn`, etc.).
+    ///
+    /// Note: the transaction's compute budget is set by Jupiter's
+    /// simulation — `TransactionOpts` is intentionally not accepted here,
+    /// unlike other helium-lib transaction builders.
     pub async fn swap<C: AsRef<SolanaRpcClient>>(
         &self,
         client: &C,
         quote: &QuoteResponse,
         keypair: &Keypair,
-    ) -> Result<(VersionedTransaction, u64), Error> {
+    ) -> Result<(VersionedTransaction, u64), JupiterError> {
         let swap_request = SwapRequest {
             user_public_key: keypair.pubkey().to_string(),
             quote_response: quote.clone(),
@@ -135,17 +185,16 @@ impl Client {
             .header("x-api-key", &self.api_key)
             .json(&swap_request)
             .send()
-            .map_err(JupiterError::from)
             .await?;
 
         let swap_response: SwapResponse = match resp.status().as_u16() {
-            200 => resp.json().map_err(JupiterError::from).await?,
+            200 => resp.json().await?,
             status => {
-                let message = resp
+                let body = resp
                     .text()
                     .await
                     .unwrap_or_else(|_| "unknown error".to_string());
-                return Err(JupiterError::Api { status, message }.into());
+                return Err(JupiterError::api(status, body));
             }
         };
 
@@ -160,9 +209,11 @@ impl Client {
         let solana_client = client.as_ref();
         let (blockhash, last_valid_block_height) = solana_client
             .get_latest_blockhash_with_commitment(solana_client.commitment())
-            .await?;
+            .await
+            .map_err(JupiterError::solana)?;
         txn.message.set_recent_blockhash(blockhash);
-        let txn = VersionedTransaction::try_new(txn.message, &[keypair])?;
+        let txn = VersionedTransaction::try_new(txn.message, &[keypair])
+            .map_err(JupiterError::signing)?;
 
         Ok((txn, last_valid_block_height))
     }
@@ -194,7 +245,7 @@ pub struct QuoteResponse {
     pub price_impact_pct: String,
     pub slippage_bps: u16,
     #[serde(default)]
-    pub route_plan: Vec<RoutePlan>,
+    pub(crate) route_plan: Vec<RoutePlan>,
     /// All other fields are captured for pass-through to the /swap endpoint.
     #[serde(flatten)]
     pub extra: serde_json::Value,
@@ -202,7 +253,7 @@ pub struct QuoteResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RoutePlan {
+pub(crate) struct RoutePlan {
     #[serde(default)]
     pub swap_info: SwapInfo,
     pub percent: u8,
@@ -210,7 +261,7 @@ pub struct RoutePlan {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SwapInfo {
+pub(crate) struct SwapInfo {
     pub label: Option<String>,
     pub input_mint: Option<String>,
     pub output_mint: Option<String>,
@@ -224,12 +275,41 @@ mod tests {
 
     #[test]
     fn test_from_env_missing_api_key() {
-        // Ensure JUP_API_KEY is not set
         std::env::remove_var("JUP_API_KEY");
         let result = Client::from_env();
         assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, JupiterError::Config(_)));
+        assert!(matches!(result.unwrap_err(), JupiterError::Config(_)));
+    }
+
+    #[test]
+    fn test_from_env_invalid_slippage() {
+        std::env::set_var("JUP_API_KEY", "test-key");
+        std::env::set_var("JUP_SLIPPAGE_BPS", "not-a-number");
+        let result = Client::from_env();
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), JupiterError::Config(_)));
+        std::env::remove_var("JUP_API_KEY");
+        std::env::remove_var("JUP_SLIPPAGE_BPS");
+    }
+
+    #[test]
+    fn test_debug_redacts_api_key() {
+        let client = Client::new("secret-key-123", DEFAULT_API_URL, 100);
+        let debug = format!("{client:?}");
+        assert!(!debug.contains("secret-key-123"));
+        assert!(debug.contains("[redacted]"));
+    }
+
+    #[test]
+    fn test_error_body_truncation() {
+        let long_body = "x".repeat(500);
+        let err = JupiterError::api(500, long_body);
+        match err {
+            JupiterError::Api { message, .. } => {
+                assert!(message.len() <= MAX_ERROR_BODY_LEN + "…".len());
+            }
+            _ => panic!("expected Api variant"),
+        }
     }
 
     #[test]

--- a/helium-lib/src/jupiter.rs
+++ b/helium-lib/src/jupiter.rs
@@ -282,7 +282,8 @@ pub struct OrderResponse {
 pub(crate) struct RoutePlan {
     #[serde(default)]
     pub swap_info: SwapInfo,
-    pub percent: u8,
+    #[serde(default)]
+    pub percent: f64,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -406,6 +407,7 @@ mod tests {
         assert_eq!(order.slippage_bps, 100);
         assert_eq!(order.transaction, "base64encodedtx");
         assert_eq!(order.route_plan.len(), 1);
+        assert!((order.route_plan[0].percent - 100.0).abs() < f64::EPSILON);
         assert!(order.error_message.is_none());
     }
 

--- a/helium-lib/src/jupiter.rs
+++ b/helium-lib/src/jupiter.rs
@@ -5,6 +5,7 @@ use crate::{
     transaction::VersionedTransaction,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use solana_sdk::signer::Signer;
 
@@ -134,11 +135,11 @@ impl Client {
             .header("x-api-key", &self.api_key)
             .json(&swap_request)
             .send()
-            .await
-            .map_err(JupiterError::from)?;
+            .map_err(JupiterError::from)
+            .await?;
 
         let swap_response: SwapResponse = match resp.status().as_u16() {
-            200 => resp.json().await.map_err(JupiterError::from)?,
+            200 => resp.json().map_err(JupiterError::from).await?,
             status => {
                 let message = resp
                     .text()
@@ -151,9 +152,9 @@ impl Client {
         // Decode base64 → bincode → VersionedTransaction
         let tx_bytes = BASE64
             .decode(&swap_response.swap_transaction)
-            .map_err(|e| JupiterError::transaction_decode(e))?;
+            .map_err(JupiterError::transaction_decode)?;
         let mut txn: VersionedTransaction =
-            bincode::deserialize(&tx_bytes).map_err(|e| JupiterError::transaction_decode(e))?;
+            bincode::deserialize(&tx_bytes).map_err(JupiterError::transaction_decode)?;
 
         // Update to a fresh blockhash and re-sign
         let solana_client = client.as_ref();

--- a/helium-lib/src/jupiter.rs
+++ b/helium-lib/src/jupiter.rs
@@ -1,0 +1,279 @@
+use crate::{
+    client::SolanaRpcClient,
+    error::Error,
+    keypair::{Keypair, Pubkey},
+    transaction::VersionedTransaction,
+};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use serde::{Deserialize, Serialize};
+use solana_sdk::signer::Signer;
+
+pub const DEFAULT_API_URL: &str = "https://api.jup.ag/swap/v6";
+pub const DEFAULT_SLIPPAGE_BPS: u16 = 100;
+
+#[derive(Debug, thiserror::Error)]
+pub enum JupiterError {
+    #[error("Jupiter API request failed: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("Jupiter API error (HTTP {status}): {message}")]
+    Api { status: u16, message: String },
+    #[error("Jupiter quote returned no routes for {input_mint} → {output_mint}")]
+    NoRoutes {
+        input_mint: String,
+        output_mint: String,
+    },
+    #[error("Failed to decode swap transaction: {0}")]
+    TransactionDecode(String),
+    #[error("Jupiter configuration error: {0}")]
+    Config(String),
+}
+
+impl JupiterError {
+    pub fn config(msg: impl Into<String>) -> Self {
+        Self::Config(msg.into())
+    }
+
+    pub fn transaction_decode(msg: impl std::fmt::Display) -> Self {
+        Self::TransactionDecode(msg.to_string())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Client {
+    client: reqwest::Client,
+    base_url: String,
+    api_key: String,
+    slippage_bps: u16,
+}
+
+impl Client {
+    pub fn new(api_key: impl Into<String>, base_url: impl Into<String>, slippage_bps: u16) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url: base_url.into(),
+            api_key: api_key.into(),
+            slippage_bps,
+        }
+    }
+
+    pub fn from_env() -> Result<Self, JupiterError> {
+        let api_key = std::env::var("JUP_API_KEY")
+            .map_err(|_| JupiterError::config("JUP_API_KEY not configured"))?;
+        let base_url = std::env::var("JUP_API_URL").unwrap_or_else(|_| DEFAULT_API_URL.to_string());
+        let slippage_bps = std::env::var("JUP_SLIPPAGE_BPS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_SLIPPAGE_BPS);
+        Ok(Self::new(api_key, base_url, slippage_bps))
+    }
+
+    /// Get a swap quote from Jupiter.
+    pub async fn quote(
+        &self,
+        input_mint: &Pubkey,
+        output_mint: &Pubkey,
+        amount: u64,
+    ) -> Result<QuoteResponse, JupiterError> {
+        let url = format!("{}/quote", self.base_url);
+        let resp = self
+            .client
+            .get(&url)
+            .query(&[
+                ("inputMint", input_mint.to_string()),
+                ("outputMint", output_mint.to_string()),
+                ("amount", amount.to_string()),
+                ("slippageBps", self.slippage_bps.to_string()),
+            ])
+            .header("x-api-key", &self.api_key)
+            .send()
+            .await?;
+
+        match resp.status().as_u16() {
+            200 => {
+                let quote: QuoteResponse = resp.json().await?;
+                if quote.route_plan.is_empty() {
+                    return Err(JupiterError::NoRoutes {
+                        input_mint: input_mint.to_string(),
+                        output_mint: output_mint.to_string(),
+                    });
+                }
+                Ok(quote)
+            }
+            status => {
+                let message = resp
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "unknown error".to_string());
+                Err(JupiterError::Api { status, message })
+            }
+        }
+    }
+
+    /// Get a swap transaction from Jupiter, deserialize it, update the
+    /// blockhash, and sign with the provided keypair.
+    ///
+    /// Returns a ready-to-send `VersionedTransaction` and the last valid
+    /// block height, matching the helium-lib convention for transaction
+    /// builders (`token::transfer`, `token::burn`, etc.).
+    pub async fn swap<C: AsRef<SolanaRpcClient>>(
+        &self,
+        client: &C,
+        quote: &QuoteResponse,
+        keypair: &Keypair,
+    ) -> Result<(VersionedTransaction, u64), Error> {
+        let swap_request = SwapRequest {
+            user_public_key: keypair.pubkey().to_string(),
+            quote_response: quote.clone(),
+            wrap_and_unwrap_sol: true,
+        };
+
+        let url = format!("{}/swap", self.base_url);
+        let resp = self
+            .client
+            .post(&url)
+            .header("x-api-key", &self.api_key)
+            .json(&swap_request)
+            .send()
+            .await
+            .map_err(JupiterError::from)?;
+
+        let swap_response: SwapResponse = match resp.status().as_u16() {
+            200 => resp.json().await.map_err(JupiterError::from)?,
+            status => {
+                let message = resp
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "unknown error".to_string());
+                return Err(JupiterError::Api { status, message }.into());
+            }
+        };
+
+        // Decode base64 → bincode → VersionedTransaction
+        let tx_bytes = BASE64
+            .decode(&swap_response.swap_transaction)
+            .map_err(|e| JupiterError::transaction_decode(e))?;
+        let mut txn: VersionedTransaction =
+            bincode::deserialize(&tx_bytes).map_err(|e| JupiterError::transaction_decode(e))?;
+
+        // Update to a fresh blockhash and re-sign
+        let solana_client = client.as_ref();
+        let (blockhash, last_valid_block_height) = solana_client
+            .get_latest_blockhash_with_commitment(solana_client.commitment())
+            .await?;
+        txn.message.set_recent_blockhash(blockhash);
+        let txn = VersionedTransaction::try_new(txn.message, &[keypair])?;
+
+        Ok((txn, last_valid_block_height))
+    }
+}
+
+// ---- Jupiter API request/response types ----
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SwapRequest {
+    user_public_key: String,
+    quote_response: QuoteResponse,
+    wrap_and_unwrap_sol: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SwapResponse {
+    swap_transaction: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuoteResponse {
+    pub input_mint: String,
+    pub output_mint: String,
+    pub in_amount: String,
+    pub out_amount: String,
+    pub price_impact_pct: String,
+    pub slippage_bps: u16,
+    #[serde(default)]
+    pub route_plan: Vec<RoutePlan>,
+    /// All other fields are captured for pass-through to the /swap endpoint.
+    #[serde(flatten)]
+    pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoutePlan {
+    #[serde(default)]
+    pub swap_info: SwapInfo,
+    pub percent: u8,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapInfo {
+    pub label: Option<String>,
+    pub input_mint: Option<String>,
+    pub output_mint: Option<String>,
+    pub in_amount: Option<String>,
+    pub out_amount: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_env_missing_api_key() {
+        // Ensure JUP_API_KEY is not set
+        std::env::remove_var("JUP_API_KEY");
+        let result = Client::from_env();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, JupiterError::Config(_)));
+    }
+
+    #[test]
+    fn test_quote_response_deserialization() {
+        let json = serde_json::json!({
+            "inputMint": "hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux",
+            "inAmount": "100000000",
+            "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "outAmount": "450000",
+            "otherAmountThreshold": "445500",
+            "swapMode": "ExactIn",
+            "slippageBps": 100,
+            "priceImpactPct": "0.01",
+            "routePlan": [{
+                "swapInfo": {
+                    "ammKey": "abc123",
+                    "label": "Orca",
+                    "inputMint": "hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux",
+                    "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    "inAmount": "100000000",
+                    "outAmount": "450000",
+                    "feeAmount": "100",
+                    "feeMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                },
+                "percent": 100
+            }]
+        });
+
+        let quote: QuoteResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            quote.input_mint,
+            "hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux"
+        );
+        assert_eq!(
+            quote.output_mint,
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        );
+        assert_eq!(quote.in_amount, "100000000");
+        assert_eq!(quote.out_amount, "450000");
+        assert_eq!(quote.slippage_bps, 100);
+        assert_eq!(quote.route_plan.len(), 1);
+        assert_eq!(quote.route_plan[0].swap_info.label.as_deref(), Some("Orca"));
+        assert_eq!(quote.route_plan[0].percent, 100);
+        // Extra fields are captured
+        assert!(quote.extra.get("swapMode").is_some());
+        assert!(quote.extra.get("otherAmountThreshold").is_some());
+    }
+}

--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -37,6 +37,7 @@ pub use anchor_spl;
 pub use solana_program;
 pub use solana_sdk;
 pub use solana_sdk::bs58;
+pub use solana_transaction_status;
 pub use tuktuk_sdk;
 
 pub(crate) trait Zero {

--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -12,6 +12,7 @@ pub mod ed25519_instruction;
 pub mod entity_key;
 pub mod error;
 pub mod hotspot;
+pub mod jupiter;
 pub mod keypair;
 pub mod kta;
 pub mod memo;

--- a/helium-wallet/Cargo.toml
+++ b/helium-wallet/Cargo.toml
@@ -21,6 +21,7 @@ byteorder = "1.3.2"
 chrono = { workspace = true }
 rand = "0.8"
 dialoguer = "0.8"
+futures.workspace = true
 pbkdf2 = "0.12"
 sodiumoxide = "~0.2"
 aes-gcm = "0"

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -34,6 +34,7 @@ pub mod memo;
 pub mod price;
 pub mod router;
 pub mod sign;
+pub mod swap;
 pub mod transfer;
 pub mod upgrade;
 

--- a/helium-wallet/src/cmd/swap.rs
+++ b/helium-wallet/src/cmd/swap.rs
@@ -36,25 +36,21 @@ impl Cmd {
             .await
             .map_err(|e| anyhow!("Quote failed: {e}"))?;
 
-        let in_amount = helium_lib::token::TokenAmount::from_u64(
-            self.input_token,
-            quote.in_amount.parse().unwrap_or(0),
-        );
-        let out_amount = helium_lib::token::TokenAmount::from_u64(
-            self.output_token,
-            quote.out_amount.parse().unwrap_or(0),
-        );
-        let in_f64 = f64::from(&in_amount);
-        let out_f64 = f64::from(&out_amount);
-        let input_token = self.input_token;
-        let output_token = self.output_token;
-        let slippage_bps = quote.slippage_bps;
-        let price_impact_pct = &quote.price_impact_pct;
-
-        eprintln!("Swap: {in_f64} {input_token} → ~{out_f64} {output_token} (slippage: {slippage_bps}bps, impact: {price_impact_pct}%)");
-
         let (tx, _) = jupiter_client.swap(&client, &quote, &keypair).await?;
 
-        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
+        let response = self.commit.maybe_commit(tx, &client).await?;
+        let mut json = response.to_json();
+        if let serde_json::Value::Object(ref mut map) = json {
+            map.insert("in_amount".to_string(), quote.in_amount.into());
+            map.insert("out_amount".to_string(), quote.out_amount.into());
+            map.insert("input_mint".to_string(), quote.input_mint.into());
+            map.insert("output_mint".to_string(), quote.output_mint.into());
+            map.insert("slippage_bps".to_string(), quote.slippage_bps.into());
+            map.insert(
+                "price_impact_pct".to_string(),
+                quote.price_impact_pct.into(),
+            );
+        }
+        print_json(&json)
     }
 }

--- a/helium-wallet/src/cmd/swap.rs
+++ b/helium-wallet/src/cmd/swap.rs
@@ -1,0 +1,60 @@
+use crate::cmd::*;
+use helium_lib::{jupiter, token::Token};
+
+#[derive(Debug, Clone, clap::Args)]
+/// Swap tokens via Jupiter
+pub struct Cmd {
+    /// Input token (hnt, mobile, iot, usdc, sol)
+    input_token: Token,
+    /// Output token (hnt, mobile, iot, usdc, sol)
+    output_token: Token,
+    /// Amount to swap (human-readable, e.g. 1.5 for 1.5 HNT)
+    amount: f64,
+    /// Slippage tolerance in basis points (100 = 1%)
+    #[arg(long, default_value_t = jupiter::DEFAULT_SLIPPAGE_BPS)]
+    slippage_bps: u16,
+    /// Commit the swap
+    #[command(flatten)]
+    commit: CommitOpts,
+}
+
+impl Cmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        let password = get_wallet_password(false)?;
+        let keypair = opts.load_keypair(password.as_bytes())?;
+        let client = opts.client()?;
+
+        let jupiter_client = jupiter::Client::from_env().map_err(|e| anyhow!("Jupiter: {e}"))?;
+
+        let input_mint = self.input_token.mint();
+        let output_mint = self.output_token.mint();
+        let raw_amount =
+            helium_lib::token::TokenAmount::from_f64(self.input_token, self.amount).amount;
+
+        let quote = jupiter_client
+            .quote(input_mint, output_mint, raw_amount)
+            .await
+            .map_err(|e| anyhow!("Quote failed: {e}"))?;
+
+        let in_amount = helium_lib::token::TokenAmount::from_u64(
+            self.input_token,
+            quote.in_amount.parse().unwrap_or(0),
+        );
+        let out_amount = helium_lib::token::TokenAmount::from_u64(
+            self.output_token,
+            quote.out_amount.parse().unwrap_or(0),
+        );
+        let in_f64 = f64::from(&in_amount);
+        let out_f64 = f64::from(&out_amount);
+        let input_token = self.input_token;
+        let output_token = self.output_token;
+        let slippage_bps = quote.slippage_bps;
+        let price_impact_pct = &quote.price_impact_pct;
+
+        eprintln!("Swap: {in_f64} {input_token} → ~{out_f64} {output_token} (slippage: {slippage_bps}bps, impact: {price_impact_pct}%)");
+
+        let (tx, _) = jupiter_client.swap(&client, &quote, &keypair).await?;
+
+        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
+    }
+}

--- a/helium-wallet/src/cmd/swap.rs
+++ b/helium-wallet/src/cmd/swap.rs
@@ -35,23 +35,21 @@ impl Cmd {
         let raw_amount =
             helium_lib::token::TokenAmount::from_f64(self.input_token, self.amount).amount;
 
-        let quote = jupiter_client
-            .quote(input_mint, output_mint, raw_amount)
+        let (tx, _, order) = jupiter_client
+            .swap(&client, input_mint, output_mint, raw_amount, &keypair)
             .await?;
-
-        let (tx, _) = jupiter_client.swap(&client, &quote, &keypair).await?;
 
         let response = self.commit.maybe_commit(tx, &client).await?;
         let mut json = response.to_json();
         if let serde_json::Value::Object(ref mut map) = json {
-            map.insert("in_amount".to_string(), quote.in_amount.into());
-            map.insert("out_amount".to_string(), quote.out_amount.into());
-            map.insert("input_mint".to_string(), quote.input_mint.into());
-            map.insert("output_mint".to_string(), quote.output_mint.into());
-            map.insert("slippage_bps".to_string(), quote.slippage_bps.into());
+            map.insert("in_amount".to_string(), order.in_amount.into());
+            map.insert("out_amount".to_string(), order.out_amount.into());
+            map.insert("input_mint".to_string(), order.input_mint.into());
+            map.insert("output_mint".to_string(), order.output_mint.into());
+            map.insert("slippage_bps".to_string(), order.slippage_bps.into());
             map.insert(
                 "price_impact_pct".to_string(),
-                quote.price_impact_pct.into(),
+                order.price_impact_pct.into(),
             );
         }
         print_json(&json)

--- a/helium-wallet/src/cmd/swap.rs
+++ b/helium-wallet/src/cmd/swap.rs
@@ -1,4 +1,5 @@
 use crate::cmd::*;
+use futures::TryFutureExt;
 use helium_lib::{jupiter, token::Token};
 
 #[derive(Debug, Clone, clap::Args)]
@@ -33,8 +34,8 @@ impl Cmd {
 
         let quote = jupiter_client
             .quote(input_mint, output_mint, raw_amount)
-            .await
-            .map_err(|e| anyhow!("Quote failed: {e}"))?;
+            .map_err(|e| anyhow!("Quote failed: {e}"))
+            .await?;
 
         let (tx, _) = jupiter_client.swap(&client, &quote, &keypair).await?;
 

--- a/helium-wallet/src/cmd/swap.rs
+++ b/helium-wallet/src/cmd/swap.rs
@@ -1,5 +1,4 @@
 use crate::cmd::*;
-use futures::TryFutureExt;
 use helium_lib::{jupiter, token::Token};
 
 #[derive(Debug, Clone, clap::Args)]
@@ -21,11 +20,15 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
+        if self.amount <= 0.0 || !self.amount.is_finite() {
+            bail!("swap amount must be a positive finite number");
+        }
+
         let password = get_wallet_password(false)?;
         let keypair = opts.load_keypair(password.as_bytes())?;
         let client = opts.client()?;
 
-        let jupiter_client = jupiter::Client::from_env().map_err(|e| anyhow!("Jupiter: {e}"))?;
+        let jupiter_client = jupiter::Client::from_env()?;
 
         let input_mint = self.input_token.mint();
         let output_mint = self.output_token.mint();
@@ -34,7 +37,6 @@ impl Cmd {
 
         let quote = jupiter_client
             .quote(input_mint, output_mint, raw_amount)
-            .map_err(|e| anyhow!("Quote failed: {e}"))
             .await?;
 
         let (tx, _) = jupiter_client.swap(&client, &quote, &keypair).await?;

--- a/helium-wallet/src/main.rs
+++ b/helium-wallet/src/main.rs
@@ -4,7 +4,7 @@
 use clap::Parser;
 use helium_wallet::{
     cmd::{
-        assets, balance, burn, create, dc, export, hotspots, info, memo, price, router, sign,
+        assets, balance, burn, create, dc, export, hotspots, info, memo, price, router, sign, swap,
         transfer, upgrade, Opts,
     },
     result::Result,
@@ -39,6 +39,7 @@ pub enum Cmd {
     Price(price::Cmd),
     Transfer(transfer::Cmd),
     Burn(burn::Cmd),
+    Swap(swap::Cmd),
     Export(export::Cmd),
     Sign(sign::Cmd),
     Memo(memo::Cmd),
@@ -68,6 +69,7 @@ impl Cli {
             Cmd::Price(cmd) => cmd.run(self.opts).await,
             Cmd::Transfer(cmd) => cmd.run(self.opts).await,
             Cmd::Burn(cmd) => cmd.run(self.opts).await,
+            Cmd::Swap(cmd) => cmd.run(self.opts).await,
             Cmd::Export(cmd) => cmd.run(self.opts).await,
             Cmd::Sign(cmd) => cmd.run(self.opts).await,
             Cmd::Memo(cmd) => cmd.run(self.opts).await,


### PR DESCRIPTION
## Summary
- Add `helium_lib::jupiter` module for token swaps via the Jupiter V6 REST API
- Dedicated `JupiterError` type, `QuoteResponse` serde types, transaction decode+sign flow
- Add `helium-wallet swap` CLI command (e.g. `helium-wallet swap hnt usdc 1.5 --commit`)
- Calls Jupiter REST API directly (avoids solana-sdk v3 incompatibility with jup-ag crate)
- Requires `JUP_API_KEY` env var; optional `JUP_API_URL`, `JUP_SLIPPAGE_BPS`