### PR TITLE
chore: overhaul docs and fix associated_token_address typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,79 +7,110 @@
 
 A [Helium](https://helium.com) wallet implementation in Rust.
 
-This is a simple wallet implementation that enables the creation and
-use of an encrypted wallet.
-
 **NOTE:** This wallet is _not_ the absolute safest way to create and
 store a private key. No guarantees are implied as to its safety and
 suitability for use as a wallet associated with Helium crypto-tokens.
+
+## Workspace
+
+| Crate | Description |
+|---|---|
+| `helium-wallet` | CLI binary for wallet operations |
+| `helium-lib` | Core Rust library for Helium/Solana blockchain interaction |
+| `helium-proto-crypto` | Protobuf message signing and verification |
 
 ## Installation
 
 ### From Binary
 
-Download the latest binary for your platform here from
+Download the latest binary for your platform from
 [Releases](https://github.com/helium/helium-wallet-rs/releases/latest). Unpack
-the zip file and place the `helium-wallet` binary in your `$PATH`
-somewhere.
+the zip file and place the `helium-wallet` binary in your `$PATH`.
+
+### Building from Source
+
+Requirements: Rust toolchain, C compiler, pkg-config, cmake, clang.
+
+Ubuntu 20.04 setup:
+
+```
+sudo apt update && sudo apt install build-essential pkg-config cmake clang
+curl https://sh.rustup.rs -sSf | sh
+source $HOME/.cargo/env
+```
+
+Build:
+
+```
+git clone https://github.com/helium/helium-wallet-rs
+cd helium-wallet-rs
+cargo build --release
+```
+
+The resulting `target/release/helium-wallet` is ready for use.
 
 ## Usage
 
-At any time use `-h` or `--help` to get more help for a command.
+Use `-h` or `--help` on any command for detailed help.
 
-### Global options
+### Global Options
 
-Global options _precede_ the actual command on the command line.
+Global options _precede_ the subcommand.
 
-The following global options are supported
+| Option | Description |
+|---|---|
+| `-f` / `--file` | Wallet file(s). Repeat for sharded wallets or multiple wallets. Default: `wallet.key` |
+| `--format json\|table` | Output format |
+| `--url <URL>` | Solana RPC URL. Shortcuts: `m` (mainnet, default), `d` (devnet). Any full URL also accepted |
 
-* `-f` / `--file` can be used once or multiple times to specify either
-  shard files for a wallet or multiple wallets if the command supports
-  it. If not specified a file called `wallet.key` is assumed to be the
-  wallet to use for the command.
+### Common Command Options
 
-* `--format json|table` can be used to set the output of the command
-  to either a tabular format or a json output.
+Most commands that submit transactions accept these options via `--commit`:
 
-### Create a wallet
+| Option | Description |
+|---|---|
+| `--commit` | Submit the transaction. Without this flag the transaction is simulated (dry run) |
+| `--skip-preflight` | Skip Solana preflight checks |
+| `--min-priority-fee <u64>` | Minimum priority fee in micro-lamports |
+| `--max-priority-fee <u64>` | Maximum priority fee in micro-lamports |
 
-```
-    helium-wallet create basic
-```
+## Commands
 
-The basic wallet will be stored in `wallet.key` after specifying an
-encryption password on the command line. Options exist to specify the
-wallet output file and to force overwriting an existing wallet.
+### `create` -- Create a Wallet
 
-Use the `--seed` option to use a previously generated
-seed phrase that will be used to construct the keys for the wallet.
-The app will prompt you to enter a space separated phrase. The CLI
-wallet accepts 12 word or 24 word seed phrases from both Helium
-mobile wallet apps as well as any valid 12 or 24 word BIP39 phrase.
-Note that this does not (yet) generate an
-[HD wallet](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki).
-
-### Create a sharded wallet
-
-Sharding wallet keys is supported via [Shamir's Secret
-Sharing](https://github.com/dsprenkels/sss).  A key can be broken into
-N shards such that recovering the original key needs K distinct
-shards. This can be done by passing options to `create`:
+#### Basic
 
 ```
-    helium-wallet create sharded -n 5 -k 3
+helium-wallet create basic
 ```
 
-This will create wallet.key.1 through wallet.key.5 (the base name of
-the wallet file can be supplied with the `-o` parameter).
+The wallet is stored in `wallet.key` after specifying an encryption password. Use
+`-o` to set a different output file and `--force` to overwrite an existing wallet.
 
-When keys are sharded using `verify` will require at least K distinct
-keys.
+Use the `--seed` option to restore from a previously generated seed phrase.
+The CLI accepts 12 or 24 word BIP39 phrases from Helium mobile wallets or any
+valid BIP39 word list.
 
-The `--seed` option described above can also be used to construct a
-sharded wallet.
+#### Sharded
 
-#### Implementation details
+Sharding is supported via [Shamir's Secret Sharing](https://github.com/dsprenkels/sss).
+A key is split into N shards requiring K shards to recover:
+
+```
+helium-wallet create sharded -n 5 -k 3
+```
+
+Creates `wallet.key.1` through `wallet.key.5`. Use `-o` to set the base name.
+
+The `--seed` option works with sharded wallets too.
+
+#### Keypair
+
+```
+helium-wallet create keypair
+```
+
+#### Implementation Details
 
 A ed25519 key is generated via libsodium. The provided password is run
 through PBKDF2, with a configurable number of iterations and a random
@@ -92,154 +123,193 @@ file along with the sharding information, the key share (if
 applicable), the AES initialization vector, the PBKDF2 salt and
 iteration count and the AES-GCM authentication tag.
 
-
-### Public Key
-
-```
-    helium-wallet info
-    helium-wallet -f my.key info
-    helium-wallet -f wallet.key.1 -f wallet.key.2 -f my.key info
-```
-
-The given wallets will be read and information about the wallet,
-including the public key, displayed. This command works for all wallet
-types.
-
-### Displaying
-
-Displaying information for one or more wallets without needing its
-password can be done using;
-
+### `info` -- Wallet Information
 
 ```
-    helium-wallet info
+helium-wallet info
+helium-wallet -f my.key info
+helium-wallet -f wallet.key.1 -f wallet.key.2 -f my.key info
 ```
 
-To display a QR code for the public key of the given wallet use:
+Displays the wallet address and key type. Use `--qr` to display a QR code for
+the public key (useful for receiving tokens from the mobile wallet).
+
+This command also serves as verification for sharded wallets -- pass at least K
+shard files:
 
 ```
-    helium-wallet info --qr
+helium-wallet -f wallet.key.1 -f wallet.key.2 -f wallet.key.5 verify
 ```
 
-This is useful for sending tokens to the wallet from the mobile
-wallet.
-
-### Verifying
-
-Verifying a wallet takes a password and one or more wallet files and
-attempts to decrypt the wallet.
-
-The wallet is assumed to be sharded if the first file given to the
-verify command is a sharded wallet. The rest of the given files then
-also have to be wallet shards. For a sharded wallet to be verified, at
-least `K` wallet files must be passed in, where `K` is the value given
-when creating the wallet.
+### `balance` -- Token Balances
 
 ```
-    helium-wallet verify
-    helium-wallet -f wallet.key verify
-    helium-wallet -f wallet.key.1 -f wallet.key.2 -f wallet.key.5 verify
+helium-wallet balance
 ```
 
-### Sending Tokens
+Displays balances for HNT, MOBILE, IOT, DC, SOL, and USDC.
+
+### `transfer` (alias: `pay`) -- Send Tokens
 
 #### Single Payee
-To send tokens to one other account use:
 
 ```
-    helium-wallet pay one <payee> <hnt>
-    helium-wallet pay one <payee> <hnt> --commit
+helium-wallet transfer one <address> <amount> <token>
+helium-wallet transfer one <address> <amount> <token> --commit
 ```
 
-Where `<payee>` is the wallet address for the wallet you want to
-send tokens to, `<hnt>` is the number of HNT you want to send. Since 1 HNT
-is 100,000,000 bones the `hnt` value can go up to 8 decimal digits of
-precision.
+Tokens: `hnt`, `mobile`, `iot`, `usdc`, `sol`, `dc`. HNT supports 8 decimal
+places; MOBILE and IOT support 6.
 
-The default behavior of the `pay` command is to print out what the
-intended payment is going to be _without_ submitting it to the
-blockchain.  In the second example the `--commit` option commits the
-actual payment to the API for processing by the blockchain.
-
-#### Multiple Payees in one transaction
-To send tokens to multiple other accounts use:
+#### Multiple Payees
 
 ```
-    helium-wallet pay multi <path to json file>
-    helium-wallet pay multi <path to json file> --commit
+helium-wallet transfer multi <path-to-json>
+helium-wallet transfer multi <path-to-json> --commit
 ```
 
-Example json file:
+JSON format:
 
-```
-[ { "address": "<adddress1>", "amount": <hnt1>, "memo": "<memo1>" }, { "address": "<adddress2>", "amount": <hnt2>, "memo": "<memo2>" } ]
-```
-
-Where `<address#>` is the wallet address for the wallet you want to
-send tokens to, `<hnt#>` is the number of HNT you want to send. Since 1 HNT
-is 100,000,000 bones the `hnt` value can go up to 8 decimal digits of
-precision. `<memo#>` is an 8 byte base 64 encoded message.
-
-The default behavior of the `pay` command is to print out what the
-intended payment is going to be _without_ submitting it to the
-blockchain.  In the second example the `--commit` option commits the
-actual payment to the API for processing by the blockchain.
-
-
-### Environment Variables
-
-The following environment variables are supported:
-
-* `SOLANA_MAINNET_URL` - The Solana RPC URL to use for mainnet. 
-  This will get used by default or when `--url m` is passed in.
-  The default mainnet URL is a rate limited API served by the Helium 
-  Foundation. Use a custom provider for repeated or large requests.  
-
-* `SOLANA_DEVNET_URL` - The Solana RPC URL to use for devnet. 
-  This will get used when `--url d` is passed in.
-
-* `HELIUM_WALLET_PASSWORD` - The password to use to decrypt the
-  wallet. Useful for scripting or other non-interactive commands, but
-  use with care.
-
-* `HELIUM_WALLET_SEED_WORDS` - Space separated list of seed words to use
-  when restoring a wallet from a mnemonic word list.
-
-* `HELIUM_WALLET_SECRET` - Solana style byte array form of the keypair secret.
-
-### Building from Source
-
-You will need a working Rust tool-chain installed to build this CLI
-from source. In addition, you will need some basic build tools.
-
-If you wish to build from source instead of downloading
-[a prebuilt release](https://github.com/helium/helium-wallet-rs/releases/latest)
-you can add setup a Ubuntu 20.04 environment with the following:
-
-```
-sudo apt update
-sudo apt upgrade
-git clone https://github.com/helium/helium-wallet-rs
-cd helium-wallet-rs
-curl https://sh.rustup.rs -sSf | sh
-## recommended option 1
-source $HOME/.cargo/env
-sudo apt install build-essential pkg-config cmake clang
+```json
+[
+  { "address": "<address1>", "amount": 1.6, "token": "hnt" },
+  { "address": "<address2>", "amount": "max" },
+  { "address": "<address3>", "amount": 3, "token": "mobile" }
+]
 ```
 
-Clone this repo:
+Fields: `address` (required), `amount` (required, number or `"max"`),
+`token` (optional, defaults to `hnt`), `memo` (optional, 8-byte base64).
+
+### `swap` -- Swap Tokens via Jupiter
+
+Swap between tokens using the Jupiter V2 API.
 
 ```
-git clone https://github.com/helium/helium-wallet-rs
+helium-wallet swap <input_token> <output_token> <amount>
+helium-wallet swap hnt usdc 10 --commit
+helium-wallet swap mobile hnt 1000 --slippage-bps 200 --commit
 ```
 
-and build it using cargo:
+| Argument | Description |
+|---|---|
+| `input_token` | Source token: `hnt`, `mobile`, `iot`, `usdc`, `sol` |
+| `output_token` | Destination token: `hnt`, `mobile`, `iot`, `usdc`, `sol` |
+| `amount` | Human-readable amount (e.g. `1.5` for 1.5 HNT) |
+| `--slippage-bps` | Slippage tolerance in basis points. Default: 100 (1%) |
+
+Output includes `in_amount`, `out_amount`, `price_impact_pct`, and the
+transaction signature (when `--commit` is used).
+
+Jupiter environment variables (see [Environment Variables](#environment-variables)):
+`JUP_API_KEY`, `JUP_API_URL`, `JUP_SLIPPAGE_BPS`.
+
+### `burn` -- Burn Tokens
 
 ```
-cd helium-wallet-rs
-cargo build --release
+helium-wallet burn <subdao> <amount>
+helium-wallet burn iot 100 --commit
 ```
 
-The resulting `target/release/helium-wallet` is ready for use. Place
-it somewhere in your `$PATH` or run it straight from the target
-folder.
+Burns subdao tokens (IOT or MOBILE).
+
+### `hotspots` -- Hotspot Management
+
+Subcommands: `add`, `list`, `info`, `update`, `transfer`, `burn`, `rewards`, `updates`.
+
+```
+helium-wallet hotspots list
+helium-wallet hotspots info <address>
+helium-wallet hotspots add <subcommand>
+helium-wallet hotspots update <address> [options] --commit
+helium-wallet hotspots transfer <address> <new-owner> --commit
+helium-wallet hotspots burn <address> --commit
+helium-wallet hotspots rewards <subcommand>
+helium-wallet hotspots updates <address>
+```
+
+### `dc` -- Data Credit Operations
+
+Subcommands: `price`, `mint`, `delegate`, `burn`.
+
+```
+helium-wallet dc price
+helium-wallet dc mint <hnt-amount> --commit
+helium-wallet dc delegate <address> --commit
+helium-wallet dc burn <amount> --commit
+```
+
+### `assets` -- Asset Management
+
+Subcommands: `rewards`, `info`, `burn`, `transfer`.
+
+```
+helium-wallet assets info <asset>
+helium-wallet assets rewards <subcommand>
+helium-wallet assets burn <asset> --commit
+helium-wallet assets transfer <asset> <address> --commit
+```
+
+### `sign` -- Sign and Verify
+
+```
+helium-wallet sign file <path>
+helium-wallet sign msg <message>
+helium-wallet sign verify file <path> --signature <sig>
+helium-wallet sign verify msg <message> --signature <sig>
+```
+
+### `price` -- Token Prices
+
+```
+helium-wallet price
+```
+
+### `export` -- Export Wallet
+
+```
+helium-wallet export
+```
+
+### `upgrade` -- Upgrade Wallet Format
+
+```
+helium-wallet upgrade
+```
+
+### `memo` -- Encode/Decode Memos
+
+```
+helium-wallet memo <subcommand>
+```
+
+### `router` -- Router Operations
+
+```
+helium-wallet router <subcommand>
+```
+
+## Environment Variables
+
+### Solana RPC
+
+| Variable | Description |
+|---|---|
+| `SOLANA_MAINNET_URL` | Solana RPC URL for mainnet (used by default or with `--url m`). The default is a rate-limited API served by the Helium Foundation; use a custom provider for repeated or large requests |
+| `SOLANA_DEVNET_URL` | Solana RPC URL for devnet (used with `--url d`) |
+
+### Wallet
+
+| Variable | Description |
+|---|---|
+| `HELIUM_WALLET_PASSWORD` | Wallet decryption password. Useful for scripting; use with care |
+| `HELIUM_WALLET_SEED_WORDS` | Space-separated seed words for restoring a wallet |
+| `HELIUM_WALLET_SECRET` | Solana-style byte array keypair secret |
+
+### Jupiter (Swap)
+
+| Variable | Default | Description |
+|---|---|---|
+| `JUP_API_KEY` | _(none)_ | Jupiter API key. Optional -- omit for keyless access at 0.5 RPS |
+| `JUP_API_URL` | `https://api.jup.ag/swap/v2` | Jupiter API base URL |
+| `JUP_SLIPPAGE_BPS` | `100` (1%) | Default slippage tolerance in basis points |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Global options _precede_ the subcommand.
 | Option | Description |
 |---|---|
 | `-f` / `--file` | Wallet file(s). Repeat for sharded wallets or multiple wallets. Default: `wallet.key` |
-| `--format json\|table` | Output format |
 | `--url <URL>` | Solana RPC URL. Shortcuts: `m` (mainnet, default), `d` (devnet). Any full URL also accepted |
 
 ### Common Command Options
@@ -138,7 +137,7 @@ This command also serves as verification for sharded wallets -- pass at least K
 shard files:
 
 ```
-helium-wallet -f wallet.key.1 -f wallet.key.2 -f wallet.key.5 verify
+helium-wallet -f wallet.key.1 -f wallet.key.2 -f wallet.key.5 info
 ```
 
 ### `balance` -- Token Balances
@@ -149,7 +148,7 @@ helium-wallet balance
 
 Displays balances for HNT, MOBILE, IOT, DC, SOL, and USDC.
 
-### `transfer` (alias: `pay`) -- Send Tokens
+### `transfer` -- Send Tokens
 
 #### Single Payee
 
@@ -158,7 +157,7 @@ helium-wallet transfer one <address> <amount> <token>
 helium-wallet transfer one <address> <amount> <token> --commit
 ```
 
-Tokens: `hnt`, `mobile`, `iot`, `usdc`, `sol`, `dc`. HNT supports 8 decimal
+Tokens: `hnt`, `mobile`, `iot`, `usdc`, `sol`. HNT supports 8 decimal
 places; MOBILE and IOT support 6.
 
 #### Multiple Payees

--- a/helium-lib/README.md
+++ b/helium-lib/README.md
@@ -1,0 +1,93 @@
+# helium-lib
+
+Core Rust library for interacting with the Helium network on Solana. Used by
+the `helium-wallet` CLI and available for integration into other Rust projects.
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `asset` | Compressed NFT asset operations (fetch, transfer, burn, search) |
+| `b64` | Base64 message encoding/decoding |
+| `boosting` | Mobile hotspot hex boosting |
+| `client` | Solana RPC client wrapper with DAS (Digital Asset Standard) and gRPC config support |
+| `dao` | Helium DAO and SubDAO operations (HNT, IOT, MOBILE) |
+| `dc` | Data credit minting, delegation, and burning |
+| `entity_key` | Entity key management for hotspots |
+| `error` | Error types (`Error`, `DecodeError`, `EncodeError`, `ConfirmationError`, `JupiterError`) |
+| `hotspot` | Hotspot CRUD, transfer, and onboarding (submodules: `dataonly`, `info`, `cert`) |
+| `jupiter` | Token swaps via Jupiter V6 API |
+| `keypair` | Solana keypair wrappers with optional BIP39 mnemonic support |
+| `kta` | KeyToAsset (KTA) lookups |
+| `memo` | Memo encoding/decoding |
+| `message` | Versioned transaction message building |
+| `onboarding` | Hotspot onboarding API client |
+| `priority_fee` | Compute budget and priority fee calculation |
+| `programs` | On-chain program IDs (`helium_sub_daos`, `lazy_distributor`, etc.) |
+| `queue` | Reward queue operations |
+| `reward` | Reward claiming via lazy distributor |
+| `schedule` | Schedule-based reward claiming |
+| `token` | Token operations (HNT, MOBILE, IOT, DC, SOL, USDC) -- balances, transfers, burns, prices |
+| `transaction` | Versioned transaction building and confirmation |
+
+## Feature Flags
+
+| Feature | Description |
+|---------|-------------|
+| `clap` | Adds CLI argument parsing support (value parsers for `Token` types) |
+| `mnemonic` | Enables BIP39 mnemonic/seed phrase support for keypairs via `helium-mnemonic` |
+
+## Re-exports
+
+The crate re-exports several foundational Solana and Anchor crates for
+convenience, so downstream consumers do not need to manage version alignment
+themselves:
+
+- `anchor_client`
+- `anchor_lang`
+- `anchor_spl`
+- `solana_sdk` (includes `bs58`)
+- `solana_program`
+- `solana_client`
+- `solana_transaction_status`
+- `tuktuk_sdk`
+
+## Usage
+
+Add `helium-lib` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+helium-lib = { git = "https://github.com/helium/helium-wallet-rs" }
+```
+
+### Creating a client and querying a token balance
+
+```rust
+use helium_lib::{
+    client::Client,
+    keypair::Pubkey,
+    token::{self, Token},
+};
+use std::str::FromStr;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Connect to mainnet (accepts "m", "mainnet-beta", "d", "devnet", or a URL)
+    let client = Client::try_from("m")?;
+
+    // Initialize the KeyToAsset cache
+    helium_lib::init(client.solana_client.clone())?;
+
+    // Look up the HNT associated token address for a wallet
+    let wallet = Pubkey::from_str("YOUR_SOLANA_PUBKEY")?;
+    let hnt_address = Token::Hnt.associated_token_address(&wallet);
+
+    // Fetch the balance
+    if let Some(balance) = token::balance_for_address(&client, &hnt_address).await? {
+        println!("HNT balance: {}", balance.amount);
+    }
+
+    Ok(())
+}
+```

--- a/helium-lib/README.md
+++ b/helium-lib/README.md
@@ -16,7 +16,7 @@ the `helium-wallet` CLI and available for integration into other Rust projects.
 | `entity_key` | Entity key management for hotspots |
 | `error` | Error types (`Error`, `DecodeError`, `EncodeError`, `ConfirmationError`, `JupiterError`) |
 | `hotspot` | Hotspot CRUD, transfer, and onboarding (submodules: `dataonly`, `info`, `cert`) |
-| `jupiter` | Token swaps via Jupiter V6 API |
+| `jupiter` | Token swaps via Jupiter V2 API |
 | `keypair` | Solana keypair wrappers with optional BIP39 mnemonic support |
 | `kta` | KeyToAsset (KTA) lookups |
 | `memo` | Memo encoding/decoding |

--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -462,7 +462,7 @@ pub fn transfer_instruction(
     Ok(ix)
 }
 
-/// Get an unsigned transaction for an asset transfer
+/// Gets an unsigned transaction for an asset transfer.
 ///
 /// The asset is transferred from the owner to the given recipient
 /// Note that the owner is currently expected to sign this transaction and pay for
@@ -503,7 +503,7 @@ pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     Ok((txn, block_height))
 }
 
-/// Get an unsigned burn transaction for an asset
+/// Gets an unsigned burn transaction for an asset.
 pub async fn burn_message<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     pubkey: &Pubkey,

--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use solana_sdk::{signature::NullSigner, signer::Signer};
 use std::{collections::HashMap, result::Result as StdResult, str::FromStr};
 
+/// Fetches a compressed NFT asset for a given Helium entity key (e.g., hotspot public key).
 pub async fn for_entity_key<E, C: AsRef<DasClient>>(
     client: &C,
     entity_key: &E,
@@ -32,6 +33,7 @@ where
     for_kta(client, &kta).await
 }
 
+/// Fetches compressed NFT assets for multiple entity keys in batch.
 pub async fn for_entity_keys<E, C: AsRef<DasClient>>(
     client: &C,
     entity_keys: &[E],
@@ -43,6 +45,7 @@ where
     for_ktas(client, ktas.as_slice()).await
 }
 
+/// Fetches the compressed NFT asset referenced by a key-to-asset account.
 pub async fn for_kta<C: AsRef<DasClient>>(
     client: &C,
     kta: &helium_entity_manager::accounts::KeyToAssetV0,
@@ -50,6 +53,7 @@ pub async fn for_kta<C: AsRef<DasClient>>(
     get(client, &kta.asset).await
 }
 
+/// Fetches compressed NFT assets for multiple key-to-asset accounts in batch.
 pub async fn for_ktas<C: AsRef<DasClient>>(
     client: &C,
     ktas: &[helium_entity_manager::accounts::KeyToAssetV0],
@@ -58,6 +62,7 @@ pub async fn for_ktas<C: AsRef<DasClient>>(
     get_many(client, &pubkeys).await
 }
 
+/// Fetches both the asset and its Merkle proof from a key-to-asset account.
 pub async fn for_kta_with_proof<C: AsRef<DasClient> + AsRef<SolanaRpcClient>>(
     client: &C,
     kta: &helium_entity_manager::accounts::KeyToAssetV0,
@@ -65,11 +70,13 @@ pub async fn for_kta_with_proof<C: AsRef<DasClient> + AsRef<SolanaRpcClient>>(
     get_with_proof(client, &kta.asset).await
 }
 
+/// Fetches a single compressed NFT asset by its Solana public key.
 pub async fn get<C: AsRef<DasClient>>(client: &C, pubkey: &Pubkey) -> Result<Asset, Error> {
     let asset_response: Asset = client.as_ref().get_asset(pubkey).await?;
     Ok(asset_response)
 }
 
+/// Fetches multiple compressed NFT assets by their Solana public keys (batched in chunks of 1000).
 pub async fn get_many<C: AsRef<DasClient>>(
     client: &C,
     pubkeys: &[Pubkey],
@@ -86,6 +93,7 @@ pub async fn get_many<C: AsRef<DasClient>>(
     Ok(assets)
 }
 
+/// Fetches an asset and its Merkle proof concurrently. Needed for transfer/burn operations.
 pub async fn get_with_proof<C: AsRef<DasClient> + AsRef<SolanaRpcClient>>(
     client: &C,
     pubkey: &Pubkey,
@@ -94,6 +102,7 @@ pub async fn get_with_proof<C: AsRef<DasClient> + AsRef<SolanaRpcClient>>(
     Ok((asset, asset_proof))
 }
 
+/// Derives the Metaplex metadata PDA for a collection mint.
 pub fn collection_metadata_key(collection_key: &Pubkey) -> Pubkey {
     let (collection_metadata, _bump) = Pubkey::find_program_address(
         &[
@@ -106,6 +115,7 @@ pub fn collection_metadata_key(collection_key: &Pubkey) -> Pubkey {
     collection_metadata
 }
 
+/// Derives the Metaplex master edition PDA for a collection mint.
 pub fn collection_master_edition_key(collection_key: &Pubkey) -> Pubkey {
     let (collection_master_edition, _cme_bump) = Pubkey::find_program_address(
         &[
@@ -119,18 +129,21 @@ pub fn collection_master_edition_key(collection_key: &Pubkey) -> Pubkey {
     collection_master_edition
 }
 
+/// Derives the Bubblegum tree authority PDA for a given Merkle tree.
 pub fn merkle_tree_authority(merkle_tree: &Pubkey) -> Pubkey {
     let (tree_authority, _ta_bump) =
         Pubkey::find_program_address(&[merkle_tree.as_ref()], &bubblegum::ID);
     tree_authority
 }
 
+/// Derives the Bubblegum collection CPI signer PDA.
 pub fn bubblegum_signer() -> Pubkey {
     let (bubblegum_signer, _bump) =
         Pubkey::find_program_address(&[b"collection_cpi"], &bubblegum::ID);
     bubblegum_signer
 }
 
+/// Utilities for determining Merkle tree canopy heights, used to trim proof sizes.
 pub mod canopy {
     use super::*;
     use crate::spl_account_compression::types::{
@@ -169,6 +182,7 @@ pub mod canopy {
         Ok(canopy_depth as usize)
     }
 
+    /// Returns the canopy height for a single Merkle tree.
     pub async fn height<C: AsRef<SolanaRpcClient>>(
         client: &C,
         tree: &Pubkey,
@@ -180,6 +194,7 @@ pub mod canopy {
         height_from_account(&tree_account)
     }
 
+    /// Returns canopy heights for multiple Merkle trees, using a remote cache when available.
     pub async fn heights<C: AsRef<SolanaRpcClient>>(
         client: &C,
         trees: &[Pubkey],
@@ -325,9 +340,11 @@ pub mod canopy {
     }
 }
 
+/// Functions for fetching Merkle proofs from DAS, with canopy height applied.
 pub mod proof {
     use super::*;
 
+    /// Fetches the Merkle proof for a single asset, including canopy height.
     pub async fn get<C: AsRef<DasClient> + AsRef<SolanaRpcClient>>(
         client: &C,
         pubkey: &Pubkey,
@@ -339,6 +356,7 @@ pub mod proof {
         Ok(asset_proof)
     }
 
+    /// Fetches Merkle proofs for multiple assets in batch, including canopy heights.
     pub async fn get_many<C: AsRef<DasClient> + AsRef<SolanaRpcClient>>(
         client: &C,
         pubkeys: &[Pubkey],
@@ -369,6 +387,7 @@ pub mod proof {
     }
 }
 
+/// Searches for compressed NFT assets using DAS search parameters.
 pub async fn search<C: AsRef<DasClient>>(
     client: &C,
     params: DasSearchAssetsParams,
@@ -376,6 +395,7 @@ pub async fn search<C: AsRef<DasClient>>(
     Ok(client.as_ref().search_assets(params).await?)
 }
 
+/// Returns all assets owned by a wallet that match a given creator, with automatic pagination.
 pub async fn for_owner<C: AsRef<DasClient>>(
     client: &C,
     creator: &Pubkey,
@@ -402,6 +422,7 @@ pub async fn for_owner<C: AsRef<DasClient>>(
     Ok(results)
 }
 
+/// Builds a Bubblegum transfer instruction for a compressed NFT asset.
 pub fn transfer_instruction(
     recipient: &Pubkey,
     asset: &Asset,
@@ -467,6 +488,7 @@ pub async fn transfer_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     Ok((txn, block_height))
 }
 
+/// Signs and returns a transaction to transfer a compressed NFT to a new owner.
 pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     pubkey: &Pubkey,
@@ -529,6 +551,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     message::mk_message(client, ixs, &opts.lut_addresses, &asset.ownership.owner).await
 }
 
+/// Signs and returns a transaction to permanently burn (destroy) a compressed NFT.
 pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     pubkey: &Pubkey,
@@ -540,6 +563,7 @@ pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     Ok((txn, block_height))
 }
 
+/// A paginated list of compressed NFT assets returned from a DAS search.
 #[derive(Deserialize, Serialize, Clone)]
 pub struct AssetPage {
     pub total: u32,
@@ -548,8 +572,10 @@ pub struct AssetPage {
     pub items: Vec<Asset>,
 }
 
+/// A Solana compressed NFT (cNFT) representing a Helium entity such as a hotspot.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Asset {
+    /// The asset's on-chain address.
     #[serde(with = "serde_pubkey")]
     pub id: Pubkey,
     pub compression: AssetCompression,
@@ -561,6 +587,7 @@ pub struct Asset {
     pub burnt: bool,
 }
 
+/// A creator entry on a compressed NFT, with verification status and royalty share.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AssetCreator {
     #[serde(with = "serde_pubkey")]
@@ -571,6 +598,7 @@ pub struct AssetCreator {
 
 pub type Hash = [u8; 32];
 
+/// Compression metadata for a cNFT: hashes, leaf position, and the Merkle tree it belongs to.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AssetCompression {
     #[serde(with = "serde_hash")]
@@ -588,6 +616,7 @@ impl AssetCompression {
     }
 }
 
+/// A collection group that a compressed NFT belongs to (e.g., the Helium hotspot collection).
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AssetGroup {
     pub group_key: String,
@@ -595,6 +624,7 @@ pub struct AssetGroup {
     pub group_value: Pubkey,
 }
 
+/// Ownership information for a compressed NFT: current owner and optional delegate.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AssetOwnership {
     #[serde(with = "serde_pubkey")]
@@ -603,6 +633,7 @@ pub struct AssetOwnership {
     pub delegate: Option<Pubkey>,
 }
 
+/// Merkle proof for a compressed NFT, required for on-chain operations (transfer, burn, etc.).
 #[derive(Debug, Deserialize, Clone)]
 pub struct AssetProof {
     pub proof: Vec<String>,
@@ -665,12 +696,14 @@ impl AssetProof {
     }
 }
 
+/// The off-chain content associated with a compressed NFT (metadata URI and parsed metadata).
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AssetContent {
     pub metadata: AssetMetadata,
     pub json_uri: url::Url,
 }
 
+/// Parsed JSON metadata for a compressed NFT, including name, symbol, and trait attributes.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AssetMetadata {
     #[serde(default)]
@@ -690,6 +723,7 @@ impl AssetMetadata {
     }
 }
 
+/// A single key-value trait attribute from an asset's metadata (e.g., `"trait_type": "entity_key"`).
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AssetMetadataAttribute {
     #[serde(default)]

--- a/helium-lib/src/b64.rs
+++ b/helium-lib/src/b64.rs
@@ -5,16 +5,19 @@ use base64::{
 };
 use helium_proto::Message;
 
+/// Base64-encode bytes using the standard alphabet.
 pub fn encode<T: AsRef<[u8]>>(v: T) -> String {
     STANDARD.encode(v.as_ref())
 }
 
+/// Serialize a protobuf message and base64-encode the result.
 pub fn encode_message<T: Message>(v: &T) -> Result<String, EncodeError> {
     let mut buf = vec![];
     v.encode(&mut buf).map_err(EncodeError::from)?;
     Ok(STANDARD.encode(buf))
 }
 
+/// Base64-decode a string and deserialize it as a protobuf message.
 pub fn decode_message<T>(v: &str) -> Result<T, DecodeError>
 where
     T: Message + Default,
@@ -24,24 +27,29 @@ where
     Ok(message)
 }
 
+/// Base64-encode bytes using the URL-safe alphabet without padding.
 pub fn url_encode<T: AsRef<[u8]>>(v: T) -> String {
     URL_SAFE_NO_PAD.encode(v.as_ref())
 }
 
+/// Base64-decode bytes using the standard alphabet.
 pub fn decode<T: AsRef<[u8]>>(v: T) -> Result<Vec<u8>, DecodeError> {
     STANDARD.decode(v.as_ref()).map_err(DecodeError::from)
 }
 
+/// Base64-decode bytes using the URL-safe alphabet without padding.
 pub fn url_decode<T: AsRef<[u8]>>(v: T) -> Result<Vec<u8>, DecodeError> {
     URL_SAFE_NO_PAD
         .decode(v.as_ref())
         .map_err(DecodeError::from)
 }
 
+/// Base64-encode a `u64` as little-endian bytes.
 pub fn encode_u64(v: u64) -> String {
     STANDARD.encode(v.to_le_bytes())
 }
 
+/// Base64-decode a string into a `u64` (little-endian).
 pub fn decode_u64(v: &str) -> Result<u64, DecodeError> {
     let decoded = STANDARD.decode(v).map_err(DecodeError::from)?;
     let int_bytes = decoded.as_slice().try_into().map_err(DecodeError::from)?;

--- a/helium-lib/src/boosting.rs
+++ b/helium-lib/src/boosting.rs
@@ -10,13 +10,19 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 
+/// Parameters required to activate hex boosting for a mobile hotspot.
 pub trait StartBoostingHex {
+    /// The authority that can start boosting.
     fn start_authority(&self) -> Pubkey;
+    /// The boost configuration account.
     fn boost_config(&self) -> Pubkey;
+    /// The boosted hex account.
     fn boosted_hex(&self) -> Pubkey;
+    /// When the boost should become active.
     fn activation_ts(&self) -> DateTime<Utc>;
 }
 
+/// Build a message that activates hex boosting for a set of hexes.
 pub async fn start_boost_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     keypair: &Keypair,
@@ -73,6 +79,7 @@ pub async fn start_boost_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, &ixs, &opts.lut_addresses, &keypair.pubkey()).await
 }
 
+/// Activate hex boosting and return a signed transaction.
 pub async fn start_boost<C: AsRef<SolanaRpcClient>>(
     client: &C,
     updates: impl IntoIterator<Item = impl StartBoostingHex>,

--- a/helium-lib/src/boosting.rs
+++ b/helium-lib/src/boosting.rs
@@ -22,7 +22,7 @@ pub trait StartBoostingHex {
     fn activation_ts(&self) -> DateTime<Utc>;
 }
 
-/// Build a message that activates hex boosting for a set of hexes.
+/// Builds a message that activates hex boosting for a set of hexes.
 pub async fn start_boost_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     keypair: &Keypair,

--- a/helium-lib/src/client.rs
+++ b/helium-lib/src/client.rs
@@ -12,39 +12,62 @@ use jsonrpc_client::{JsonRpcError, SendRequest};
 use std::{collections::HashMap, marker::Send, sync::Arc};
 use tracing::instrument;
 
+/// Mainnet onboarding server base URL.
 pub static ONBOARDING_URL_MAINNET: &str = "https://onboarding.dewi.org/api/v3";
+/// Devnet onboarding server base URL.
 pub static ONBOARDING_URL_DEVNET: &str = "https://onboarding.web.test-helium.com/api/v3";
 
+/// Mainnet ECC verifier URL.
 pub static VERIFIER_URL_MAINNET: &str = "https://ecc-verifier.web.helium.io";
+/// Devnet ECC verifier URL.
 pub static VERIFIER_URL_DEVNET: &str = "https://ecc-verifier.web.test-helium.com";
 
+/// Default mainnet Solana RPC endpoint.
 pub static SOLANA_URL_MAINNET: &str = "https://solana-rpc.web.helium.io:443";
+/// Default devnet Solana RPC endpoint.
 pub static SOLANA_URL_DEVNET: &str = "https://solana-rpc.web.test-helium.com";
+/// Environment variable to override the mainnet Solana RPC URL.
 pub static SOLANA_URL_MAINNET_ENV: &str = "SOLANA_MAINNET_URL";
+/// Environment variable to override the devnet Solana RPC URL.
 pub static SOLANA_URL_DEVNET_ENV: &str = "SOLANA_DEVNET_URL";
 
+/// Default mainnet certificate service URL.
 pub static CERT_URL_MAINNET: &str = "https://api.prod.ims.nova.xyz/api/wifi/brownfield/inventory";
+/// Default devnet certificate service URL.
 pub static CERT_URL_DEVNET: &str = "https://api.svt.ims.nova.xyz/api/wifi/brownfield/inventory";
+/// Environment variable to override the mainnet certificate URL.
 pub static CERT_URL_MAINNET_ENV: &str = "CERT_MAINNET_URL";
+/// Environment variable to override the devnet certificate URL.
 pub static CERT_URL_DEVNET_ENV: &str = "CERT_DEVNET_URL";
 
 pub use crate::hotspot::cert::Client as CertClient;
 pub use solana_client::nonblocking::rpc_client::RpcClient as SolanaRpcClient;
 
+/// Returns `true` if the given URL refers to a devnet endpoint.
 pub fn is_devnet(url: &str) -> bool {
     url == "d" || url.starts_with("devnet") || url.contains("test-helium")
 }
 
+/// Main Solana RPC client for helium-lib operations.
+///
+/// Wraps a Solana RPC client, a DAS (Digital Asset Standard) client, and a
+/// certificate service client behind shared handles.
 #[derive(Clone)]
 pub struct Client {
+    /// Solana JSON-RPC client.
     pub solana_client: Arc<SolanaRpcClient>,
+    /// Digital Asset Standard API client for compressed NFT lookups.
     pub das_client: Arc<DasClient>,
+    /// Certificate service client for hotspot location verification.
     pub cert_client: Arc<CertClient>,
 }
 
+/// Deserializes on-chain accounts into Anchor program types.
 #[async_trait::async_trait]
 pub trait GetAnchorAccount {
+    /// Fetch and deserialize a single account.
     async fn anchor_account<T: AccountDeserialize>(&self, pubkey: &Pubkey) -> Result<T, Error>;
+    /// Fetch and deserialize multiple accounts, returning `None` for missing ones.
     async fn anchor_accounts<T: AccountDeserialize + Send>(
         &self,
         pubkeys: &[Pubkey],
@@ -156,6 +179,7 @@ impl AsRef<CertClient> for Client {
     }
 }
 
+/// Parameters for the DAS `searchAssets` RPC method.
 #[derive(
     serde::Serialize, Default, Debug, Clone, std::hash::Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -180,6 +204,8 @@ pub struct DasSearchAssetsParams {
 }
 
 impl DasSearchAssetsParams {
+    /// Build search params that find assets owned by `owner_address` and
+    /// created by `creator_address`.
     pub fn for_owner(owner_address: Pubkey, creator_address: Pubkey) -> Self {
         Self {
             owner_address: Some(owner_address),
@@ -191,6 +217,7 @@ impl DasSearchAssetsParams {
     }
 }
 
+/// Errors from DAS RPC requests.
 #[derive(Debug, thiserror::Error)]
 pub enum DasClientError {
     #[error("jsonrpc: {0}")]
@@ -214,6 +241,7 @@ impl From<JsonRpcError> for DasClientError {
 }
 
 impl DasClientError {
+    /// Returns `true` if the error indicates a missing on-chain record.
     pub fn is_account_not_found(&self) -> bool {
         match self {
             Self::Rpc(jsonrpc_client::Error::JsonRpc(jsonrpc_client::JsonRpcError {
@@ -224,6 +252,7 @@ impl DasClientError {
         }
     }
 
+    /// Construct a `MissingKey` error for a response field that was expected but absent.
     pub fn missing_response_key<S: ToString>(v: S) -> Self {
         Self::MissingKey(v.to_string())
     }
@@ -234,6 +263,7 @@ pub trait DAS {}
 
 static USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
+/// Digital Asset Standard API client for compressed NFT lookups.
 #[jsonrpc_client::implement(DAS)]
 #[derive(Debug, Clone)]
 pub struct DasClient {
@@ -249,6 +279,7 @@ impl Default for DasClient {
 }
 
 impl DasClient {
+    /// Create a DAS client targeting the given Solana RPC URL.
     pub fn with_base_url(url: &str) -> Result<Self, Error> {
         let client = reqwest::Client::new();
         let base_url = url.parse().map_err(DecodeError::from)?;
@@ -258,6 +289,7 @@ impl DasClient {
         })
     }
 
+    /// Fetch a single asset by its on-chain address.
     #[instrument(skip(self), level = "trace")]
     pub async fn get_asset(&self, address: &Pubkey) -> Result<asset::Asset, DasClientError> {
         let body = jsonrpc_client::Request::new_v2("getAsset")
@@ -272,6 +304,7 @@ impl DasClient {
         Ok(response)
     }
 
+    /// Fetch multiple assets in a single RPC call.
     #[instrument(skip(self), level = "trace")]
     pub async fn get_asset_batch(
         &self,
@@ -292,6 +325,7 @@ impl DasClient {
         Ok(response)
     }
 
+    /// Fetch the Merkle proof for a compressed asset.
     #[instrument(skip(self), level = "trace")]
     pub async fn get_asset_proof(
         &self,
@@ -309,6 +343,7 @@ impl DasClient {
         Ok(response)
     }
 
+    /// Fetch Merkle proofs for multiple compressed assets in one call.
     #[instrument(skip(self), level = "trace")]
     pub async fn get_asset_proof_batch(
         &self,
@@ -343,6 +378,7 @@ impl DasClient {
         Ok(result)
     }
 
+    /// Search for assets matching the given filter parameters.
     #[instrument(skip(self, params), level = "trace")]
     pub async fn search_assets(
         &self,
@@ -388,6 +424,7 @@ impl jsonrpc_client::SendRequest for DasClient {
     }
 }
 
+/// gRPC config service clients for querying IoT and Mobile hotspot metadata.
 pub mod config {
     use super::*;
     use crate::{
@@ -399,8 +436,11 @@ pub mod config {
     use stream::BoxStream;
     use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 
+    /// gRPC connection timeout.
     pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+    /// gRPC request timeout.
     pub const RPC_TIMEOUT: Duration = Duration::from_secs(10);
+    /// TCP keepalive interval for gRPC connections.
     pub const RPC_TCP_KEEPALIVE: Duration = Duration::from_secs(100);
 
     trait MessageSign {
@@ -465,13 +505,17 @@ pub mod config {
         Ok(endpoint.connect_lazy())
     }
 
+    /// Unified config client for either the IoT or Mobile sub-DAO.
     #[derive(Clone)]
     pub enum Client {
+        /// IoT config service client.
         Iot(iot::Client),
+        /// Mobile config service client.
         Mobile(mobile::Client),
     }
 
     impl Client {
+        /// Create a config client for the given sub-DAO.
         pub fn for_subdao(
             subdao: SubDao,
             config: &str,
@@ -485,6 +529,7 @@ pub mod config {
             Ok(result)
         }
 
+        /// Look up hotspot info for a single address.
         pub async fn info(
             &mut self,
             address: &helium_crypto::PublicKey,
@@ -495,6 +540,7 @@ pub mod config {
             }
         }
 
+        /// Look up hotspot info for multiple addresses.
         pub async fn batch_info(
             &mut self,
             addresses: &[helium_crypto::PublicKey],
@@ -505,6 +551,7 @@ pub mod config {
             }
         }
 
+        /// Stream hotspot info updated since the given unix timestamp.
         pub async fn stream_info_since(
             &mut self,
             updated_since: u64,
@@ -518,6 +565,7 @@ pub mod config {
             }
         }
 
+        /// Stream batches of hotspot info updated since the given unix timestamp.
         pub async fn stream_batch_info_since(
             &mut self,
             updated_since: u64,
@@ -541,6 +589,7 @@ pub mod config {
         }
     }
 
+    /// IoT config service gateway client.
     pub mod iot {
         use super::*;
         use helium_proto::services::iot_config::{
@@ -553,6 +602,7 @@ pub mod config {
         impl_message_verify!(GatewayInfoResV1);
         impl_message_verify!(GatewayInfoStreamResV1);
 
+        /// IoT gateway config service client.
         #[derive(Clone)]
         pub struct Client {
             keypair: Arc<helium_crypto::Keypair>,
@@ -561,6 +611,7 @@ pub mod config {
         }
 
         impl Client {
+            /// Connect to the IoT config service at the given URI.
             pub fn new(
                 uri: &str,
                 address: helium_crypto::PublicKey,
@@ -575,6 +626,7 @@ pub mod config {
                 })
             }
 
+            /// Look up a single IoT hotspot by its public key.
             pub async fn info(
                 &mut self,
                 address: &helium_crypto::PublicKey,
@@ -596,6 +648,7 @@ pub mod config {
                 }
             }
 
+            /// Look up IoT hotspot info for multiple public keys.
             pub async fn batch_info(
                 &mut self,
                 addresses: &[helium_crypto::PublicKey],
@@ -615,6 +668,7 @@ pub mod config {
                     .await
             }
 
+            /// Stream IoT hotspot info, one entry at a time.
             pub async fn stream_info_since(
                 &mut self,
                 _updated_since: u64,
@@ -630,6 +684,7 @@ pub mod config {
                 Ok(streaming.boxed())
             }
 
+            /// Stream IoT hotspot info in batches of `batch_size`.
             pub async fn stream_batch_info_since(
                 &mut self,
                 _updated_since: u64,
@@ -693,6 +748,7 @@ pub mod config {
         }
     }
 
+    /// Mobile config service gateway client.
     pub mod mobile {
         use super::*;
         use helium_proto::services::mobile_config::{
@@ -708,6 +764,7 @@ pub mod config {
         impl_message_verify!(GatewayInfoStreamResV2);
         impl_message_verify!(GatewayInfoStreamResV4);
 
+        /// Mobile gateway config service client.
         #[derive(Clone)]
         pub struct Client {
             keypair: Arc<helium_crypto::Keypair>,
@@ -716,6 +773,7 @@ pub mod config {
         }
 
         impl Client {
+            /// Connect to the Mobile config service at the given URI.
             pub fn new(
                 uri: &str,
                 address: helium_crypto::PublicKey,
@@ -730,6 +788,7 @@ pub mod config {
                 })
             }
 
+            /// Look up a single Mobile hotspot by its public key.
             pub async fn info(
                 &mut self,
                 address: &helium_crypto::PublicKey,
@@ -751,6 +810,7 @@ pub mod config {
                 }
             }
 
+            /// Look up Mobile hotspot info for multiple public keys.
             pub async fn batch_info(
                 &mut self,
                 addresses: &[helium_crypto::PublicKey],
@@ -787,6 +847,7 @@ pub mod config {
                     .map(|vec| vec.into_iter().collect())
             }
 
+            /// Stream Mobile hotspot info updated since the given unix timestamp.
             pub async fn stream_info_since(
                 &mut self,
                 updated_since: u64,
@@ -802,6 +863,7 @@ pub mod config {
                 Ok(streaming.boxed())
             }
 
+            /// Stream Mobile hotspot info in batches using the V4 protocol.
             pub async fn stream_batch_info_since(
                 &mut self,
                 updated_since: u64,

--- a/helium-lib/src/dao.rs
+++ b/helium-lib/src/dao.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use sha2::{Digest, Sha256};
 
+/// The top-level Helium DAO. Currently only HNT.
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize, Default,
 )]
@@ -21,6 +22,7 @@ impl std::fmt::Display for Dao {
 }
 
 impl Dao {
+    /// Derive the on-chain PDA for this DAO.
     pub fn key(&self) -> Pubkey {
         let mint = match self {
             Self::Hnt => Token::Hnt.mint(),
@@ -30,6 +32,7 @@ impl Dao {
         dao_key
     }
 
+    /// Derive the data-only config PDA.
     pub fn dataonly_config_key(&self) -> Pubkey {
         let (key, _) = Pubkey::find_program_address(
             &[b"data_only_config", self.key().as_ref()],
@@ -38,6 +41,7 @@ impl Dao {
         key
     }
 
+    /// Derive the data-only escrow PDA.
     pub fn dataonly_escrow_key(&self) -> Pubkey {
         let (data_only_escrow, _doe_bump) = Pubkey::find_program_address(
             &[b"data_only_escrow", self.dataonly_config_key().as_ref()],
@@ -46,6 +50,7 @@ impl Dao {
         data_only_escrow
     }
 
+    /// Derive the entity creator PDA for the helium entity manager.
     pub fn entity_creator_key(&self) -> Pubkey {
         let (key, _) = Pubkey::find_program_address(
             &[b"entity_creator", self.key().as_ref()],
@@ -54,6 +59,7 @@ impl Dao {
         key
     }
 
+    /// Derive the KeyToAsset PDA for the given entity key.
     pub fn entity_key_to_kta_key<E: AsEntityKey + ?Sized>(&self, entity_key: &E) -> Pubkey {
         let hash = Sha256::digest(entity_key.as_entity_key());
         let (key, _) = Pubkey::find_program_address(
@@ -63,16 +69,19 @@ impl Dao {
         key
     }
 
+    /// Derive the rewards oracle signer PDA.
     pub fn oracle_signer_key() -> Pubkey {
         let (key, _) = Pubkey::find_program_address(&[b"oracle_signer"], &rewards_oracle::ID);
         key
     }
 
+    /// Derive the DC account payer PDA.
     pub fn dc_account_payer() -> Pubkey {
         let (key, _) = Pubkey::find_program_address(&[b"account_payer"], &data_credits::ID);
         key
     }
 
+    /// Derive the data credits PDA.
     pub fn dc_key() -> Pubkey {
         let (key, _) =
             Pubkey::find_program_address(&[b"dc", Token::Dc.mint().as_ref()], &data_credits::ID);
@@ -80,6 +89,7 @@ impl Dao {
     }
 }
 
+/// A Helium sub-DAO (IoT or Mobile).
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "lowercase")]
@@ -99,10 +109,12 @@ impl std::fmt::Display for SubDao {
 }
 
 impl SubDao {
+    /// Return all sub-DAO variants.
     pub const fn all() -> [SubDao; 2] {
         [SubDao::Iot, SubDao::Mobile]
     }
 
+    /// Derive the on-chain PDA for this sub-DAO.
     pub fn key(&self) -> Pubkey {
         let (subdao_key, _) = Pubkey::find_program_address(
             &[b"sub_dao", self.token().mint().as_ref()],
@@ -111,6 +123,7 @@ impl SubDao {
         subdao_key
     }
 
+    /// The native token for this sub-DAO.
     pub fn token(&self) -> Token {
         match self {
             Self::Iot => Token::Iot,
@@ -118,6 +131,7 @@ impl SubDao {
         }
     }
 
+    /// Derive the delegated DC PDA for a router key.
     pub fn delegated_dc_key<E: AsEntityKey>(&self, router_key: &E) -> Pubkey {
         let hash = Sha256::digest(router_key.as_entity_key());
         let (key, _) = Pubkey::find_program_address(
@@ -127,6 +141,7 @@ impl SubDao {
         key
     }
 
+    /// Derive the DC escrow PDA for a delegated DC account.
     pub fn escrow_key(&self, delegated_dc_key: &Pubkey) -> Pubkey {
         let (key, _) = Pubkey::find_program_address(
             &[b"escrow_dc_account", delegated_dc_key.as_ref()],
@@ -135,6 +150,7 @@ impl SubDao {
         key
     }
 
+    /// Derive the rewardable entity config PDA.
     pub fn rewardable_entity_config_key(&self) -> Pubkey {
         let suffix = match self {
             Self::Iot => b"IOT".as_ref(),
@@ -147,6 +163,7 @@ impl SubDao {
         key
     }
 
+    /// Derive the hotspot info PDA for the given entity key.
     pub fn info_key<E: AsEntityKey>(&self, entity_key: &E) -> Pubkey {
         let hash = Sha256::digest(entity_key.as_entity_key());
         let config_key = self.rewardable_entity_config_key();
@@ -161,6 +178,7 @@ impl SubDao {
         key
     }
 
+    /// Derive the sub-DAO config PDA (e.g. `iot_config` or `mobile_config`).
     pub fn config_key(&self) -> Pubkey {
         let prefix = match self {
             Self::Iot => "iot_config",
@@ -173,6 +191,7 @@ impl SubDao {
         key
     }
 
+    /// Derive the current epoch info PDA based on today's date.
     pub fn epoch_info_key(&self) -> Pubkey {
         const EPOCH_LENGTH: i64 = 60 * 60 * 24;
         let epoch = chrono::Utc::now().timestamp() / EPOCH_LENGTH;

--- a/helium-lib/src/dc.rs
+++ b/helium-lib/src/dc.rs
@@ -15,7 +15,7 @@ use crate::{
     TransactionOpts,
 };
 
-/// Build a message that mints data credits by burning HNT.
+/// Builds a message that mints data credits by burning HNT.
 pub async fn mint_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: TokenAmount,
@@ -89,7 +89,7 @@ pub async fn mint_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, ixs, &opts.lut_addresses, payer).await
 }
 
-/// Mint data credits by burning HNT and return a signed transaction.
+/// Mints data credits by burning HNT and returns a signed transaction.
 pub async fn mint<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: TokenAmount,
@@ -102,7 +102,7 @@ pub async fn mint<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
-/// Build a message that delegates data credits to a router/OUI.
+/// Builds a message that delegates data credits to a router/OUI.
 pub async fn delegate_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     subdao: SubDao,
@@ -154,7 +154,7 @@ pub async fn delegate_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, ixs, &opts.lut_addresses, owner).await
 }
 
-/// Delegate data credits to a router/OUI and return a signed transaction.
+/// Delegates data credits to a router/OUI and returns a signed transaction.
 pub async fn delegate<C: AsRef<SolanaRpcClient>>(
     client: &C,
     subdao: SubDao,
@@ -169,7 +169,7 @@ pub async fn delegate<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
-/// Build a message that burns data credits without tracking.
+/// Builds a message that burns data credits without tracking.
 pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: u64,
@@ -212,7 +212,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, ixs, &opts.lut_addresses, owner).await
 }
 
-/// Burn data credits and return a signed transaction.
+/// Burns data credits and returns a signed transaction.
 pub async fn burn<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: u64,
@@ -224,7 +224,7 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
-/// Build a message that burns delegated data credits for a router.
+/// Builds a message that burns delegated data credits for a router.
 pub async fn burn_delegated_message<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     client: &C,
     sub_dao: SubDao,
@@ -296,7 +296,7 @@ pub async fn burn_delegated_message<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     message::mk_message(client, ixs, &opts.lut_addresses, payer).await
 }
 
-/// Burn delegated data credits and return a signed transaction.
+/// Burns delegated data credits and returns a signed transaction.
 pub async fn burn_delegated<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     client: &C,
     sub_dao: SubDao,

--- a/helium-lib/src/dc.rs
+++ b/helium-lib/src/dc.rs
@@ -15,6 +15,7 @@ use crate::{
     TransactionOpts,
 };
 
+/// Build a message that mints data credits by burning HNT.
 pub async fn mint_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: TokenAmount,
@@ -48,14 +49,14 @@ pub async fn mint_message<C: AsRef<SolanaRpcClient>>(
             hnt_mint: *Token::Hnt.mint(),
             dc_mint: *Token::Dc.mint(),
             recipient,
-            recipient_token_account: Token::Dc.associated_token_adress(&recipient),
+            recipient_token_account: Token::Dc.associated_token_address(&recipient),
             system_program: solana_sdk::system_program::ID,
             token_program: anchor_spl::token::ID,
             associated_token_program: anchor_spl::associated_token::ID,
             hnt_price_oracle,
             circuit_breaker_program: circuit_breaker::ID,
             circuit_breaker: Token::Dc.mint_circuit_breaker_address(),
-            burner: Token::Hnt.associated_token_adress(owner),
+            burner: Token::Hnt.associated_token_address(owner),
         }
     }
 
@@ -88,6 +89,7 @@ pub async fn mint_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, ixs, &opts.lut_addresses, payer).await
 }
 
+/// Mint data credits by burning HNT and return a signed transaction.
 pub async fn mint<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: TokenAmount,
@@ -100,6 +102,7 @@ pub async fn mint<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
+/// Build a message that delegates data credits to a router/OUI.
 pub async fn delegate_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     subdao: SubDao,
@@ -116,7 +119,7 @@ pub async fn delegate_message<C: AsRef<SolanaRpcClient>>(
             dao: Dao::Hnt.key(),
             sub_dao: subdao.key(),
             owner,
-            from_account: Token::Dc.associated_token_adress(&owner),
+            from_account: Token::Dc.associated_token_address(&owner),
             escrow_account: subdao.escrow_key(&delegated_dc_key),
             payer: owner,
             associated_token_program: anchor_spl::associated_token::ID,
@@ -151,6 +154,7 @@ pub async fn delegate_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, ixs, &opts.lut_addresses, owner).await
 }
 
+/// Delegate data credits to a router/OUI and return a signed transaction.
 pub async fn delegate<C: AsRef<SolanaRpcClient>>(
     client: &C,
     subdao: SubDao,
@@ -165,6 +169,7 @@ pub async fn delegate<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
+/// Build a message that burns data credits without tracking.
 pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: u64,
@@ -174,7 +179,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
     fn mk_accounts(owner: Pubkey) -> impl ToAccountMetas {
         data_credits::client::accounts::BurnWithoutTrackingV0 {
             burn_accounts: data_credits::client::accounts::BurnAccounts {
-                burner: Token::Dc.associated_token_adress(&owner),
+                burner: Token::Dc.associated_token_address(&owner),
                 dc_mint: *Token::Dc.mint(),
                 data_credits: Dao::dc_key(),
                 token_program: anchor_spl::token::ID,
@@ -207,6 +212,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, ixs, &opts.lut_addresses, owner).await
 }
 
+/// Burn data credits and return a signed transaction.
 pub async fn burn<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: u64,
@@ -218,6 +224,7 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
+/// Build a message that burns delegated data credits for a router.
 pub async fn burn_delegated_message<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     client: &C,
     sub_dao: SubDao,
@@ -289,6 +296,7 @@ pub async fn burn_delegated_message<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     message::mk_message(client, ixs, &opts.lut_addresses, payer).await
 }
 
+/// Burn delegated data credits and return a signed transaction.
 pub async fn burn_delegated<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     client: &C,
     sub_dao: SubDao,

--- a/helium-lib/src/entity_key.rs
+++ b/helium-lib/src/entity_key.rs
@@ -2,7 +2,9 @@ use crate::{error::DecodeError, helium_entity_manager};
 use solana_sdk::bs58;
 use std::{fmt::Display, hash::Hash};
 
+/// Convert a value to its on-chain entity key byte representation.
 pub trait AsEntityKey {
+    /// Return the entity key bytes used for PDA derivation.
     fn as_entity_key(&self) -> Vec<u8>;
 }
 
@@ -46,6 +48,7 @@ impl AsEntityKey for helium_crypto::PublicKeyBinary {
 
 pub use helium_entity_manager::types::KeySerialization;
 
+/// Parse an entity key string using the specified encoding (UTF-8 or base58).
 pub fn from_str(str: &str, encoding: KeySerialization) -> Result<Vec<u8>, DecodeError> {
     let entity_key = match encoding {
         KeySerialization::UTF8 => str.as_entity_key(),
@@ -56,6 +59,7 @@ pub fn from_str(str: &str, encoding: KeySerialization) -> Result<Vec<u8>, Decode
     Ok(entity_key)
 }
 
+/// Encoding format for entity keys (base58 or UTF-8).
 #[derive(Debug, Clone, serde::Serialize, Copy, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "lowercase")]
@@ -83,6 +87,7 @@ impl From<EntityKeyEncoding> for KeySerialization {
     }
 }
 
+/// An entity key paired with its encoding.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct EncodedEntityKey {
@@ -94,6 +99,7 @@ pub struct EncodedEntityKey {
 }
 
 impl EncodedEntityKey {
+    /// Decode this encoded entity key into raw bytes.
     pub fn as_entity_key(&self) -> Result<Vec<u8>, DecodeError> {
         from_str(&self.entity_key, self.encoding.into())
     }

--- a/helium-lib/src/error.rs
+++ b/helium-lib/src/error.rs
@@ -5,6 +5,7 @@ use solana_sdk::signature::Signature;
 use std::{array::TryFromSliceError, num::TryFromIntError, time::Duration};
 use thiserror::Error;
 
+/// Main error type for helium-lib operations.
 #[derive(Error, Debug)]
 pub enum Error {
     #[cfg(feature = "mnemonic")]
@@ -77,10 +78,12 @@ impl From<tonic::Status> for Error {
 }
 
 impl Error {
+    /// Create an error indicating a Solana account was not found.
     pub fn account_not_found() -> Self {
         anchor_client::ClientError::AccountNotFound.into()
     }
 
+    /// Check whether this error represents a missing Solana account.
     pub fn is_account_not_found(&self) -> bool {
         use solana_client::{
             client_error::{
@@ -104,6 +107,7 @@ impl Error {
     }
 }
 
+/// Errors during data encoding (protobuf, JSON, bincode, etc.).
 #[derive(Debug, Error)]
 pub enum EncodeError {
     #[error("proto: {0}")]
@@ -124,6 +128,7 @@ impl EncodeError {
     }
 }
 
+/// Errors during data decoding (protobuf, base58, hex, etc.).
 #[derive(Debug, Error)]
 pub enum DecodeError {
     #[error("io: {0}")]

--- a/helium-lib/src/hotspot/cert.rs
+++ b/helium-lib/src/hotspot/cert.rs
@@ -12,6 +12,7 @@ use helium_crypto::PublicKey;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt::{self, Debug};
 
+/// Fetch an existing certificate for a hotspot.
 pub async fn get<C: AsRef<Client>>(
     client: C,
     hotspot: PublicKey,
@@ -20,6 +21,7 @@ pub async fn get<C: AsRef<Client>>(
     get_or_create(client, None, hotspot, keypair, false).await
 }
 
+/// Fetch or create a location certificate for a hotspot.
 pub async fn get_or_create<C: AsRef<Client>>(
     client: C,
     location_info: Option<LocationInfo>,
@@ -36,6 +38,7 @@ pub async fn get_or_create<C: AsRef<Client>>(
         .await
 }
 
+/// Signed request payload sent to the certificate service.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CertRequest {
     /// Base64 encoded version of a serialized LocationData
@@ -46,6 +49,7 @@ pub struct CertRequest {
     pub dry_run: bool,
 }
 
+/// Response containing location and RADSEC certificate information.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CertResponse {
     #[serde(flatten)]
@@ -54,6 +58,7 @@ pub struct CertResponse {
     pub cert: CertInfo,
 }
 
+/// RADSEC certificate details.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CertInfo {
     pub radsec_private_key: String,
@@ -63,6 +68,7 @@ pub struct CertInfo {
 }
 
 impl CertRequest {
+    /// Build a signed certificate request for the given location data.
     pub fn for_location(
         data: LocationData,
         keypair: &Keypair,
@@ -78,6 +84,7 @@ impl CertRequest {
     }
 }
 
+/// Location data payload embedded in a certificate request.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LocationData {
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -99,6 +106,7 @@ impl LocationData {
     }
 }
 
+/// Physical location details for certificate requests.
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct LocationInfo {
     pub location_address: String,
@@ -106,6 +114,7 @@ pub struct LocationInfo {
     pub nas_ids: Vec<String>,
 }
 
+/// Errors from the certificate service client.
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
     #[error(transparent)]
@@ -114,6 +123,7 @@ pub enum ClientError {
     Encode(#[from] crate::error::EncodeError),
 }
 
+/// HTTP request error with optional server error message.
 #[derive(Debug)]
 pub struct RequestError {
     pub error: reqwest::Error,
@@ -147,6 +157,7 @@ impl fmt::Display for RequestError {
     }
 }
 
+/// HTTP client for the hotspot certificate/location verification service.
 #[derive(Debug, Clone)]
 pub struct Client {
     inner: reqwest::Client,
@@ -161,6 +172,7 @@ impl Default for Client {
 }
 
 impl Client {
+    /// Create a certificate client with the given base URL and optional API token.
     pub fn new(url: &str, token: Option<String>) -> Result<Self, Error> {
         let inner = reqwest::Client::new();
         let base_url = url.parse().map_err(DecodeError::from)?;
@@ -171,6 +183,7 @@ impl Client {
         })
     }
 
+    /// POST JSON to the certificate service and deserialize the response.
     pub async fn post<T: Serialize + Sync, R: DeserializeOwned>(
         &self,
         path: &str,

--- a/helium-lib/src/hotspot/cert.rs
+++ b/helium-lib/src/hotspot/cert.rs
@@ -12,7 +12,7 @@ use helium_crypto::PublicKey;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt::{self, Debug};
 
-/// Fetch an existing certificate for a hotspot.
+/// Fetches an existing certificate for a hotspot.
 pub async fn get<C: AsRef<Client>>(
     client: C,
     hotspot: PublicKey,
@@ -21,7 +21,7 @@ pub async fn get<C: AsRef<Client>>(
     get_or_create(client, None, hotspot, keypair, false).await
 }
 
-/// Fetch or create a location certificate for a hotspot.
+/// Fetches or creates a location certificate for a hotspot.
 pub async fn get_or_create<C: AsRef<Client>>(
     client: C,
     location_info: Option<LocationInfo>,

--- a/helium-lib/src/hotspot/dataonly.rs
+++ b/helium-lib/src/hotspot/dataonly.rs
@@ -49,7 +49,7 @@ mod iot {
                 iot_info: SubDao::Iot.info_key(&entity_key),
                 hotspot_owner: *owner,
                 merkle_tree: config_account.merkle_tree,
-                dc_burner: Token::Dc.associated_token_adress(owner),
+                dc_burner: Token::Dc.associated_token_address(owner),
                 rewardable_entity_config: SubDao::Iot.rewardable_entity_config_key(),
                 data_only_config: data_only_config_key,
                 dao: dao.key(),
@@ -115,7 +115,7 @@ mod mobile {
                 mobile_info: SubDao::Mobile.info_key(&entity_key),
                 hotspot_owner: *owner,
                 merkle_tree: config_account.merkle_tree,
-                dc_burner: Token::Dc.associated_token_adress(owner),
+                dc_burner: Token::Dc.associated_token_address(owner),
                 rewardable_entity_config: SubDao::Mobile.rewardable_entity_config_key(),
                 data_only_config: data_only_config_key,
                 dao: dao.key(),
@@ -125,7 +125,7 @@ mod mobile {
                 dc: Dao::dc_key(),
                 dnt_mint: *Token::Mobile.mint(),
                 dnt_price: *Token::Mobile.price_key().unwrap(), // safe to unwrap
-                dnt_burner: Token::Mobile.associated_token_adress(owner),
+                dnt_burner: Token::Mobile.associated_token_address(owner),
                 compression_program: spl_account_compression::ID,
                 data_credits_program: data_credits::ID,
                 helium_sub_daos_program: helium_sub_daos::ID,
@@ -159,6 +159,11 @@ mod mobile {
     }
 }
 
+/// Builds an instruction to onboard a data-only hotspot for a specific sub-DAO.
+///
+/// Data-only hotspots are lighter-weight hotspots that transfer data but do not
+/// participate in Proof-of-Coverage. They are cheaper to onboard and require
+/// fewer DC fees than full hotspots.
 pub fn onboard_instruction(
     subdao: SubDao,
     hotspot_key: &helium_crypto::PublicKey,
@@ -188,6 +193,7 @@ pub fn onboard_instruction(
     }
 }
 
+/// Builds an unsigned transaction to onboard a data-only hotspot.
 pub async fn onboard_transaction<
     C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount,
 >(
@@ -230,6 +236,7 @@ pub async fn onboard_transaction<
     Ok((txn, block_height))
 }
 
+/// Signs and returns a transaction to onboard a data-only hotspot for a sub-DAO.
 pub async fn onboard<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     subdao: SubDao,
@@ -253,6 +260,7 @@ pub async fn onboard<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAcc
     Ok((txn, block_height))
 }
 
+/// Builds an unsigned transaction to issue (mint) a new data-only hotspot entity on-chain.
 pub async fn issue_transaction<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     verifier: &str,
@@ -334,6 +342,7 @@ pub async fn issue_transaction<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
     Ok((signed_txn, block_height))
 }
 
+/// A newly issued data-only hotspot with its public key and animal name.
 #[derive(Debug, serde::Serialize)]
 pub struct IssueHotspot {
     key: PublicKey,
@@ -349,12 +358,14 @@ impl From<&helium_crypto::Keypair> for IssueHotspot {
     }
 }
 
+/// A base64-encoded add-gateway token paired with the hotspot it was generated for.
 #[derive(Debug, serde::Serialize)]
 pub struct IssueToken {
     hotspot: IssueHotspot,
     token: String,
 }
 
+/// Creates a signed add-gateway token from a gateway keypair for data-only hotspot issuance.
 pub fn issue_token(gw_keypair: &helium_crypto::Keypair) -> Result<IssueToken, Error> {
     let mut txn = BlockchainTxnAddGatewayV1 {
         gateway: gw_keypair.public_key().to_vec(),
@@ -377,6 +388,7 @@ pub fn issue_token(gw_keypair: &helium_crypto::Keypair) -> Result<IssueToken, Er
     })
 }
 
+/// Decodes a base64 add-gateway token back into its protobuf transaction.
 pub fn issue_token_to_add_tx(token: &str) -> Result<BlockchainTxnAddGatewayV1, Error> {
     let envelope: BlockchainTxn = b64::decode_message(token)?;
     match envelope.txn {
@@ -385,6 +397,7 @@ pub fn issue_token_to_add_tx(token: &str) -> Result<BlockchainTxnAddGatewayV1, E
     }
 }
 
+/// Signs and returns a transaction to issue a new data-only hotspot entity on-chain.
 pub async fn issue<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     verifier: &str,

--- a/helium-lib/src/hotspot/info.rs
+++ b/helium-lib/src/hotspot/info.rs
@@ -35,6 +35,7 @@ use solana_transaction_status::{
 };
 use std::{collections::HashMap, str::FromStr};
 
+/// Fetches on-chain hotspot info for a single sub-DAO by its info account key.
 pub async fn get<C: GetAnchorAccount>(
     client: &C,
     subdao: SubDao,
@@ -54,6 +55,7 @@ pub async fn get<C: GetAnchorAccount>(
     Ok(hotspot_info)
 }
 
+/// Fetches on-chain hotspot info for multiple info account keys in a single sub-DAO.
 pub async fn get_many<C: GetAnchorAccount>(
     client: &C,
     subdao: SubDao,
@@ -89,6 +91,9 @@ async fn for_entity_key_in_subdao<C: GetAnchorAccount, E: AsEntityKey>(
     get(client, subdao, &info_key).await
 }
 
+/// Fetches hotspot info across multiple sub-DAOs for a given entity key.
+///
+/// Returns a map of sub-DAO to info for each sub-DAO the hotspot is registered in.
 pub async fn for_entity_key<C: GetAnchorAccount>(
     client: &C,
     subdaos: &[SubDao],
@@ -106,6 +111,7 @@ pub async fn for_entity_key<C: GetAnchorAccount>(
         .await
 }
 
+/// Pagination parameters for querying historical hotspot info updates from on-chain signatures.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct HotspotInfoUpdateParams {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -127,6 +133,7 @@ impl From<HotspotInfoUpdateParams> for GetConfirmedSignaturesForAddress2Config {
     }
 }
 
+/// Retrieves historical hotspot info updates by scanning on-chain transaction history.
 pub async fn updates<C: AsRef<SolanaRpcClient>>(
     client: &C,
     account: &Pubkey,

--- a/helium-lib/src/hotspot/mod.rs
+++ b/helium-lib/src/hotspot/mod.rs
@@ -31,7 +31,9 @@ pub mod cert;
 pub mod dataonly;
 pub mod info;
 
+/// The well-known creator address used to identify Helium hotspot compressed NFTs.
 pub const HOTSPOT_CREATOR: Pubkey = pubkey!("Fv5hf1Fg58htfC7YEXKNEfkpuogUUQDDTLgjGWxxv48H");
+/// The on-chain ECC verifier used to validate gateway signatures during data-only hotspot issuance.
 pub const ECC_VERIFIER: Pubkey = pubkey!("eccSAJM3tq7nQSpQTm8roxv4FPoipCkMsGizW2KBhqZ");
 
 pub fn entity_key_from_kta(
@@ -49,6 +51,7 @@ pub fn entity_key_from_kta(
     Ok(helium_crypto::PublicKey::from_str(&key_str)?)
 }
 
+/// Returns all hotspots owned by the given wallet address.
 pub async fn for_owner<C: AsRef<DasClient>>(
     client: &C,
     owner: &Pubkey,
@@ -70,6 +73,7 @@ pub async fn for_owner<C: AsRef<DasClient>>(
         .try_collect()
 }
 
+/// Searches for hotspots using Digital Asset Standard (DAS) search parameters.
 pub async fn search<C: AsRef<DasClient>>(
     client: &C,
     params: DasSearchAssetsParams,
@@ -82,6 +86,7 @@ pub async fn search<C: AsRef<DasClient>>(
         .and_then(HotspotPage::from_asset_page)
         .await
 }
+/// Derives the human-readable three-word animal name for a hotspot from its public key.
 pub fn name(hotspot_key: &helium_crypto::PublicKey) -> String {
     hotspot_key
         .to_string()
@@ -91,6 +96,7 @@ pub fn name(hotspot_key: &helium_crypto::PublicKey) -> String {
         .to_string()
 }
 
+/// Fetches a single hotspot by its helium public key.
 pub async fn get<C: AsRef<DasClient>>(
     client: &C,
     hotspot_key: &helium_crypto::PublicKey,
@@ -100,6 +106,7 @@ pub async fn get<C: AsRef<DasClient>>(
     Hotspot::from_asset(asset).await
 }
 
+/// Fetches a hotspot along with its on-chain info for the specified sub-DAOs (IoT, Mobile).
 pub async fn get_with_info<C: AsRef<DasClient> + GetAnchorAccount>(
     client: &C,
     subdaos: &[SubDao],
@@ -115,6 +122,7 @@ pub async fn get_with_info<C: AsRef<DasClient> + GetAnchorAccount>(
     Ok(hotspot)
 }
 
+/// Builds an instruction to update hotspot info directly on-chain (no onboarding server).
 pub fn direct_update_instruction(
     kta: &helium_entity_manager::accounts::KeyToAssetV0,
     asset: &asset::Asset,
@@ -139,7 +147,7 @@ pub fn direct_update_instruction(
                     hotspot_owner: owner.to_owned(),
                     merkle_tree: asset.compression.tree,
                     tree_authority: asset::merkle_tree_authority(&asset.compression.tree),
-                    dc_burner: Token::Dc.associated_token_adress(owner),
+                    dc_burner: Token::Dc.associated_token_address(owner),
                     rewardable_entity_config: subdao.rewardable_entity_config_key(),
                     dao: Dao::Hnt.key(),
                     sub_dao: subdao.key(),
@@ -209,6 +217,7 @@ pub fn direct_update_instruction(
     Ok(ix)
 }
 
+/// Builds an unsigned transaction for a direct on-chain hotspot info update.
 pub async fn direct_update_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot: &helium_crypto::PublicKey,
@@ -236,6 +245,9 @@ pub async fn direct_update_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClie
     Ok((txn, block_height))
 }
 
+/// Signs and returns a transaction to update hotspot info directly on-chain.
+///
+/// Unlike [`update`], this bypasses the onboarding server and submits directly to Solana.
 pub async fn direct_update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot: &helium_crypto::PublicKey,
@@ -251,6 +263,10 @@ pub async fn direct_update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     Ok((txn, block_height))
 }
 
+/// Updates hotspot info, optionally routing through an onboarding server.
+///
+/// When `onboarding_server` is `Some`, the transaction is fetched from the server
+/// and partially signed. When `None`, falls back to [`direct_update`].
 pub async fn update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     onboarding_server: Option<String>,
@@ -287,6 +303,7 @@ pub async fn transfer_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     asset::transfer_transaction(client, &kta.asset, recipient, opts).await
 }
 
+/// Signs and returns a transaction to transfer a hotspot to a new owner.
 pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot_key: &helium_crypto::PublicKey,
@@ -298,6 +315,7 @@ pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     asset::transfer(client, &kta.asset, recipient, keypair, opts).await
 }
 
+/// Builds an unsigned burn message for destroying a hotspot NFT.
 pub async fn burn_message<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot_key: &helium_crypto::PublicKey,
@@ -307,6 +325,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     asset::burn_message(client, &kta.asset, opts).await
 }
 
+/// Signs and returns a transaction to permanently burn (destroy) a hotspot NFT.
 pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot_key: &helium_crypto::PublicKey,
@@ -317,11 +336,14 @@ pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     asset::burn(client, &kta.asset, keypair, opts).await
 }
 
+/// Whether a hotspot is a full hotspot (capable of PoC) or data-only.
 #[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq, Default, Hash, Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 pub enum HotspotMode {
+    /// Full hotspot that participates in Proof-of-Coverage.
     Full,
+    /// Data-only hotspot that transfers data but does not participate in PoC.
     #[default]
     DataOnly,
 }
@@ -357,6 +379,7 @@ impl std::str::FromStr for HotspotMode {
     }
 }
 
+/// A paginated list of hotspots returned from a search query.
 #[derive(Serialize, Clone)]
 pub struct HotspotPage {
     pub total: u32,
@@ -387,16 +410,23 @@ impl HotspotPage {
     }
 }
 
+/// A Helium hotspot represented as a compressed NFT on Solana.
 #[derive(Debug, Serialize, Clone, Deserialize)]
 pub struct Hotspot {
+    /// The hotspot's helium-crypto public key (used to derive the animal name).
     pub key: helium_crypto::PublicKey,
+    /// The Solana compressed-NFT asset address.
     #[serde(with = "serde_pubkey")]
     pub asset: Pubkey,
+    /// Human-readable three-word animal name.
     pub name: String,
+    /// The Solana wallet that owns this hotspot.
     #[serde(with = "serde_pubkey")]
     pub owner: Pubkey,
+    /// Whether this hotspot NFT has been burned (destroyed).
     #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     pub burnt: bool,
+    /// On-chain info per sub-DAO (IoT / Mobile), populated by [`get_with_info`].
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub info: Option<HashMap<SubDao, HotspotInfo>>,
 }
@@ -423,6 +453,7 @@ impl Hotspot {
     }
 }
 
+/// Latitude/longitude coordinates derived from an H3 cell index.
 #[derive(Serialize, Debug, Clone, Copy, Deserialize)]
 pub struct HotspotGeo {
     pub lat: f64,
@@ -439,6 +470,7 @@ impl From<h3o::CellIndex> for HotspotGeo {
     }
 }
 
+/// A hotspot's asserted location as both an H3 cell index and lat/lng coordinates.
 #[derive(Serialize, Debug, Clone, Copy, Deserialize)]
 pub struct HotspotLocation {
     #[serde(with = "serde_cell_index")]
@@ -516,9 +548,13 @@ pub mod serde_cell_index {
     }
 }
 
+/// On-chain hotspot metadata, varying by sub-DAO.
+///
+/// `Iot` includes gain/elevation for LoRaWAN; `Mobile` includes device type and deployment info.
 #[derive(Debug, Serialize, Clone, Hash, Deserialize)]
 #[serde(rename_all = "lowercase", tag = "sub_dao")]
 pub enum HotspotInfo {
+    /// IoT (LoRaWAN) hotspot info with antenna gain, elevation, and location.
     Iot {
         mode: HotspotMode,
         #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -531,6 +567,7 @@ pub enum HotspotInfo {
         #[serde(skip_serializing_if = "is_zero", default)]
         location_asserts: u16,
     },
+    /// Mobile (5G/WiFi) hotspot info with device type, deployment details, and ownership tracking.
     Mobile {
         mode: HotspotMode,
         #[serde(flatten)]
@@ -555,9 +592,11 @@ pub enum HotspotInfo {
     },
 }
 
+/// Deployment-specific info for a Mobile hotspot -- either WiFi or CBRS radio details.
 #[derive(Debug, Serialize, Clone, Hash, Deserialize)]
 #[serde(rename_all = "lowercase", untagged)]
 pub enum MobileDeploymentInfo {
+    /// WiFi access point deployment details (antenna type, elevation, azimuth).
     WifiInfo {
         #[serde(skip_serializing_if = "is_zero")]
         antenna: u32,
@@ -567,12 +606,14 @@ pub enum MobileDeploymentInfo {
         #[serde(skip_serializing_if = "is_zero", default)]
         azimuth: u16,
     },
+    /// CBRS small-cell deployment with one or more radio entries.
     CbrsInfo {
         #[serde(skip_serializing_if = "Vec::is_empty", default)]
         radio_infos: Vec<CbrsRadioInfo>,
     },
 }
 
+/// Information about a single CBRS radio in a Mobile hotspot deployment.
 #[derive(Debug, Serialize, Clone, Hash, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub struct CbrsRadioInfo {
@@ -592,6 +633,7 @@ impl From<mobile_config::CbrsRadioDeploymentInfo> for CbrsRadioInfo {
     }
 }
 
+/// A hotspot info update that has been committed on-chain, including block and timestamp metadata.
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub struct CommittedHotspotInfoUpdate {
@@ -603,9 +645,14 @@ pub struct CommittedHotspotInfoUpdate {
     pub update: HotspotInfoUpdate,
 }
 
+/// A pending update to hotspot on-chain info, scoped to a specific sub-DAO.
+///
+/// `Iot` updates may include gain, elevation, and location.
+/// `Mobile` updates include only location.
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "lowercase", untagged)]
 pub enum HotspotInfoUpdate {
+    /// IoT hotspot update with optional gain, elevation, and location fields.
     Iot {
         #[serde(skip_serializing_if = "Option::is_none")]
         gain: Option<Decimal>,
@@ -615,6 +662,7 @@ pub enum HotspotInfoUpdate {
         #[serde(skip_serializing_if = "Option::is_none")]
         location: Option<HotspotLocation>,
     },
+    /// Mobile hotspot update with an optional location change.
     Mobile {
         #[serde(flatten)]
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -722,14 +770,19 @@ impl HotspotInfoUpdate {
     }
 }
 
+/// The hardware type of a Mobile network hotspot.
 #[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq, Default, Hash, Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "snake_case")]
 pub enum MobileDeviceType {
+    /// CBRS small-cell radio.
     #[default]
     Cbrs,
+    /// Indoor WiFi access point.
     WifiIndoor,
+    /// Outdoor WiFi access point.
     WifiOutdoor,
+    /// Data-only WiFi access point (no PoC rewards).
     WifiDataOnly,
 }
 

--- a/helium-lib/src/hotspot/mod.rs
+++ b/helium-lib/src/hotspot/mod.rs
@@ -86,6 +86,7 @@ pub async fn search<C: AsRef<DasClient>>(
         .and_then(HotspotPage::from_asset_page)
         .await
 }
+
 /// Derives the human-readable three-word animal name for a hotspot from its public key.
 pub fn name(hotspot_key: &helium_crypto::PublicKey) -> String {
     hotspot_key
@@ -288,7 +289,7 @@ pub async fn update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     Ok(tx)
 }
 
-/// Get an unsigned transaction for a Hotspot transfer.
+/// Gets an unsigned transaction for a hotspot transfer.
 ///
 /// The Hotspot is transferred from the owner of the Hotspot to the given recipient
 /// Note that the owner is currently expected to sign this transaction and pay for

--- a/helium-lib/src/jupiter.rs
+++ b/helium-lib/src/jupiter.rs
@@ -7,29 +7,40 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde::{Deserialize, Serialize};
 use solana_sdk::signer::Signer;
 
+/// Default Jupiter V2 swap API base URL.
 pub const DEFAULT_API_URL: &str = "https://api.jup.ag/swap/v2";
+/// Default slippage tolerance in basis points (100 bps = 1%).
 pub const DEFAULT_SLIPPAGE_BPS: u16 = 100;
 const MAX_ERROR_BODY_LEN: usize = 200;
 
+/// Errors that can occur during Jupiter swap operations.
 #[derive(Debug, thiserror::Error)]
 pub enum JupiterError {
+    /// HTTP request to Jupiter API failed.
     #[error("Jupiter API request failed: {0}")]
     Request(#[from] reqwest::Error),
+    /// Jupiter API returned a non-200 status code.
     #[error("Jupiter API error (HTTP {status}): {message}")]
     Api { status: u16, message: String },
+    /// Jupiter reported an error within the swap response body.
     #[error("Jupiter swap error: {0}")]
     SwapError(String),
+    /// No swap routes found for the given token pair.
     #[error("Jupiter quote returned no routes for {input_mint} → {output_mint}")]
     NoRoutes {
         input_mint: String,
         output_mint: String,
     },
+    /// Failed to deserialize the base64-encoded swap transaction.
     #[error("Failed to decode swap transaction: {0}")]
     TransactionDecode(String),
+    /// Solana RPC call failed during swap execution.
     #[error("Solana RPC error: {0}")]
     Solana(String),
+    /// Transaction signing failed.
     #[error("Transaction signing failed: {0}")]
     Signing(String),
+    /// Invalid client configuration (e.g., bad slippage value).
     #[error("Jupiter configuration error: {0}")]
     Config(String),
 }
@@ -96,6 +107,7 @@ impl std::fmt::Debug for Client {
 }
 
 impl Client {
+    /// Creates a new Jupiter client with explicit configuration.
     pub fn new(
         api_key: Option<impl Into<String>>,
         base_url: impl Into<String>,
@@ -256,11 +268,17 @@ impl Client {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderResponse {
+    /// Input token mint address.
     pub input_mint: String,
+    /// Output token mint address.
     pub output_mint: String,
+    /// Input amount in smallest token units.
     pub in_amount: String,
+    /// Quoted output amount in smallest token units.
     pub out_amount: String,
+    /// Estimated price impact as a percentage string.
     pub price_impact_pct: String,
+    /// Slippage tolerance used for this order.
     pub slippage_bps: u16,
     #[serde(default)]
     pub(crate) route_plan: Vec<RoutePlan>,

--- a/helium-lib/src/keypair.rs
+++ b/helium-lib/src/keypair.rs
@@ -4,14 +4,18 @@ use crate::{
 };
 use std::sync::Arc;
 
+/// Wrapper around a Solana keypair with signing and optional BIP39 mnemonic support.
 #[derive(PartialEq, Debug)]
 pub struct Keypair(solana_sdk::signer::keypair::Keypair);
+
+/// A keypair that always fails signing, used as a placeholder when building unsigned transactions.
 #[derive(Debug, Clone)]
 pub struct VoidKeypair;
 
 pub use solana_sdk::pubkey;
 pub use solana_sdk::{pubkey::Pubkey, pubkey::PUBKEY_BYTES, signature::Signature, signer::Signer};
 
+/// Serde support for serializing/deserializing `Pubkey` as a base58 string.
 pub mod serde_pubkey {
     use super::*;
     use serde::de::{self, Deserialize};
@@ -33,6 +37,7 @@ pub mod serde_pubkey {
     }
 }
 
+/// Serde support for `Option<Pubkey>`, serializing as a nullable base58 string.
 pub mod serde_opt_pubkey {
     use super::*;
     use serde::{Deserialize, Serialize};
@@ -60,6 +65,7 @@ pub mod serde_opt_pubkey {
     }
 }
 
+/// Convert a `helium_crypto::PublicKey` (ed25519) to a Solana `Pubkey`.
 pub fn to_pubkey(key: &helium_crypto::PublicKey) -> Result<Pubkey, DecodeError> {
     match key.key_type() {
         helium_crypto::KeyType::Ed25519 => {
@@ -70,6 +76,7 @@ pub fn to_pubkey(key: &helium_crypto::PublicKey) -> Result<Pubkey, DecodeError> 
     }
 }
 
+/// Convert a Solana `Pubkey` to a `helium_crypto::PublicKey`.
 pub fn to_helium_pubkey(key: &Pubkey) -> Result<helium_crypto::PublicKey, DecodeError> {
     use helium_crypto::ReadFrom;
     let mut input = std::io::Cursor::new(key.as_ref());
@@ -106,14 +113,17 @@ impl From<solana_sdk::signer::keypair::Keypair> for Keypair {
 }
 
 impl Keypair {
+    /// Generate a new random keypair.
     pub fn generate() -> Self {
         Keypair(solana_sdk::signer::keypair::Keypair::new())
     }
 
+    /// Create a void (non-signing) keypair for building unsigned transactions.
     pub fn void() -> Arc<VoidKeypair> {
         Arc::new(VoidKeypair)
     }
 
+    /// Derive a keypair deterministically from entropy bytes (e.g. a seed).
     pub fn generate_from_entropy(entropy: &[u8]) -> Result<Self, Error> {
         Ok(Keypair(
             solana_sdk::signer::keypair::keypair_from_seed(entropy)
@@ -121,12 +131,14 @@ impl Keypair {
         ))
     }
 
+    /// Get the 64-byte secret key (secret bytes + public key bytes).
     pub fn secret(&self) -> Vec<u8> {
         let mut result = self.0.secret_bytes().to_vec();
         result.extend_from_slice(self.pubkey().as_ref());
         result
     }
 
+    /// Sign a message, returning the ed25519 signature.
     pub fn sign(&self, msg: &[u8]) -> Result<Signature, Error> {
         Ok(self.try_sign_message(msg)?)
     }
@@ -140,6 +152,7 @@ impl Keypair {
         Ok(words.join(" "))
     }
 
+    /// Restore a keypair from a BIP39 seed phrase. Requires the `mnemonic` feature.
     #[cfg(feature = "mnemonic")]
     pub fn from_words(words: &[&str]) -> Result<Arc<Self>, Error> {
         let entropy_bytes = helium_mnemonic::mnemonic_to_entropy(words)?;

--- a/helium-lib/src/kta.rs
+++ b/helium-lib/src/kta.rs
@@ -10,13 +10,13 @@ use std::{
     sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
-/// Initialize the global KTA cache with the given Solana RPC client.
+/// Initializes the global KTA cache with the given Solana RPC client.
 pub fn init(solana_client: Arc<SolanaRpcClient>) -> Result<(), Error> {
     let _ = CACHE.set(KtaCache::new(solana_client)?);
     Ok(())
 }
 
-/// Fetch a KeyToAsset account, using the cache when available.
+/// Fetches a KeyToAsset account, using the cache when available.
 pub async fn get(kta_key: &Pubkey) -> Result<KeyToAssetV0, Error> {
     let cache = CACHE.get().ok_or_else(Error::account_not_found)?;
     cache.get(kta_key).await
@@ -28,7 +28,7 @@ pub fn get_cached(kta_key: &Pubkey) -> Result<KeyToAssetV0, Error> {
     cache.get_cached(kta_key)
 }
 
-/// Fetch multiple KeyToAsset accounts, using the cache when available.
+/// Fetches multiple KeyToAsset accounts, using the cache when available.
 pub async fn get_many(kta_keys: &[Pubkey]) -> Result<Vec<KeyToAssetV0>, Error> {
     let cache = CACHE.get().ok_or_else(Error::account_not_found)?;
     cache.get_many(kta_keys).await

--- a/helium-lib/src/kta.rs
+++ b/helium-lib/src/kta.rs
@@ -10,31 +10,37 @@ use std::{
     sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
+/// Initialize the global KTA cache with the given Solana RPC client.
 pub fn init(solana_client: Arc<SolanaRpcClient>) -> Result<(), Error> {
     let _ = CACHE.set(KtaCache::new(solana_client)?);
     Ok(())
 }
 
+/// Fetch a KeyToAsset account, using the cache when available.
 pub async fn get(kta_key: &Pubkey) -> Result<KeyToAssetV0, Error> {
     let cache = CACHE.get().ok_or_else(Error::account_not_found)?;
     cache.get(kta_key).await
 }
 
+/// Return a cached KeyToAsset account or error if not yet cached.
 pub fn get_cached(kta_key: &Pubkey) -> Result<KeyToAssetV0, Error> {
     let cache = CACHE.get().ok_or_else(Error::account_not_found)?;
     cache.get_cached(kta_key)
 }
 
+/// Fetch multiple KeyToAsset accounts, using the cache when available.
 pub async fn get_many(kta_keys: &[Pubkey]) -> Result<Vec<KeyToAssetV0>, Error> {
     let cache = CACHE.get().ok_or_else(Error::account_not_found)?;
     cache.get_many(kta_keys).await
 }
 
+/// Return multiple cached KeyToAsset accounts or error if any are missing.
 pub fn get_many_cached(kta_keys: &[Pubkey]) -> Result<Vec<KeyToAssetV0>, Error> {
     let cache = CACHE.get().ok_or_else(Error::account_not_found)?;
     cache.get_many_cached(kta_keys)
 }
 
+/// Look up the KeyToAsset account for an entity key.
 pub async fn for_entity_key<E>(entity_key: &E) -> Result<KeyToAssetV0, Error>
 where
     E: AsEntityKey,
@@ -43,6 +49,7 @@ where
     get(&kta_key).await
 }
 
+/// Look up KeyToAsset accounts for multiple entity keys.
 pub async fn for_entity_keys<E>(entity_keys: &[E]) -> Result<Vec<KeyToAssetV0>, Error>
 where
     E: AsEntityKey,

--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -13,11 +13,11 @@ pub mod b64;
 /// Solana RPC and DAS client wrappers.
 pub mod client;
 
-/// Hex boosting configuration for coverage areas.
+/// Hex boosting activation for mobile coverage areas.
 pub mod boosting;
 /// Helium DAO and sub-DAO account lookups.
 pub mod dao;
-/// Data Credit minting and delegation.
+/// Data Credit minting, delegation, and burning.
 pub mod dc;
 /// Ed25519 signature verification instructions.
 pub mod ed25519_instruction;
@@ -43,11 +43,11 @@ pub mod onboarding;
 pub mod priority_fee;
 /// Anchor program ID and account definitions.
 pub mod programs;
-/// Transaction queuing and batch submission.
+/// Reward claim queuing via task queues.
 pub mod queue;
 /// Reward claim and oracle interactions.
 pub mod reward;
-/// Reward schedule and epoch utilities.
+/// Cron-based scheduled reward claiming.
 pub mod schedule;
 /// Token operations: transfers, burns, balances, and prices.
 pub mod token;
@@ -105,7 +105,7 @@ use keypair::Pubkey;
 use solana_sdk::{instruction::Instruction, transaction::Transaction};
 use std::{ops::RangeInclusive, sync::Arc};
 
-/// Initialize the global KTA (key-to-asset) cache.
+/// Initializes the global KTA (key-to-asset) cache.
 ///
 /// Must be called before any KTA lookups. Requires an active Solana RPC client.
 pub fn init(solana_client: Arc<client::SolanaRpcClient>) -> Result<(), error::Error> {
@@ -138,7 +138,7 @@ impl TransactionOpts {
     }
 }
 
-/// Create a transaction with a fresh blockhash, returning the transaction and block height.
+/// Creates a transaction with a fresh blockhash, returning the transaction and block height.
 pub async fn mk_transaction_with_blockhash<C: AsRef<SolanaRpcClient>>(
     client: &C,
     ixs: &[Instruction],

--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -1,29 +1,57 @@
+//! Client library for interacting with the Helium network on Solana.
+//!
+//! Provides token operations, hotspot management, onboarding, rewards,
+//! and transaction building for the Helium ecosystem.
+
 #![forbid(unsafe_code)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
+/// Compressed NFT asset operations (DAS API).
 pub mod asset;
+/// Base64 encoding/decoding utilities.
 pub mod b64;
+/// Solana RPC and DAS client wrappers.
 pub mod client;
 
+/// Hex boosting configuration for coverage areas.
 pub mod boosting;
+/// Helium DAO and sub-DAO account lookups.
 pub mod dao;
+/// Data Credit minting and delegation.
 pub mod dc;
+/// Ed25519 signature verification instructions.
 pub mod ed25519_instruction;
+/// Entity key encoding for hotspots and other network entities.
 pub mod entity_key;
+/// Error types used throughout the library.
 pub mod error;
+/// Hotspot onboarding, configuration, and info queries.
 pub mod hotspot;
+/// Jupiter DEX swap integration.
 pub mod jupiter;
+/// Solana keypair management with optional BIP39 mnemonic support.
 pub mod keypair;
+/// Key-to-asset (KTA) account lookups and caching.
 pub mod kta;
+/// Transaction memo encoding.
 pub mod memo;
+/// Versioned message construction with address lookup tables.
 pub mod message;
+/// Maker onboarding server client.
 pub mod onboarding;
+/// Compute unit price estimation for transaction priority fees.
 pub mod priority_fee;
+/// Anchor program ID and account definitions.
 pub mod programs;
+/// Transaction queuing and batch submission.
 pub mod queue;
+/// Reward claim and oracle interactions.
 pub mod reward;
+/// Reward schedule and epoch utilities.
 pub mod schedule;
+/// Token operations: transfers, burns, balances, and prices.
 pub mod token;
+/// Transaction building, signing, and confirmation.
 pub mod transaction;
 
 pub use crate::programs::{
@@ -77,13 +105,20 @@ use keypair::Pubkey;
 use solana_sdk::{instruction::Instruction, transaction::Transaction};
 use std::{ops::RangeInclusive, sync::Arc};
 
+/// Initialize the global KTA (key-to-asset) cache.
+///
+/// Must be called before any KTA lookups. Requires an active Solana RPC client.
 pub fn init(solana_client: Arc<client::SolanaRpcClient>) -> Result<(), error::Error> {
     kta::init(solana_client)
 }
 
+/// Options controlling transaction priority fees and address lookup tables.
 pub struct TransactionOpts {
+    /// Minimum priority fee in micro-lamports per compute unit.
     pub min_priority_fee: u64,
+    /// Maximum priority fee in micro-lamports per compute unit.
     pub max_priority_fee: u64,
+    /// Address lookup tables to include for transaction compression.
     pub lut_addresses: Vec<Pubkey>,
 }
 
@@ -103,6 +138,7 @@ impl TransactionOpts {
     }
 }
 
+/// Create a transaction with a fresh blockhash, returning the transaction and block height.
 pub async fn mk_transaction_with_blockhash<C: AsRef<SolanaRpcClient>>(
     client: &C,
     ixs: &[Instruction],

--- a/helium-lib/src/memo.rs
+++ b/helium-lib/src/memo.rs
@@ -7,6 +7,7 @@ use crate::{
     transaction, TransactionOpts,
 };
 
+/// Build a message that records an on-chain memo.
 pub async fn memo_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     data: &str,
@@ -28,6 +29,7 @@ pub async fn memo_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, ixs, &opts.lut_addresses, pubkey).await
 }
 
+/// Record an on-chain memo and return a signed transaction.
 pub async fn memo<C: AsRef<SolanaRpcClient>>(
     client: &C,
     data: &str,

--- a/helium-lib/src/memo.rs
+++ b/helium-lib/src/memo.rs
@@ -7,7 +7,7 @@ use crate::{
     transaction, TransactionOpts,
 };
 
-/// Build a message that records an on-chain memo.
+/// Builds a message that records an on-chain memo.
 pub async fn memo_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     data: &str,
@@ -29,7 +29,7 @@ pub async fn memo_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, ixs, &opts.lut_addresses, pubkey).await
 }
 
-/// Record an on-chain memo and return a signed transaction.
+/// Records an on-chain memo and returns a signed transaction.
 pub async fn memo<C: AsRef<SolanaRpcClient>>(
     client: &C,
     data: &str,

--- a/helium-lib/src/message.rs
+++ b/helium-lib/src/message.rs
@@ -17,7 +17,7 @@ pub const COMMON_LUT: Pubkey = pubkey!("43eY9L2spbM2b1MPDFFBStUiFGt29ziZ1nc1xbpz
 
 pub use solana_sdk::message::VersionedMessage;
 
-/// Fetch and deserialize address lookup table accounts from on-chain.
+/// Fetches and deserializes address lookup table accounts from on-chain.
 pub async fn get_lut_accounts<C: AsRef<SolanaRpcClient>>(
     client: &C,
     addresses: &[Pubkey],
@@ -54,7 +54,7 @@ pub fn mk_raw_message(
     Ok(msg)
 }
 
-/// Build a versioned message with a fresh blockhash, resolving LUT addresses on-chain.
+/// Builds a versioned message with a fresh blockhash, resolving LUT addresses on-chain.
 pub async fn mk_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     ixs: &[Instruction],

--- a/helium-lib/src/message.rs
+++ b/helium-lib/src/message.rs
@@ -10,11 +10,14 @@ use crate::{
 };
 use itertools::Itertools;
 
+/// Common address lookup table on devnet.
 pub const COMMON_LUT_DEVNET: Pubkey = pubkey!("FnqYkQ6ZKnVKdkvYCGsEeiP5qgGqVbcFUkGduy2ta4gA");
+/// Common address lookup table on mainnet.
 pub const COMMON_LUT: Pubkey = pubkey!("43eY9L2spbM2b1MPDFFBStUiFGt29ziZ1nc1xbpzsfVt");
 
 pub use solana_sdk::message::VersionedMessage;
 
+/// Fetch and deserialize address lookup table accounts from on-chain.
 pub async fn get_lut_accounts<C: AsRef<SolanaRpcClient>>(
     client: &C,
     addresses: &[Pubkey],
@@ -36,6 +39,7 @@ pub async fn get_lut_accounts<C: AsRef<SolanaRpcClient>>(
     .try_collect()
 }
 
+/// Compile instructions and lookup tables into a V0 versioned message.
 pub fn mk_raw_message(
     ixs: &[Instruction],
     lut_accounts: &[AddressLookupTableAccount],
@@ -50,6 +54,7 @@ pub fn mk_raw_message(
     Ok(msg)
 }
 
+/// Build a versioned message with a fresh blockhash, resolving LUT addresses on-chain.
 pub async fn mk_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     ixs: &[Instruction],

--- a/helium-lib/src/onboarding.rs
+++ b/helium-lib/src/onboarding.rs
@@ -3,12 +3,14 @@ use futures::TryFutureExt;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::marker::Send;
 
+/// HTTP client for the Helium onboarding server API.
 pub struct Client {
     base_url: String,
     inner: reqwest::Client,
 }
 
 impl Client {
+    /// Create a client targeting the given onboarding server URL.
     pub fn new(base_url: &str) -> Self {
         Self {
             base_url: base_url.to_string(),
@@ -16,6 +18,7 @@ impl Client {
         }
     }
 
+    /// Send a GET request and deserialize the response data.
     pub async fn get<T>(&self, path: &str) -> Result<T, OnboardingError>
     where
         T: 'static + DeserializeOwned + Send,
@@ -29,6 +32,7 @@ impl Client {
         onboarding_resp.data.ok_or_else(|| OnboardingError::NoData)
     }
 
+    /// Send a POST request with JSON body and deserialize the response data.
     pub async fn post<T, P>(&self, path: &str, params: &P) -> Result<T, OnboardingError>
     where
         T: 'static + DeserializeOwned + Send,
@@ -43,6 +47,7 @@ impl Client {
         onboarding_resp.data.ok_or_else(|| OnboardingError::NoData)
     }
 
+    /// Fetch onboarding info for a hotspot by its public key.
     pub async fn get_hotspot(
         &self,
         hotspot: &helium_crypto::PublicKey,
@@ -50,6 +55,7 @@ impl Client {
         self.get::<Hotspot>(&format!("/hotspots/{hotspot}")).await
     }
 
+    /// Get a signed metadata-update transaction from the onboarding server.
     pub async fn get_update_txn(
         &self,
         hotspot: &helium_crypto::PublicKey,
@@ -91,6 +97,7 @@ impl Client {
     }
 }
 
+/// Hotspot record from the onboarding server.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all(deserialize = "camelCase"))]
 pub struct Hotspot {
@@ -99,6 +106,7 @@ pub struct Hotspot {
     pub public_address: helium_crypto::PublicKey,
 }
 
+/// Maker (manufacturer) record from the onboarding server.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all(deserialize = "camelCase"))]
 pub struct Maker {
@@ -109,6 +117,7 @@ pub struct Maker {
     pub name: String,
 }
 
+/// Errors from onboarding server requests.
 #[derive(Debug, thiserror::Error)]
 pub enum OnboardingError {
     #[error("onboarding request: {0}")]

--- a/helium-lib/src/priority_fee.rs
+++ b/helium-lib/src/priority_fee.rs
@@ -9,10 +9,17 @@ use crate::{
 use itertools::Itertools;
 use std::ops::RangeInclusive;
 
+/// Maximum number of writable accounts sampled for fee estimation.
 pub const MAX_RECENT_PRIORITY_FEE_ACCOUNTS: usize = 128;
+/// Floor for computed priority fees (micro-lamports per CU).
 pub const MIN_PRIORITY_FEE: u64 = 1;
+/// Ceiling for computed priority fees (micro-lamports per CU).
 pub const MAX_PRIORITY_FEE: u64 = 2500000;
 
+/// Estimate a priority fee for the given accounts, clamped to `fee_range`.
+///
+/// Uses the Helius priority-fee API on mainnet, falls back to median
+/// recent fees otherwise.
 pub async fn get_estimate<C: AsRef<SolanaRpcClient>>(
     client: &C,
     accounts: &impl ToAccountMetas,
@@ -113,6 +120,8 @@ mod base {
     }
 }
 
+/// Return placeholder compute-budget and compute-price instructions for
+/// transaction size estimation.
 pub fn compute_placeholder_instructions() -> [Instruction; 2] {
     [
         // Set budget high, will be updated by client or simulation
@@ -121,14 +130,17 @@ pub fn compute_placeholder_instructions() -> [Instruction; 2] {
     ]
 }
 
+/// Create a `SetComputeUnitLimit` instruction.
 pub fn compute_budget_instruction(compute_limit: u32) -> Instruction {
     solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(compute_limit)
 }
 
+/// Create a `SetComputeUnitPrice` instruction.
 pub fn compute_price_instruction(priority_fee: u64) -> Instruction {
     solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_price(priority_fee)
 }
 
+/// Estimate the priority fee for the given accounts and return the instruction.
 pub async fn compute_price_instruction_for_accounts<C: AsRef<SolanaRpcClient>>(
     client: &C,
     accounts: &impl ToAccountMetas,
@@ -138,6 +150,7 @@ pub async fn compute_price_instruction_for_accounts<C: AsRef<SolanaRpcClient>>(
     Ok(compute_price_instruction(priority_fee))
 }
 
+/// Estimate the priority fee from instruction account lists and return the instruction.
 pub async fn compute_price_instruction_for_instructions<C: AsRef<SolanaRpcClient>>(
     client: &C,
     instructions: &[Instruction],

--- a/helium-lib/src/priority_fee.rs
+++ b/helium-lib/src/priority_fee.rs
@@ -130,12 +130,12 @@ pub fn compute_placeholder_instructions() -> [Instruction; 2] {
     ]
 }
 
-/// Create a `SetComputeUnitLimit` instruction.
+/// Creates a `SetComputeUnitLimit` instruction.
 pub fn compute_budget_instruction(compute_limit: u32) -> Instruction {
     solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(compute_limit)
 }
 
-/// Create a `SetComputeUnitPrice` instruction.
+/// Creates a `SetComputeUnitPrice` instruction.
 pub fn compute_price_instruction(priority_fee: u64) -> Instruction {
     solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_price(priority_fee)
 }

--- a/helium-lib/src/queue.rs
+++ b/helium-lib/src/queue.rs
@@ -13,16 +13,20 @@ use solana_sdk::signer::Signer;
 use tuktuk_sdk::tuktuk_program::TaskQueueV0;
 use tuktuk_sdk::{tuktuk, tuktuk_program};
 
+/// Well-known task queue address for reward claims.
 pub const TASK_QUEUE_ID: Pubkey = pubkey!("H39gEszvsi6AT4rYBiJTuZHJSF5hMHy6CKGTd7wzhsg7");
 
+/// Derive the PDA for a wallet's claim payer signer.
 pub fn claim_wallet_key(task_queue_key: &Pubkey, wallet: &Pubkey) -> Pubkey {
     tuktuk::custom_signer_key(task_queue_key, &[b"claim_payer", wallet.as_ref()])
 }
 
+/// Derive the task queue authority PDA.
 pub fn task_queue_authority_key(task_queue_key: &Pubkey, queue_authority: &Pubkey) -> Pubkey {
     tuktuk::task_queue::task_queue_authority_key(task_queue_key, queue_authority)
 }
 
+/// Build an instruction to queue a wallet reward claim.
 pub fn claim_wallet_instruction(
     task_queue_key: &Pubkey,
     task_queue: &TaskQueueV0,
@@ -63,6 +67,7 @@ pub fn claim_wallet_instruction(
     };
     Ok(ix)
 }
+/// Queue a wallet reward claim and return a signed transaction.
 pub async fn claim_wallet<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     task_queue_key: &Pubkey,

--- a/helium-lib/src/queue.rs
+++ b/helium-lib/src/queue.rs
@@ -16,17 +16,17 @@ use tuktuk_sdk::{tuktuk, tuktuk_program};
 /// Well-known task queue address for reward claims.
 pub const TASK_QUEUE_ID: Pubkey = pubkey!("H39gEszvsi6AT4rYBiJTuZHJSF5hMHy6CKGTd7wzhsg7");
 
-/// Derive the PDA for a wallet's claim payer signer.
+/// Derives the PDA for a wallet's claim payer signer.
 pub fn claim_wallet_key(task_queue_key: &Pubkey, wallet: &Pubkey) -> Pubkey {
     tuktuk::custom_signer_key(task_queue_key, &[b"claim_payer", wallet.as_ref()])
 }
 
-/// Derive the task queue authority PDA.
+/// Derives the task queue authority PDA.
 pub fn task_queue_authority_key(task_queue_key: &Pubkey, queue_authority: &Pubkey) -> Pubkey {
     tuktuk::task_queue::task_queue_authority_key(task_queue_key, queue_authority)
 }
 
-/// Build an instruction to queue a wallet reward claim.
+/// Builds an instruction to queue a wallet reward claim.
 pub fn claim_wallet_instruction(
     task_queue_key: &Pubkey,
     task_queue: &TaskQueueV0,
@@ -67,7 +67,8 @@ pub fn claim_wallet_instruction(
     };
     Ok(ix)
 }
-/// Queue a wallet reward claim and return a signed transaction.
+
+/// Queues a wallet reward claim and returns a signed transaction.
 pub async fn claim_wallet<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     task_queue_key: &Pubkey,

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -23,6 +23,7 @@ use itertools::{izip, Itertools};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
 
+/// A reward oracle that provides lifetime reward amounts for Helium entities.
 #[derive(Debug, Serialize, Clone)]
 pub struct Oracle {
     #[serde(with = "crate::keypair::serde_pubkey")]
@@ -39,6 +40,7 @@ impl From<lazy_distributor::types::OracleConfigV0> for Oracle {
     }
 }
 
+/// A reward amount reported by a specific oracle, identified by oracle index.
 #[derive(Debug, Serialize, Clone)]
 pub struct OracleReward {
     pub oracle: Oracle,
@@ -46,14 +48,18 @@ pub struct OracleReward {
     pub reward: TokenAmount,
 }
 
+/// Helium tokens that are eligible for reward claiming via the lazy distributor.
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize, Default,
 )]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "lowercase")]
 pub enum ClaimableToken {
+    /// IoT network token rewards.
     Iot,
+    /// Mobile network token rewards.
     Mobile,
+    /// HNT token rewards (default).
     #[default]
     Hnt,
 }
@@ -110,6 +116,10 @@ impl ClaimableToken {
     }
 }
 
+/// Fetches the on-chain lazy distributor account for a claimable token.
+///
+/// The lazy distributor is the mechanism that distributes Helium rewards on-chain
+/// using oracle-signed reward amounts.
 pub async fn lazy_distributor<C: GetAnchorAccount>(
     client: &C,
     token: ClaimableToken,
@@ -121,6 +131,9 @@ pub async fn lazy_distributor<C: GetAnchorAccount>(
         .await
 }
 
+/// Derives the circuit breaker PDA for a lazy distributor's rewards escrow.
+///
+/// The circuit breaker rate-limits reward distribution to prevent excessive payouts.
 pub fn lazy_distributor_circuit_breaker(
     ld_account: &lazy_distributor::accounts::LazyDistributorV0,
 ) -> Pubkey {
@@ -155,6 +168,7 @@ fn time_decay_previous_value(
     .ok()
 }
 
+/// Returns the maximum claimable amount, bounded by the circuit breaker's windowed threshold.
 pub async fn max_claim<C: GetAnchorAccount>(
     client: &C,
     token: ClaimableToken,
@@ -214,6 +228,7 @@ fn set_current_rewards_instruction(
     Ok(ix)
 }
 
+/// Builds an instruction to distribute rewards to a custom destination account.
 pub fn distribute_rewards_instruction_for_destination(
     token: ClaimableToken,
     ld_account: &lazy_distributor::accounts::LazyDistributorV0,
@@ -234,7 +249,7 @@ pub fn distribute_rewards_instruction_for_destination(
             owner: *destination_account,
             circuit_breaker: lazy_distributor_circuit_breaker(ld_account),
             recipient: token.recipient_key_from_kta(kta),
-            destination_account: Token::from(token).associated_token_adress(destination_account),
+            destination_account: Token::from(token).associated_token_address(destination_account),
         },
     }
     .to_account_metas(None);
@@ -248,6 +263,7 @@ pub fn distribute_rewards_instruction_for_destination(
     Ok(ix)
 }
 
+/// Builds an instruction to distribute rewards to the asset owner using a compression proof.
 pub fn distribute_rewards_instruction_for_owner(
     token: ClaimableToken,
     ld_account: &lazy_distributor::accounts::LazyDistributorV0,
@@ -270,7 +286,7 @@ pub fn distribute_rewards_instruction_for_owner(
             owner: asset.ownership.owner,
             circuit_breaker: lazy_distributor_circuit_breaker(ld_account),
             recipient: token.recipient_key_from_kta(kta),
-            destination_account: Token::from(token).associated_token_adress(&asset.ownership.owner),
+            destination_account: Token::from(token).associated_token_address(&asset.ownership.owner),
         },
         compression_program: spl_account_compression::ID,
         merkle_tree: asset.compression.tree,
@@ -295,6 +311,7 @@ pub fn distribute_rewards_instruction_for_owner(
     Ok(ix)
 }
 
+/// Claims pending rewards for a single entity. Returns `None` if no rewards are available.
 pub async fn claim<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     token: ClaimableToken,
@@ -322,6 +339,7 @@ pub async fn claim<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccou
     Ok(Some((txn, block_height)))
 }
 
+/// Shared context needed to build claim instructions for a single entity.
 pub struct ClaimCommon<'a> {
     pub token: ClaimableToken,
     pub ld_account: &'a lazy_distributor::accounts::LazyDistributorV0,
@@ -333,6 +351,7 @@ pub struct ClaimCommon<'a> {
     pub oracle_ixn: Instruction,
 }
 
+/// Builds claim instructions that send rewards to a custom destination account.
 pub fn claim_instructions_for_destination(
     common: ClaimCommon,
     destination: &Pubkey,
@@ -355,6 +374,7 @@ pub fn claim_instructions_for_destination(
     Ok(ixs)
 }
 
+/// Builds claim instructions that send rewards to the compressed NFT owner.
 pub fn claim_instructions_for_owner(
     common: ClaimCommon,
     asset_proof: asset::AssetProof,
@@ -392,6 +412,7 @@ pub fn claim_instructions_for_owner(
     Ok(ixs)
 }
 
+/// A request to claim rewards for a specific entity, with an optional cap on the amount.
 pub struct ClaimTicket {
     pub amount: Option<u64>,
     pub encoded_entity_key: EncodedEntityKey,
@@ -436,6 +457,7 @@ impl AsEntityKey for ClaimTicket {
     }
 }
 
+/// Builds claim instructions for multiple entities in batch. Returns `None` entries for entities with no rewards.
 pub async fn claim_instructions<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     token: ClaimableToken,
@@ -578,6 +600,7 @@ pub async fn claim_instructions<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + G
         .try_collect()
 }
 
+/// Returns pending (unclaimed) reward amounts for multiple entities as a simplified map.
 pub async fn pending_amounts<C: GetAnchorAccount, E: AsRef<EncodedEntityKey>>(
     client: &C,
     token: ClaimableToken,
@@ -594,6 +617,9 @@ pub async fn pending_amounts<C: GetAnchorAccount, E: AsRef<EncodedEntityKey>>(
         .await
 }
 
+/// Returns pending (unclaimed) rewards for multiple entities with full oracle details.
+///
+/// Computes pending = lifetime - already_claimed for each entity, using the median oracle value.
 pub async fn pending<C: GetAnchorAccount, E: AsRef<EncodedEntityKey>>(
     client: &C,
     token: ClaimableToken,
@@ -666,6 +692,7 @@ pub async fn pending<C: GetAnchorAccount, E: AsRef<EncodedEntityKey>>(
     Ok(entity_key_rewards)
 }
 
+/// Fetches lifetime reward totals from all oracles for the given entities.
 pub async fn lifetime<C: GetAnchorAccount, E: AsRef<EncodedEntityKey>>(
     client: &C,
     token: ClaimableToken,
@@ -779,9 +806,11 @@ async fn bulk_from_oracle<E: AsRef<EncodedEntityKey>>(
         .try_collect()
 }
 
+/// Reward recipient accounts -- tracks total claimed rewards and optional custom destinations.
 pub mod recipient {
     use super::*;
 
+    /// Fetches the recipient account for a key-to-asset, if one exists.
     pub async fn for_kta<C: GetAnchorAccount>(
         client: &C,
         token: ClaimableToken,
@@ -791,6 +820,7 @@ pub mod recipient {
         Ok(client.anchor_account(&recipient_key).await.ok())
     }
 
+    /// Fetches the recipient account for an entity key, if one exists.
     pub async fn for_entity_key<C: GetAnchorAccount, E: AsEntityKey>(
         client: &C,
         token: ClaimableToken,
@@ -800,6 +830,7 @@ pub mod recipient {
         for_kta(client, token, &kta).await
     }
 
+    /// Fetches recipient accounts for multiple key-to-asset entries in batch.
     pub async fn for_ktas<C: GetAnchorAccount>(
         client: &C,
         token: ClaimableToken,
@@ -812,6 +843,7 @@ pub mod recipient {
         client.anchor_accounts(&recipient_keys).await
     }
 
+    /// Fetches recipient accounts for multiple entity keys in batch.
     pub async fn for_entity_keys<C: GetAnchorAccount, E: AsEntityKey>(
         client: &C,
         token: ClaimableToken,
@@ -821,6 +853,7 @@ pub mod recipient {
         for_ktas(client, token, &ktas).await
     }
 
+    /// Builds an instruction to initialize a new recipient account for reward tracking.
     pub fn init_instruction(
         token: ClaimableToken,
         kta: &helium_entity_manager::accounts::KeyToAssetV0,
@@ -872,8 +905,10 @@ pub mod recipient {
         Ok(ix)
     }
 
+    /// Compute budget units for recipient initialization.
     pub const INIT_INSTRUCTION_BUDGET: u32 = 150_000;
 
+    /// Builds an unsigned message to initialize a recipient account.
     pub async fn init_message<E: AsEntityKey, C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
         client: &C,
         token: ClaimableToken,
@@ -898,6 +933,7 @@ pub mod recipient {
         message::mk_message(client, ixs, &opts.lut_addresses, payer).await
     }
 
+    /// Signs and returns a transaction to initialize a recipient account.
     pub async fn init<E: AsEntityKey, C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
         client: &C,
         token: ClaimableToken,
@@ -911,9 +947,11 @@ pub mod recipient {
         Ok((txn, block_height))
     }
 
+    /// Resolves the actual reward destination for entities (custom destination or asset owner).
     pub mod destination {
         use super::*;
 
+        /// Returns the reward destination for a key-to-asset (custom destination or asset owner).
         pub async fn for_kta<C: GetAnchorAccount + AsRef<DasClient>>(
             client: &C,
             token: ClaimableToken,
@@ -931,6 +969,7 @@ pub mod recipient {
             }
         }
 
+        /// Returns reward destinations for multiple key-to-asset entries in batch.
         pub async fn for_ktas<C: GetAnchorAccount + AsRef<DasClient>>(
             client: &C,
             token: ClaimableToken,
@@ -970,6 +1009,7 @@ pub mod recipient {
             Ok(maybe_destinations.into_iter().flatten().collect())
         }
 
+        /// Returns the reward destination for a single entity key.
         pub async fn for_entity_key<C: GetAnchorAccount + AsRef<DasClient>, E: AsEntityKey>(
             client: &C,
             token: ClaimableToken,
@@ -979,6 +1019,7 @@ pub mod recipient {
             for_kta(client, token, &kta).await
         }
 
+        /// Returns reward destinations for multiple entity keys in batch.
         pub async fn for_entity_keys<C: GetAnchorAccount + AsRef<DasClient>, E: AsEntityKey>(
             client: &C,
             token: ClaimableToken,
@@ -988,6 +1029,7 @@ pub mod recipient {
             for_ktas(client, token, &ktas).await
         }
 
+        /// Builds an instruction to change the reward destination for an entity.
         pub fn update_instruction(
             token: ClaimableToken,
             kta: &helium_entity_manager::accounts::KeyToAssetV0,
@@ -1043,6 +1085,7 @@ pub mod recipient {
             Ok(ix)
         }
 
+        /// Builds an unsigned message to update the reward destination, initializing the recipient if needed.
         pub async fn update_message<
             C: AsRef<SolanaRpcClient> + AsRef<DasClient> + GetAnchorAccount,
             E: AsEntityKey,
@@ -1086,6 +1129,7 @@ pub mod recipient {
             message::mk_message(client, &ixs, &opts.lut_addresses, owner).await
         }
 
+        /// Signs and returns a transaction to update the reward destination.
         pub async fn update<
             E: AsEntityKey,
             C: AsRef<SolanaRpcClient> + AsRef<DasClient> + GetAnchorAccount,

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -286,7 +286,8 @@ pub fn distribute_rewards_instruction_for_owner(
             owner: asset.ownership.owner,
             circuit_breaker: lazy_distributor_circuit_breaker(ld_account),
             recipient: token.recipient_key_from_kta(kta),
-            destination_account: Token::from(token).associated_token_address(&asset.ownership.owner),
+            destination_account: Token::from(token)
+                .associated_token_address(&asset.ownership.owner),
         },
         compression_program: spl_account_compression::ID,
         merkle_tree: asset.compression.tree,

--- a/helium-lib/src/schedule.rs
+++ b/helium-lib/src/schedule.rs
@@ -18,14 +18,17 @@ use crate::{
 };
 use itertools::Itertools;
 
+/// Derive the entity cron authority PDA for a wallet.
 pub fn entity_cron_authority_key(wallet: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"entity_cron_authority", wallet.as_ref()], &hpl_crons::ID).0
 }
 
+/// Derive the cron job PDA for a wallet and job ID.
 pub fn cron_job_key_for_wallet(wallet: &Pubkey, job_id: u32) -> Pubkey {
     tuktuk::cron::cron_job_key(&entity_cron_authority_key(wallet), job_id)
 }
 
+/// Fetch a cron job account, returning `None` if it does not exist.
 pub async fn get<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     key: &Pubkey,
@@ -37,6 +40,7 @@ pub async fn get<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount
     }
 }
 
+/// Build an instruction to initialize a scheduled entity claim cron job.
 pub fn init_instruction(
     task_queue_key: &Pubkey,
     task_queue: &TaskQueueV0,
@@ -92,6 +96,7 @@ pub fn init_instruction(
     Ok(ix)
 }
 
+/// Initialize a scheduled entity claim cron job and return a signed transaction.
 pub async fn init<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     task_queue_key: &Pubkey,
@@ -141,6 +146,7 @@ pub async fn init<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccoun
     Ok((txn, block_height))
 }
 
+/// Build an instruction to requeue an existing entity claim cron job.
 pub fn requeue_instruction(
     task_queue_key: &Pubkey,
     task_queue: &TaskQueueV0,
@@ -190,6 +196,7 @@ pub fn requeue_instruction(
     Ok(ix)
 }
 
+/// Requeue a scheduled entity claim cron job and return a signed transaction.
 pub async fn requeue<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     task_queue_key: &Pubkey,
@@ -225,8 +232,10 @@ pub async fn requeue<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAcc
     Ok((txn, block_height))
 }
 
+/// Compute units needed to close a cron job.
 pub const CU_CLOSE: u32 = 60_000;
 
+/// Build an instruction to close a scheduled entity claim cron job.
 pub fn close_instruction(cron_id: u32, name: &str, payer: &Pubkey) -> Result<Instruction, Error> {
     fn mk_accounts(job_id: u32, name: &str, payer: &Pubkey) -> impl ToAccountMetas {
         let user_authority = *payer;
@@ -257,8 +266,10 @@ pub fn close_instruction(cron_id: u32, name: &str, payer: &Pubkey) -> Result<Ins
     Ok(ix)
 }
 
+/// Compute units needed to remove one entity claim from a cron job.
 pub const CU_CLOSE_ENTITY_CLAIM: u32 = 40_000;
 
+/// Build an instruction to remove a single entity from a cron job.
 pub fn close_entity_claim_instruction(
     cron_job_key: &Pubkey,
     cron_job_index: u32,
@@ -296,6 +307,7 @@ pub fn close_entity_claim_instruction(
     Ok(ix)
 }
 
+/// Close a cron job (removing all entities first) and return a signed transaction.
 pub async fn close<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     cron_job_key: &Pubkey,
@@ -348,6 +360,7 @@ pub async fn close<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccou
     Ok((txn, block_height))
 }
 
+/// Build an instruction to add a wallet claim to a cron job.
 pub fn claim_wallet_instruction(
     cron_job_key: &Pubkey,
     cron_job: &CronJobV0,
@@ -389,6 +402,7 @@ pub fn claim_wallet_instruction(
     Ok(ix)
 }
 
+/// Add a wallet claim to a cron job and return a signed transaction.
 pub async fn claim_wallet<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     cron_job_key: &Pubkey,
@@ -415,6 +429,7 @@ pub async fn claim_wallet<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnch
     Ok((txn, block_height))
 }
 
+/// Build an instruction to add an entity asset claim to a cron job.
 pub fn claim_asset_instruction(
     cron_job_key: &Pubkey,
     cron_job: &CronJobV0,
@@ -456,6 +471,7 @@ pub fn claim_asset_instruction(
     Ok(ix)
 }
 
+/// Add an entity asset claim to a cron job and return a signed transaction.
 pub async fn claim_asset<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     cron_job_key: &Pubkey,

--- a/helium-lib/src/schedule.rs
+++ b/helium-lib/src/schedule.rs
@@ -18,17 +18,17 @@ use crate::{
 };
 use itertools::Itertools;
 
-/// Derive the entity cron authority PDA for a wallet.
+/// Derives the entity cron authority PDA for a wallet.
 pub fn entity_cron_authority_key(wallet: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"entity_cron_authority", wallet.as_ref()], &hpl_crons::ID).0
 }
 
-/// Derive the cron job PDA for a wallet and job ID.
+/// Derives the cron job PDA for a wallet and job ID.
 pub fn cron_job_key_for_wallet(wallet: &Pubkey, job_id: u32) -> Pubkey {
     tuktuk::cron::cron_job_key(&entity_cron_authority_key(wallet), job_id)
 }
 
-/// Fetch a cron job account, returning `None` if it does not exist.
+/// Fetches a cron job account, returning `None` if it does not exist.
 pub async fn get<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     key: &Pubkey,
@@ -40,7 +40,7 @@ pub async fn get<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount
     }
 }
 
-/// Build an instruction to initialize a scheduled entity claim cron job.
+/// Builds an instruction to initialize a scheduled entity claim cron job.
 pub fn init_instruction(
     task_queue_key: &Pubkey,
     task_queue: &TaskQueueV0,
@@ -96,7 +96,7 @@ pub fn init_instruction(
     Ok(ix)
 }
 
-/// Initialize a scheduled entity claim cron job and return a signed transaction.
+/// Initializes a scheduled entity claim cron job and returns a signed transaction.
 pub async fn init<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     task_queue_key: &Pubkey,
@@ -146,7 +146,7 @@ pub async fn init<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccoun
     Ok((txn, block_height))
 }
 
-/// Build an instruction to requeue an existing entity claim cron job.
+/// Builds an instruction to requeue an existing entity claim cron job.
 pub fn requeue_instruction(
     task_queue_key: &Pubkey,
     task_queue: &TaskQueueV0,
@@ -235,7 +235,7 @@ pub async fn requeue<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAcc
 /// Compute units needed to close a cron job.
 pub const CU_CLOSE: u32 = 60_000;
 
-/// Build an instruction to close a scheduled entity claim cron job.
+/// Builds an instruction to close a scheduled entity claim cron job.
 pub fn close_instruction(cron_id: u32, name: &str, payer: &Pubkey) -> Result<Instruction, Error> {
     fn mk_accounts(job_id: u32, name: &str, payer: &Pubkey) -> impl ToAccountMetas {
         let user_authority = *payer;
@@ -269,7 +269,7 @@ pub fn close_instruction(cron_id: u32, name: &str, payer: &Pubkey) -> Result<Ins
 /// Compute units needed to remove one entity claim from a cron job.
 pub const CU_CLOSE_ENTITY_CLAIM: u32 = 40_000;
 
-/// Build an instruction to remove a single entity from a cron job.
+/// Builds an instruction to remove a single entity from a cron job.
 pub fn close_entity_claim_instruction(
     cron_job_key: &Pubkey,
     cron_job_index: u32,
@@ -360,7 +360,7 @@ pub async fn close<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccou
     Ok((txn, block_height))
 }
 
-/// Build an instruction to add a wallet claim to a cron job.
+/// Builds an instruction to add a wallet claim to a cron job.
 pub fn claim_wallet_instruction(
     cron_job_key: &Pubkey,
     cron_job: &CronJobV0,
@@ -429,7 +429,7 @@ pub async fn claim_wallet<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnch
     Ok((txn, block_height))
 }
 
-/// Build an instruction to add an entity asset claim to a cron job.
+/// Builds an instruction to add an entity asset claim to a cron job.
 pub fn claim_asset_instruction(
     cron_job_key: &Pubkey,
     cron_job: &CronJobV0,

--- a/helium-lib/src/staking.rs
+++ b/helium-lib/src/staking.rs
@@ -13,6 +13,7 @@ pub const DEFAULT_TIMEOUT: u64 = 120;
 /// The default base URL if none is specified.
 pub const DEFAULT_BASE_URL: &str = "https://onboarding.dewi.org/api/v2";
 
+/// Legacy staking/onboarding server client (v2 API).
 pub struct Client {
     base_url: String,
     client: reqwest::Client,

--- a/helium-lib/src/token.rs
+++ b/helium-lib/src/token.rs
@@ -63,7 +63,7 @@ const SPL_TRANSFER_CHECKED_CU: u32 = 7000;
 /// (Estimated value based on similar operations)
 const SPL_CLOSE_ACCOUNT_CU: u32 = 3000;
 
-/// Build a versioned message that burns a token amount from the payer's account.
+/// Builds a versioned message that burns a token amount from the payer's account.
 pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     token_amount: &TokenAmount,
@@ -91,7 +91,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, &[ix], &opts.lut_addresses, payer).await
 }
 
-/// Burn a token amount from the keypair's account, returning a signed transaction.
+/// Burns a token amount from the keypair's account, returning a signed transaction.
 pub async fn burn<C: AsRef<SolanaRpcClient>>(
     client: &C,
     token_amount: &TokenAmount,
@@ -103,7 +103,7 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
-/// Build a versioned message that transfers tokens to one or more recipients.
+/// Builds a versioned message that transfers tokens to one or more recipients.
 pub async fn transfer_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     transfers: &[(Pubkey, TokenAmount)],
@@ -182,7 +182,7 @@ pub async fn transfer<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
-/// Build a message to close multiple accounts and return funds to destination.
+/// Builds a message to close multiple accounts and return funds to destination.
 ///
 /// Supports both SPL token accounts and the owner's system account:
 /// - SPL token accounts (any account != owner): closed via `spl_token::close_account`.
@@ -302,7 +302,7 @@ pub async fn close_account<C: AsRef<SolanaRpcClient>>(
     close_accounts(client, &[*account], destination, owner, fee_payer, opts).await
 }
 
-/// Fetch the token balance for a single account address.
+/// Fetches the token balance for a single account address.
 pub async fn balance_for_address<C: AsRef<SolanaRpcClient>>(
     client: &C,
     pubkey: &Pubkey,
@@ -331,7 +331,7 @@ fn to_token_balance(pubkey: Pubkey, value: Option<Account>) -> Result<Option<Tok
     }
 }
 
-/// Fetch token balances for multiple account addresses in batched RPC calls.
+/// Fetches token balances for multiple account addresses in batched RPC calls.
 pub async fn balance_for_addresses<C: AsRef<SolanaRpcClient>>(
     client: &C,
     pubkeys: &[Pubkey],

--- a/helium-lib/src/token.rs
+++ b/helium-lib/src/token.rs
@@ -14,6 +14,7 @@ use futures::stream::{self, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use std::{collections::HashMap, result::Result as StdResult, str::FromStr};
 
+/// Errors from parsing or validating a token type.
 #[derive(Debug, thiserror::Error)]
 pub enum TokenError {
     #[error("Invalid token type: {0}")]
@@ -62,6 +63,7 @@ const SPL_TRANSFER_CHECKED_CU: u32 = 7000;
 /// (Estimated value based on similar operations)
 const SPL_CLOSE_ACCOUNT_CU: u32 = 3000;
 
+/// Build a versioned message that burns a token amount from the payer's account.
 pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     token_amount: &TokenAmount,
@@ -73,7 +75,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
             return Err(DecodeError::other("native token burn not supported").into());
         }
         spl_mint => {
-            let token_account = token_amount.token.associated_token_adress(payer);
+            let token_account = token_amount.token.associated_token_address(payer);
             anchor_spl::token::spl_token::instruction::burn_checked(
                 &anchor_spl::token::spl_token::id(),
                 &token_account,
@@ -89,6 +91,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, &[ix], &opts.lut_addresses, payer).await
 }
 
+/// Burn a token amount from the keypair's account, returning a signed transaction.
 pub async fn burn<C: AsRef<SolanaRpcClient>>(
     client: &C,
     token_amount: &TokenAmount,
@@ -100,6 +103,7 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
+/// Build a versioned message that transfers tokens to one or more recipients.
 pub async fn transfer_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     transfers: &[(Pubkey, TokenAmount)],
@@ -122,8 +126,8 @@ pub async fn transfer_message<C: AsRef<SolanaRpcClient>>(
                 cu_budget += SYS_PROGRAM_TRANSFER_CU;
             }
             spl_mint => {
-                let source_pubkey = token_amount.token.associated_token_adress(payer);
-                let destination_pubkey = token_amount.token.associated_token_adress(payee);
+                let source_pubkey = token_amount.token.associated_token_address(payer);
+                let destination_pubkey = token_amount.token.associated_token_address(payee);
                 let ix = spl_associated_token_account::instruction::create_associated_token_account_idempotent(
                     payer,
                     payee,
@@ -166,6 +170,7 @@ pub async fn transfer_message<C: AsRef<SolanaRpcClient>>(
     message::mk_message(client, final_ixs, &opts.lut_addresses, payer).await
 }
 
+/// Transfer tokens to one or more recipients, returning a signed transaction.
 pub async fn transfer<C: AsRef<SolanaRpcClient>>(
     client: &C,
     transfers: &[(Pubkey, TokenAmount)],
@@ -297,6 +302,7 @@ pub async fn close_account<C: AsRef<SolanaRpcClient>>(
     close_accounts(client, &[*account], destination, owner, fee_payer, opts).await
 }
 
+/// Fetch the token balance for a single account address.
 pub async fn balance_for_address<C: AsRef<SolanaRpcClient>>(
     client: &C,
     pubkey: &Pubkey,
@@ -325,6 +331,7 @@ fn to_token_balance(pubkey: Pubkey, value: Option<Account>) -> Result<Option<Tok
     }
 }
 
+/// Fetch token balances for multiple account addresses in batched RPC calls.
 pub async fn balance_for_addresses<C: AsRef<SolanaRpcClient>>(
     client: &C,
     pubkeys: &[Pubkey],
@@ -350,14 +357,18 @@ pub async fn balance_for_addresses<C: AsRef<SolanaRpcClient>>(
         .try_collect()
 }
 
+/// Pyth oracle price lookups for Helium tokens.
 pub mod price {
     use super::*;
     use crate::programs::helium_entity_manager::accounts::PriceUpdateV2;
     use rust_decimal::prelude::*;
 
+    /// Raw 32-byte Pyth price feed identifier.
     pub type FeedId = [u8; 32];
+    /// Number of Data Credits per USD.
     pub const DC_PER_USD: i64 = 100_000;
 
+    /// Errors from fetching or validating a token price.
     #[derive(Debug, thiserror::Error)]
     pub enum PriceError {
         #[error("invalid or unsupported token: {0}")]
@@ -374,6 +385,7 @@ pub mod price {
         PositiveExponent,
     }
 
+    /// A token price snapshot from the Pyth oracle.
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
     pub struct Price {
         pub timestamp: DateTime<Utc>,
@@ -387,6 +399,7 @@ pub mod price {
         Ok(feed_id)
     }
 
+    /// Fetch the current price for a token, rejecting prices older than `max_age`.
     pub async fn get_with_max_age<C: AsRef<SolanaRpcClient>>(
         client: &C,
         token: Token,
@@ -430,22 +443,30 @@ pub mod price {
         })
     }
 
+    /// Fetch the current price for a token with a default 10-minute max age.
     pub async fn get<C: AsRef<SolanaRpcClient>>(client: &C, token: Token) -> Result<Price, Error> {
         get_with_max_age(client, token, Duration::minutes(10)).await
     }
 }
 
+/// Helium ecosystem tokens on Solana.
 #[derive(
     Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord,
 )]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "lowercase")]
 pub enum Token {
+    /// Native Solana token (lamports).
     Sol,
+    /// Helium Network Token -- the primary governance and staking token.
     Hnt,
+    /// MOBILE sub-DAO token for 5G/cellular coverage.
     Mobile,
+    /// IOT sub-DAO token for LoRaWAN coverage.
     Iot,
+    /// Data Credits -- non-transferable, burned to pay for network usage.
     Dc,
+    /// USD Coin stablecoin.
     Usdc,
 }
 
@@ -479,6 +500,7 @@ impl FromStr for Token {
 }
 
 impl Token {
+    /// Look up a token by its SPL mint address, returning `None` for unknown mints.
     pub fn from_mint(mint: Pubkey) -> Option<Self> {
         let token = match mint {
             mint if mint == *HNT_MINT => Token::Hnt,
@@ -493,6 +515,7 @@ impl Token {
         Some(token)
     }
 
+    /// All supported token types.
     pub fn all() -> Vec<Self> {
         vec![
             Self::Hnt,
@@ -528,17 +551,19 @@ impl Token {
         Self::from_allowed(s, &[Self::Iot, Self::Mobile, Self::Hnt])
     }
 
-    pub fn associated_token_adress(&self, address: &Pubkey) -> Pubkey {
+    /// Derive the associated token account address for a wallet. Returns the wallet itself for SOL.
+    pub fn associated_token_address(&self, address: &Pubkey) -> Pubkey {
         match self {
             Self::Sol => *address,
             _ => spl_associated_token_account::get_associated_token_address(address, self.mint()),
         }
     }
 
-    pub fn associated_token_adresses(address: &Pubkey) -> Vec<Pubkey> {
+    /// Derive associated token account addresses for all supported tokens.
+    pub fn associated_token_addresses(address: &Pubkey) -> Vec<Pubkey> {
         Self::all()
             .iter()
-            .map(|token| token.associated_token_adress(address))
+            .map(|token| token.associated_token_address(address))
             .collect::<Vec<_>>()
     }
 
@@ -551,6 +576,7 @@ impl Token {
     }
 }
 
+/// A token balance at a specific on-chain account address.
 #[derive(Debug, serde::Serialize, Default, Clone, Copy)]
 pub struct TokenBalance {
     #[serde(with = "serde_pubkey")]
@@ -558,6 +584,7 @@ pub struct TokenBalance {
     pub amount: TokenAmount,
 }
 
+/// Map of token type to balance, used for multi-token wallet summaries.
 #[derive(Debug, serde::Serialize, Clone, Default)]
 pub struct TokenBalanceMap(HashMap<Token, TokenBalance>);
 
@@ -586,6 +613,7 @@ impl From<Vec<Option<TokenBalance>>> for TokenBalanceMap {
     }
 }
 
+/// A token amount stored as raw integer units (e.g. lamports for SOL, bones for HNT).
 #[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
 pub struct TokenAmount {
     pub token: Token,
@@ -701,12 +729,14 @@ impl Default for TokenAmount {
 }
 
 impl TokenAmount {
+    /// Create a token amount from a human-readable decimal value (e.g. `1.5` HNT).
     pub fn from_f64<T: Into<Token>>(token: T, amount: f64) -> Self {
         let token = token.into();
         let amount = (amount * 10_usize.pow(token.decimals().into()) as f64) as u64;
         Self { token, amount }
     }
 
+    /// Create a token amount from raw integer units (e.g. lamports, bones).
     pub fn from_u64<T: Into<Token>>(token: T, amount: u64) -> Self {
         Self {
             token: token.into(),
@@ -716,6 +746,7 @@ impl TokenAmount {
 }
 
 impl Token {
+    /// Number of decimal places for this token (e.g. 8 for HNT, 9 for SOL, 0 for DC).
     pub fn decimals(&self) -> u8 {
         match self {
             Self::Hnt => 8,
@@ -726,6 +757,7 @@ impl Token {
         }
     }
 
+    /// The SPL mint address for this token (system program ID for SOL).
     pub fn mint(&self) -> &Pubkey {
         match self {
             Self::Hnt => &HNT_MINT,

--- a/helium-lib/src/transaction.rs
+++ b/helium-lib/src/transaction.rs
@@ -56,7 +56,7 @@ impl SignatureStatus {
     }
 }
 
-/// Build a signed versioned transaction from a message and signers.
+/// Builds a signed versioned transaction from a message and signers.
 pub fn mk_transaction<T: Signers + ?Sized>(
     msg: message::VersionedMessage,
     signers: &T,

--- a/helium-lib/src/transaction.rs
+++ b/helium-lib/src/transaction.rs
@@ -56,6 +56,7 @@ impl SignatureStatus {
     }
 }
 
+/// Build a signed versioned transaction from a message and signers.
 pub fn mk_transaction<T: Signers + ?Sized>(
     msg: message::VersionedMessage,
     signers: &T,
@@ -63,6 +64,7 @@ pub fn mk_transaction<T: Signers + ?Sized>(
     VersionedTransaction::try_new(msg, signers).map_err(Error::from)
 }
 
+/// Pack multiple instruction groups into size-limited transactions.
 pub fn pack_instructions(
     instructions: &[&[Instruction]],
     lookup_tables: Option<Vec<AddressLookupTableAccount>>,

--- a/helium-wallet/src/cmd/balance.rs
+++ b/helium-wallet/src/cmd/balance.rs
@@ -16,7 +16,7 @@ impl Cmd {
         let address = opts.maybe_wallet_key(self.address)?;
         let client = opts.client()?;
         let balances =
-            token::balance_for_addresses(&client, &Token::associated_token_adresses(&address))
+            token::balance_for_addresses(&client, &Token::associated_token_addresses(&address))
                 .await?;
         let json = json!({
             "address": address.to_string(),


### PR DESCRIPTION
## Summary

- Rewrite root README with complete CLI command reference (all 15 commands), workspace overview, swap docs, and full environment variable tables
- Add helium-lib crate README with module overview, feature flags, re-exports, and usage example
- Add rustdoc comments across all public items in helium-lib (~270 items were undocumented)
- Fix `associated_token_adress` typo -> `associated_token_address` across 7 files (16 call sites) — **breaking API change**