### PR TITLE
ci: switch macOS builds from Intel to Apple Silicon

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,7 +108,8 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
         run: |
-          echo "NAME=helium-wallet-${TARGET,,}" >> $GITHUB_ENV
+          TARGET_LC=$(echo "$TARGET" | tr '[:upper:]' '[:lower:]')
+          echo "NAME=helium-wallet-${TARGET_LC}" >> $GITHUB_ENV
 
       - name: Build | Package
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,8 +62,6 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86-64-linux
-          - os: macos-13
-            target: x86-64-macos
           - os: macos-14
             target: arm64-macos
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,7 +108,7 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
         run: |
-          echo "NAME=helium-wallet-${TARGET}" >> $GITHUB_ENV
+          echo "NAME=helium-wallet-${TARGET,,}" >> $GITHUB_ENV
 
       - name: Build | Package
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,11 +61,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            arch: x86-64-linux
+            target: x86-64-linux
           - os: macos-13
-            arch: x86-64-macos
+            target: x86-64-macos
           - os: macos-14
-            arch: aarch64-macos
+            target: arm64-macos
 
     steps:
       - name: Setup | Cancel Previous Runs
@@ -98,7 +98,7 @@ jobs:
       - name: Setup | Rust Cache
         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
         with:
-          key: ${{ matrix.arch }}
+          key: ${{ matrix.target }}
 
       - name: Build | Compile
         run: cargo build --all --locked --release
@@ -106,9 +106,9 @@ jobs:
       - name: Build | Name
         shell: bash
         env:
-          ARCH: ${{ matrix.arch }}
+          TARGET: ${{ matrix.target }}
         run: |
-          echo "NAME=helium-wallet-${ARCH}" >> $GITHUB_ENV
+          echo "NAME=helium-wallet-${TARGET}" >> $GITHUB_ENV
 
       - name: Build | Package
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            arch: x86-64-linux
+          - os: macos-13
+            arch: x86-64-macos
+          - os: macos-14
+            arch: aarch64-macos
 
     steps:
       - name: Setup | Cancel Previous Runs
@@ -92,22 +98,16 @@ jobs:
       - name: Setup | Rust Cache
         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
         with:
-          key: ${{ matrix.os }}
+          key: ${{ matrix.arch }}
 
       - name: Build | Compile
         run: cargo build --all --locked --release
 
       - name: Build | Name
         shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-              ARCH=x86-64-linux
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-              ARCH=x86-64-macos
-          else
-              echo "$RUNNER_OS not supported"
-              exit 1
-          fi
           echo "NAME=helium-wallet-${ARCH}" >> $GITHUB_ENV
 
       - name: Build | Package


### PR DESCRIPTION
## Summary

- Replace \`macos-latest\` in the build matrix with explicit targets
- Drop Intel macOS builds (GitHub retired the \`macos-13\` runner; Apple transitioned off Intel in 2020)
- Produce native \`helium-wallet-arm64-macos\` binaries via \`macos-14\`
- Rename \`matrix.arch\` to \`matrix.target\` (the value is a combined arch+OS identifier, not just an arch)
- Force lowercase on the resulting artifact name via \`tr\` (portable across bash 3.2/4+)

Intel Mac users can still build from source.