### PR TITLE
fix(asset): drop root-side canopy from Merkle proof

### DIFF
--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -679,9 +679,13 @@ impl Asset {
 
 impl AssetProof {
     pub fn proof(&self) -> Result<Vec<solana_program::instruction::AccountMeta>, Error> {
+        let proof_len = self
+            .proof
+            .len()
+            .saturating_sub(self.canopy_height.unwrap_or(0));
         self.proof
             .iter()
-            .take(self.canopy_height.unwrap_or(self.proof.len()))
+            .take(proof_len)
             .map(|s| {
                 Pubkey::from_str(s)
                     .map_err(DecodeError::from)

--- a/helium-lib/src/transaction.rs
+++ b/helium-lib/src/transaction.rs
@@ -139,7 +139,7 @@ pub async fn confirm_signatures<C: AsRef<SolanaRpcClient>>(
 
         // Process results - remove confirmed/failed from pending
         let mut still_pending = Vec::new();
-        for (sig, status) in pending.iter().zip(statuses.into_iter()) {
+        for (sig, status) in pending.iter().zip(statuses) {
             match &status {
                 SignatureStatus::Confirmed | SignatureStatus::Failed(_) => {
                     results.insert(*sig, status);

--- a/helium-wallet/src/cmd/hotspots/rewards.rs
+++ b/helium-wallet/src/cmd/hotspots/rewards.rs
@@ -68,8 +68,12 @@ pub struct PendingCmd {
 impl PendingCmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let client = opts.client()?;
-        let owner = opts.maybe_wallet_key(self.owner)?;
-        let hotspots = collect_hotspots(&client, self.hotspots.clone(), Some(owner)).await?;
+        let owner = match (self.hotspots.as_ref(), self.owner) {
+            (Some(_), _) => None,
+            (None, Some(owner)) => Some(owner),
+            (None, None) => Some(opts.maybe_wallet_key(None)?),
+        };
+        let hotspots = collect_hotspots(&client, self.hotspots.clone(), owner).await?;
         let encoded_entity_keys: Vec<EncodedEntityKey> = hotspots.iter().map(Into::into).collect();
         let pending =
             reward::pending_amounts(&client, self.token, None, &encoded_entity_keys).await?;
@@ -96,8 +100,12 @@ pub struct LifetimeCmd {
 impl LifetimeCmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let client = opts.client()?;
-        let owner = opts.maybe_wallet_key(self.owner)?;
-        let hotspots = collect_hotspots(&client, self.hotspots.clone(), Some(owner)).await?;
+        let owner = match (self.hotspots.as_ref(), self.owner) {
+            (Some(_), _) => None,
+            (None, Some(owner)) => Some(owner),
+            (None, None) => Some(opts.maybe_wallet_key(None)?),
+        };
+        let hotspots = collect_hotspots(&client, self.hotspots.clone(), owner).await?;
         let encoded_entity_keys: Vec<EncodedEntityKey> = hotspots.iter().map(Into::into).collect();
         let rewards = reward::lifetime(&client, self.token, &encoded_entity_keys).await?;
 


### PR DESCRIPTION
## Summary

Two fixes surfaced from #519:

1. **`AssetProof::proof()` was truncating the wrong end of the Merkle proof.** Used `canopy_height` as the *take count* instead of the *drop count*, keeping root-side siblings (already in the on-chain canopy) and overflowing the transaction wire-size limit on trees with non-trivial canopies.
2. **`hotspots rewards pending` and `hotspots rewards lifetime` required a `wallet.key` on disk** even when an explicit hotspot list was provided and the wallet's pubkey was never used.

## Fix 1: proof truncation (`helium-lib/src/asset.rs`)

For tree `J53f1jfy6QGU8U3qty2MwyNPk68AoybUkigeukDTj356`: `max_depth = 14`, `canopy_depth = 11`, DAS returns a 14-node proof. Only the leaf-side `14 - 11 = 3` should be sent as accounts; the root-side levels live in the on-chain canopy. The wallet was sending 11.

```rust
// before
.take(self.canopy_height.unwrap_or(self.proof.len()))
// after
.take(self.proof.len().saturating_sub(self.canopy_height.unwrap_or(0)))
```

Regression introduced in 4ec469e (`Calculate proof size properly`), where call sites migrated from passing an explicit proof length (`Some(3)`) to relying on `AssetProof::canopy_height`, but the `.take()` argument wasn't flipped.

Same accessor is also used by hotspot direct updates and dataonly onboarding.

## Fix 2: read-only commands no longer require a wallet

`PendingCmd` / `LifetimeCmd` only fall back to the wallet's pubkey when neither `[hotspots...]` nor `--owner` is provided.

## Verification (A/B against the reported hotspot)

Same hotspot (`14XYHBiU…`), same RPC (`solana-rpc.web.helium.io`), same throwaway payer wallet — only the code differs:

| Branch | Result |
|---|---|
| `master` | `RPC error -32602: VersionedTransaction too large: 1752 bytes (max raw: 1232)` — wire-size guard rejection (#519) |
| `fix/proof-canopy-truncation` | `Attempt to debit an account but found no record of a prior credit` — runtime fee-debit error from the zero-SOL payer |

Master reproduces the original wire-size rejection. The fix branch is past that guard and into the runtime, failing only because the test payer has no SOL — exactly the expected next failure. The size regression is gone.