### PR TITLE
feat(squads): native v3+v4 multisig integration in helium-wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,19 @@ name = "anchor-attribute-access-control"
 version = "0.31.1"
 source = "git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey#1dfe80386037379325c30095dcdb51e152c1e3c5"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.31.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-access-control"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a883ca44ef14b2113615fc6d3a85fefc68b5002034e88db37f7f1f802f88aa9"
+dependencies = [
+ "anchor-syn 0.32.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -164,7 +176,20 @@ name = "anchor-attribute-account"
 version = "0.31.1"
 source = "git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey#1dfe80386037379325c30095dcdb51e152c1e3c5"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.31.1",
+ "bs58",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-account"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c4d97763b29030412b4b80715076377edc9cc63bc3c9e667297778384b9fd2"
+dependencies = [
+ "anchor-syn 0.32.1",
  "bs58",
  "proc-macro2",
  "quote",
@@ -176,7 +201,18 @@ name = "anchor-attribute-constant"
 version = "0.31.1"
 source = "git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey#1dfe80386037379325c30095dcdb51e152c1e3c5"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.31.1",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-constant"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae3328bbf9bbd517a51621b1ba6cbec06cbbc25e8cfc7403bddf69bcf088206"
+dependencies = [
+ "anchor-syn 0.32.1",
  "quote",
  "syn 1.0.109",
 ]
@@ -186,7 +222,18 @@ name = "anchor-attribute-error"
 version = "0.31.1"
 source = "git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey#1dfe80386037379325c30095dcdb51e152c1e3c5"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.31.1",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-error"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2398a6d9e16df1ee9d7d37d970a8246756de898c8dd16ef6bdbe4da20cf39a"
+dependencies = [
+ "anchor-syn 0.32.1",
  "quote",
  "syn 1.0.109",
 ]
@@ -196,7 +243,19 @@ name = "anchor-attribute-event"
 version = "0.31.1"
 source = "git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey#1dfe80386037379325c30095dcdb51e152c1e3c5"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.31.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-event"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12758f4ec2f0e98d4d56916c6fe95cb23d74b8723dd902c762c5ef46ebe7b65"
+dependencies = [
+ "anchor-syn 0.32.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -207,8 +266,25 @@ name = "anchor-attribute-program"
 version = "0.31.1"
 source = "git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey#1dfe80386037379325c30095dcdb51e152c1e3c5"
 dependencies = [
- "anchor-lang-idl",
- "anchor-syn",
+ "anchor-lang-idl 0.1.2 (git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey)",
+ "anchor-syn 0.31.1",
+ "anyhow",
+ "bs58",
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-program"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7193b5af2649813584aae6e3569c46fd59616a96af2083c556b13136c3830f"
+dependencies = [
+ "anchor-lang-idl 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-syn 0.32.1",
  "anyhow",
  "bs58",
  "heck 0.3.3",
@@ -224,7 +300,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3e91b12501d37c8f07de9da8c7d22067998a7760a515231187afb47ded225"
 dependencies = [
- "anchor-lang",
+ "anchor-lang 0.31.1",
  "anyhow",
  "futures",
  "regex",
@@ -242,7 +318,18 @@ name = "anchor-derive-accounts"
 version = "0.31.1"
 source = "git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey#1dfe80386037379325c30095dcdb51e152c1e3c5"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.31.1",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-accounts"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d332d1a13c0fca1a446de140b656e66110a5e8406977dcb6a41e5d6f323760b0"
+dependencies = [
+ "anchor-syn 0.32.1",
  "quote",
  "syn 1.0.109",
 ]
@@ -252,7 +339,20 @@ name = "anchor-derive-serde"
 version = "0.31.1"
 source = "git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey#1dfe80386037379325c30095dcdb51e152c1e3c5"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.31.1",
+ "borsh-derive-internal",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-serde"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8656e4af182edaeae665fa2d2d7ee81148518b5bd0be9a67f2a381bb17da7d46"
+dependencies = [
+ "anchor-syn 0.32.1",
  "borsh-derive-internal",
  "proc-macro2",
  "quote",
@@ -270,20 +370,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "anchor-derive-space"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcff2a083560cd79817db07d89a4de39a2c4b2eaa00c1742cf0df49b25ff2bed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "anchor-lang"
 version = "0.31.1"
 source = "git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey#1dfe80386037379325c30095dcdb51e152c1e3c5"
 dependencies = [
- "anchor-attribute-access-control",
- "anchor-attribute-account",
- "anchor-attribute-constant",
- "anchor-attribute-error",
- "anchor-attribute-event",
- "anchor-attribute-program",
- "anchor-derive-accounts",
- "anchor-derive-serde",
- "anchor-derive-space",
- "anchor-lang-idl",
+ "anchor-attribute-access-control 0.31.1",
+ "anchor-attribute-account 0.31.1",
+ "anchor-attribute-constant 0.31.1",
+ "anchor-attribute-error 0.31.1",
+ "anchor-attribute-event 0.31.1",
+ "anchor-attribute-program 0.31.1",
+ "anchor-derive-accounts 0.31.1",
+ "anchor-derive-serde 0.31.1",
+ "anchor-derive-space 0.31.1",
+ "anchor-lang-idl 0.1.2 (git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey)",
  "base64 0.21.7",
  "bincode",
  "borsh 0.10.4",
@@ -293,17 +404,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "anchor-lang"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67d85d5376578f12d840c29ff323190f6eecd65b00a0b5f2b2f232751d049cc"
+dependencies = [
+ "anchor-attribute-access-control 0.32.1",
+ "anchor-attribute-account 0.32.1",
+ "anchor-attribute-constant 0.32.1",
+ "anchor-attribute-error 0.32.1",
+ "anchor-attribute-event 0.32.1",
+ "anchor-attribute-program 0.32.1",
+ "anchor-derive-accounts 0.32.1",
+ "anchor-derive-serde 0.32.1",
+ "anchor-derive-space 0.32.1",
+ "base64 0.21.7",
+ "bincode",
+ "borsh 0.10.4",
+ "bytemuck",
+ "solana-account-info",
+ "solana-clock",
+ "solana-cpi",
+ "solana-define-syscall",
+ "solana-feature-gate-interface",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-invoke",
+ "solana-loader-v3-interface 3.0.0",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-sysvar-id",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "anchor-lang-idl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e8599d21995f68e296265aa5ab0c3cef582fd58afec014d01bd0bce18a4418"
+dependencies = [
+ "anchor-lang-idl-spec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "heck 0.3.3",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "anchor-lang-idl"
 version = "0.1.2"
 source = "git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey#1dfe80386037379325c30095dcdb51e152c1e3c5"
 dependencies = [
- "anchor-lang-idl-spec",
+ "anchor-lang-idl-spec 0.1.0 (git+https://github.com/madninja/anchor.git?branch=madninja%2Fconst_pubkey)",
  "anyhow",
  "heck 0.3.3",
  "regex",
  "serde",
  "serde_json",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "anchor-lang-idl-spec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bdf143115440fe621bdac3a29a1f7472e09f6cd82b2aa569429a0c13f103838"
+dependencies = [
+ "anyhow",
+ "serde",
 ]
 
 [[package]]
@@ -321,13 +498,28 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c08cb5d762c0694f74bd02c9a5b04ea53cefc496e2c27b3234acffca5cd076b"
 dependencies = [
- "anchor-lang",
+ "anchor-lang 0.31.1",
  "spl-associated-token-account 6.0.0",
  "spl-pod",
  "spl-token 7.0.0",
  "spl-token-2022 6.0.0",
  "spl-token-group-interface 0.5.0",
  "spl-token-metadata-interface 0.6.0",
+]
+
+[[package]]
+name = "anchor-spl"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3397ab3fc5b198bbfe55d827ff58bd69f2a8d3f9f71c3732c23c2093fec4d3ef"
+dependencies = [
+ "anchor-lang 0.32.1",
+ "spl-associated-token-account 7.0.0",
+ "spl-pod",
+ "spl-token 8.0.0",
+ "spl-token-2022 8.0.1",
+ "spl-token-group-interface 0.6.0",
+ "spl-token-metadata-interface 0.7.0",
 ]
 
 [[package]]
@@ -338,6 +530,24 @@ dependencies = [
  "anyhow",
  "bs58",
  "cargo_toml",
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "syn 1.0.109",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "anchor-syn"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93b69aa7d099b59378433f6d7e20e1008fc10c69e48b220270e5b3f2ec4c8be"
+dependencies = [
+ "anyhow",
+ "bs58",
  "heck 0.3.3",
  "proc-macro2",
  "quote",
@@ -1626,6 +1836,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,7 +2031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2282,7 +2513,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3ae6081be123db88474f4c5f12f9b0d3d90b9f5ce15171dee64fe92e3cae2dd"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bs58",
  "byteorder",
  "ed25519-compact",
@@ -2303,15 +2534,16 @@ name = "helium-lib"
 version = "0.2.0"
 dependencies = [
  "anchor-client",
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.31.1",
+ "anchor-spl 0.31.1",
  "angry-purple-tiger",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bincode",
  "bytemuck",
  "chrono",
  "clap",
+ "dirs",
  "futures",
  "futures-timer",
  "h3o",
@@ -2336,6 +2568,8 @@ dependencies = [
  "solana-transaction-utils",
  "spl-associated-token-account 6.0.0",
  "spl-memo",
+ "squads-multisig-program",
+ "tempfile",
  "thiserror 1.0.69",
  "tonic",
  "tracing",
@@ -2655,7 +2889,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3021,6 +3255,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libsecp256k1"
@@ -3550,6 +3793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3859,7 +4108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -3880,7 +4129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3991,7 +4240,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.36",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4030,9 +4279,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4192,6 +4441,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4451,7 +4711,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4530,7 +4790,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5007,7 +5267,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-fee-calculator",
  "solana-instruction",
- "solana-loader-v3-interface",
+ "solana-loader-v3-interface 5.0.0",
  "solana-nonce",
  "solana-program-option",
  "solana-program-pack",
@@ -5591,6 +5851,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-invoke"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f5693c6de226b3626658377168b0184e94e8292ff16e3d31d4766e65627565"
+dependencies = [
+ "solana-account-info",
+ "solana-define-syscall",
+ "solana-instruction",
+ "solana-program-entrypoint",
+ "solana-stable-layout",
+]
+
+[[package]]
 name = "solana-keccak-hasher"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5646,6 +5919,21 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey",
  "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-loader-v3-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4be76cfa9afd84ca2f35ebc09f0da0f0092935ccdac0595d98447f259538c2"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-system-interface",
 ]
 
 [[package]]
@@ -5955,7 +6243,7 @@ dependencies = [
  "solana-keccak-hasher",
  "solana-last-restart-slot",
  "solana-loader-v2-interface",
- "solana-loader-v3-interface",
+ "solana-loader-v3-interface 5.0.0",
  "solana-loader-v4-interface",
  "solana-message",
  "solana-msg",
@@ -6931,7 +7219,7 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-loader-v2-interface",
- "solana-loader-v3-interface",
+ "solana-loader-v3-interface 5.0.0",
  "solana-message",
  "solana-program-option",
  "solana-pubkey",
@@ -7756,6 +8044,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "squads-multisig-program"
+version = "2.1.0"
+source = "git+https://github.com/Squads-Protocol/v4.git?branch=main#edbca83427b10cbe58bf65fc9b597e8eb7b17cc1"
+dependencies = [
+ "anchor-lang 0.32.1",
+ "anchor-spl 0.32.1",
+ "solana-address-lookup-table-interface",
+ "solana-borsh",
+ "solana-program",
+ "solana-security-txt",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7891,7 +8192,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8369,7 +8670,7 @@ name = "tuktuk-program"
 version = "0.3.2"
 source = "git+https://github.com/helium/tuktuk.git?branch=main#1b281ae0189e96dfaf27c7206ad2e72b98a5fb34"
 dependencies = [
- "anchor-lang",
+ "anchor-lang 0.31.1",
 ]
 
 [[package]]
@@ -8377,7 +8678,7 @@ name = "tuktuk-sdk"
 version = "0.4.0"
 source = "git+https://github.com/helium/tuktuk.git?branch=main#1b281ae0189e96dfaf27c7206ad2e72b98a5fb34"
 dependencies = [
- "anchor-lang",
+ "anchor-lang 0.31.1",
  "async-trait",
  "base64 0.22.1",
  "bincode",
@@ -8734,7 +9035,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -270,6 +270,77 @@ helium-wallet assets burn <asset> --commit
 helium-wallet assets transfer <asset> <address> --commit
 ```
 
+### `squads` -- Squads Multisig (v3 and v4)
+
+Inspect and act on Helium-managed Squads multisigs. Both v3
+(`SMPLecH…`) and v4 (`SQDS4ep…`) are supported. Wherever a target is
+expected, either a multisig PDA or a vault PDA works — vault →
+multisig resolution is cached locally after the first lookup.
+
+```
+helium-wallet squads members list   <multisig|vault>
+helium-wallet squads members add    <multisig|vault> <pubkey> [--perm <list>] --commit
+helium-wallet squads members remove <multisig|vault> <pubkey> --commit
+helium-wallet squads list           <multisig|vault> [--days <N>] [--include-drafts]
+helium-wallet squads inspect        <target> [--index <n>]
+helium-wallet squads approve        <target> [--index <n>] --commit
+helium-wallet squads reject         <target> [--index <n>] --commit
+helium-wallet squads cancel         <target> [--index <n>] --commit
+helium-wallet squads execute        <target> [--index <n>] --commit
+helium-wallet squads threshold      <multisig|vault> <new-threshold> --commit
+```
+
+| Subcommand | Purpose |
+|---|---|
+| `members list` | Print members, threshold, and version of a multisig |
+| `members add` / `members remove` | Propose adding or removing a member (v4 only). `members add` defaults to all permissions (initiate + vote + execute); `--perm vote --perm execute` narrows |
+| `list` | Actionable proposals — Active / Approved / ExecuteReady, last 7 days by default. `--days 0` for the full open set; `--include-drafts` to surface pre-activation drafts |
+| `inspect` | Decode a single proposal: status, votes, inner instructions, decoded args |
+| `approve` / `reject` / `cancel` | Cast votes on a proposal |
+| `execute` | Execute an approved (or ExecuteReady) proposal |
+| `threshold` | Propose a new approval threshold (v4 only) |
+
+Member-roster and threshold changes go through the same approve → execute lifecycle as a regular proposal — the proposing member needs the `Initiate` permission, and threshold of existing members must approve before someone with `Execute` permission lands the change.
+
+For `inspect`/`approve`/`reject`/`cancel`/`execute`, `<target>` may be
+a transaction PDA on its own (it self-identifies the multisig +
+index), or a multisig/vault PDA together with `--index <n>`. The
+transaction PDA emitted by `squads list` is suitable as input to all
+of these.
+
+Reviewer workflow:
+
+```
+helium-wallet squads list <vault>                            # find pending proposals
+helium-wallet squads inspect <transaction-pda>               # verify what it does
+helium-wallet squads approve <transaction-pda> --commit
+helium-wallet squads execute <transaction-pda> --commit      # once approved
+```
+
+#### Wrapping wallet ops as Squads proposals
+
+These commands accept an optional `--squads <multisig|vault>` to
+submit the operation as a v4 proposal instead of executing it
+directly. The wallet just signs as proposer; the actual transaction
+runs from the resolved vault when the proposal is later executed. A
+`--memo <text>` records a free-form note on the proposal.
+
+| Command | What gets wrapped |
+|---|---|
+| `transfer one`, `transfer multi` | Token transfer from the vault |
+| `burn` | Subdao token burn from the vault |
+| `dc mint` | HNT → DC mint, sourced from the vault |
+| `dc burn` | DC burn from the vault (non-router branch only) |
+| `dc delegate` | DC delegation from the vault |
+| `assets transfer`, `assets burn` | Compressed-NFT transfer/burn |
+| `hotspots transfer`, `hotspots burn` | Hotspot transfer/burn |
+
+Example:
+
+```
+helium-wallet transfer one <recipient> 5 hnt --squads <vault> --memo "Q2 disbursement" --commit
+```
+
 ### `sign` -- Sign and Verify
 
 ```

--- a/helium-lib/Cargo.toml
+++ b/helium-lib/Cargo.toml
@@ -54,6 +54,9 @@ helium-mnemonic = { path = "../helium-mnemonic", optional = true }
 bytemuck = "1"
 solana-transaction-utils = { version = ">= 0.4" }
 tuktuk-sdk = { git = "https://github.com/helium/tuktuk.git", branch = "main" }
+squads-multisig-program = { git = "https://github.com/Squads-Protocol/v4.git", branch = "main", default-features = false, features = ["no-entrypoint"] }
+dirs = "5"
 
 [dev-dependencies]
 rand = "0.8"
+tempfile = "3"

--- a/helium-lib/gen_idl.sh
+++ b/helium-lib/gen_idl.sh
@@ -16,6 +16,7 @@ mobile_entity_manager,memMa1HG4odAFmUbGWfPwS1WWfK95k99F2YTkGvyxZr
 lazy_transactions,1atrmQs3eq1N2FEYWu6tyTXbCjP4uQwExpjtnhXtS8h
 treasury_management,treaf4wWBBty3fHdyBpo35Mz84M8k3heKXmjmi9vFt5
 hpl_crons,hcrLPFgFUY6sCUKzqLWxXx5bntDiDCrAZVcrXfx9AHu
+welcome_pack,we1cGnTxTkDP9Sk49dw1d3T7ik7V2NfnY4qDGCDHXfC
 EOF
 
 anchor idl fetch 1azyuavdMyvsivtNxPoz6SucD18eDHeXzFCUPq5XU7w | \
@@ -35,3 +36,12 @@ anchor idl fetch BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY | \
   > /tmp/bubblegum.json && \
   anchor idl convert /tmp/bubblegum.json \
   > idls/bubblegum.json
+
+# Squads v3 (squads-mpl). Repo is archived and the crate pins solana 1.x, so
+# we rely on the on-chain IDL. v4 is a git dep — its IDL uses `SmallVec<L,T>`
+# which doesn't survive declare_program!.
+anchor idl fetch SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu | \
+  jq '.metadata.address = "SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu"' \
+  > /tmp/squads_mpl.json && \
+  anchor idl convert /tmp/squads_mpl.json \
+  > idls/squads_mpl.json

--- a/helium-lib/idls/squads_mpl.json
+++ b/helium-lib/idls/squads_mpl.json
@@ -1,0 +1,811 @@
+{
+  "address": "SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu",
+  "metadata": {
+    "name": "squads_mpl",
+    "version": "1.3.0",
+    "spec": "0.1.0"
+  },
+  "instructions": [
+    {
+      "name": "create",
+      "discriminator": [
+        24,
+        30,
+        200,
+        40,
+        5,
+        28,
+        7,
+        119
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "writable": true
+        },
+        {
+          "name": "creator",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "threshold",
+          "type": "u16"
+        },
+        {
+          "name": "create_key",
+          "type": "pubkey"
+        },
+        {
+          "name": "members",
+          "type": {
+            "vec": "pubkey"
+          }
+        },
+        {
+          "name": "meta",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "add_member",
+      "discriminator": [
+        13,
+        116,
+        123,
+        130,
+        126,
+        198,
+        57,
+        34
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent"
+        },
+        {
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "new_member",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "remove_member",
+      "discriminator": [
+        171,
+        57,
+        231,
+        150,
+        167,
+        128,
+        18,
+        55
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "old_member",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "remove_member_and_change_threshold",
+      "discriminator": [
+        230,
+        97,
+        183,
+        248,
+        43,
+        190,
+        154,
+        29
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "old_member",
+          "type": "pubkey"
+        },
+        {
+          "name": "new_threshold",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "add_member_and_change_threshold",
+      "discriminator": [
+        114,
+        213,
+        59,
+        47,
+        214,
+        157,
+        150,
+        170
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent"
+        },
+        {
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "new_member",
+          "type": "pubkey"
+        },
+        {
+          "name": "new_threshold",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "change_threshold",
+      "discriminator": [
+        146,
+        151,
+        213,
+        63,
+        121,
+        79,
+        9,
+        29
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "new_threshold",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "add_authority",
+      "discriminator": [
+        229,
+        9,
+        106,
+        73,
+        91,
+        213,
+        109,
+        183
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_transaction",
+      "discriminator": [
+        227,
+        193,
+        53,
+        239,
+        55,
+        126,
+        112,
+        105
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "writable": true
+        },
+        {
+          "name": "transaction",
+          "writable": true
+        },
+        {
+          "name": "creator",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "authority_index",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "activate_transaction",
+      "discriminator": [
+        56,
+        17,
+        0,
+        163,
+        135,
+        11,
+        135,
+        32
+      ],
+      "accounts": [
+        {
+          "name": "multisig"
+        },
+        {
+          "name": "transaction",
+          "writable": true
+        },
+        {
+          "name": "creator",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "add_instruction",
+      "discriminator": [
+        11,
+        70,
+        136,
+        166,
+        202,
+        55,
+        246,
+        74
+      ],
+      "accounts": [
+        {
+          "name": "multisig"
+        },
+        {
+          "name": "transaction",
+          "writable": true
+        },
+        {
+          "name": "instruction",
+          "writable": true
+        },
+        {
+          "name": "creator",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "incoming_instruction",
+          "type": {
+            "defined": {
+              "name": "IncomingInstruction"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "approve_transaction",
+      "discriminator": [
+        224,
+        39,
+        88,
+        181,
+        36,
+        59,
+        155,
+        122
+      ],
+      "accounts": [
+        {
+          "name": "multisig"
+        },
+        {
+          "name": "transaction",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "reject_transaction",
+      "discriminator": [
+        47,
+        141,
+        218,
+        192,
+        80,
+        97,
+        209,
+        116
+      ],
+      "accounts": [
+        {
+          "name": "multisig"
+        },
+        {
+          "name": "transaction",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "cancel_transaction",
+      "discriminator": [
+        65,
+        191,
+        19,
+        127,
+        230,
+        26,
+        214,
+        142
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "writable": true
+        },
+        {
+          "name": "transaction",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "execute_transaction",
+      "discriminator": [
+        231,
+        173,
+        49,
+        91,
+        235,
+        24,
+        68,
+        19
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "writable": true
+        },
+        {
+          "name": "transaction",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "account_list",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "execute_instruction",
+      "discriminator": [
+        48,
+        18,
+        40,
+        40,
+        75,
+        74,
+        147,
+        110
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "writable": true
+        },
+        {
+          "name": "transaction",
+          "writable": true
+        },
+        {
+          "name": "instruction",
+          "writable": true
+        },
+        {
+          "name": "member",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": []
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Ms",
+      "discriminator": [
+        70,
+        118,
+        9,
+        108,
+        254,
+        215,
+        31,
+        120
+      ]
+    },
+    {
+      "name": "MsTransaction",
+      "discriminator": [
+        182,
+        151,
+        104,
+        216,
+        255,
+        1,
+        19,
+        157
+      ]
+    },
+    {
+      "name": "MsInstruction",
+      "discriminator": [
+        238,
+        185,
+        126,
+        149,
+        189,
+        89,
+        255,
+        92
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "KeyNotInMultisig"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidTransactionState"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidNumberOfAccounts"
+    },
+    {
+      "code": 6003,
+      "name": "InvalidInstructionAccount"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidAuthorityIndex"
+    },
+    {
+      "code": 6005,
+      "name": "TransactionAlreadyExecuted"
+    },
+    {
+      "code": 6006,
+      "name": "CannotRemoveSoloMember"
+    },
+    {
+      "code": 6007,
+      "name": "InvalidThreshold"
+    },
+    {
+      "code": 6008,
+      "name": "DeprecatedTransaction"
+    },
+    {
+      "code": 6009,
+      "name": "InstructionFailed"
+    },
+    {
+      "code": 6010,
+      "name": "MaxMembersReached"
+    },
+    {
+      "code": 6011,
+      "name": "EmptyMembers"
+    },
+    {
+      "code": 6012,
+      "name": "PartialExecution"
+    },
+    {
+      "code": 6013,
+      "name": "NotEnoughLamports"
+    }
+  ],
+  "types": [
+    {
+      "name": "MsAccountMeta",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "is_signer",
+            "type": "bool"
+          },
+          {
+            "name": "is_writable",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "IncomingInstruction",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "program_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "keys",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "MsAccountMeta"
+                }
+              }
+            }
+          },
+          {
+            "name": "data",
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MsTransactionStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Draft"
+          },
+          {
+            "name": "Active"
+          },
+          {
+            "name": "ExecuteReady"
+          },
+          {
+            "name": "Executed"
+          },
+          {
+            "name": "Rejected"
+          },
+          {
+            "name": "Cancelled"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Ms",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "threshold",
+            "type": "u16"
+          },
+          {
+            "name": "authority_index",
+            "type": "u16"
+          },
+          {
+            "name": "transaction_index",
+            "type": "u32"
+          },
+          {
+            "name": "ms_change_index",
+            "type": "u32"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "create_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "allow_external_execute",
+            "type": "bool"
+          },
+          {
+            "name": "keys",
+            "type": {
+              "vec": "pubkey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MsTransaction",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "ms",
+            "type": "pubkey"
+          },
+          {
+            "name": "transaction_index",
+            "type": "u32"
+          },
+          {
+            "name": "authority_index",
+            "type": "u32"
+          },
+          {
+            "name": "authority_bump",
+            "type": "u8"
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "MsTransactionStatus"
+              }
+            }
+          },
+          {
+            "name": "instruction_index",
+            "type": "u8"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "approved",
+            "type": {
+              "vec": "pubkey"
+            }
+          },
+          {
+            "name": "rejected",
+            "type": {
+              "vec": "pubkey"
+            }
+          },
+          {
+            "name": "cancelled",
+            "type": {
+              "vec": "pubkey"
+            }
+          },
+          {
+            "name": "executed_index",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MsInstruction",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "program_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "keys",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "MsAccountMeta"
+                }
+              }
+            }
+          },
+          {
+            "name": "data",
+            "type": "bytes"
+          },
+          {
+            "name": "instruction_index",
+            "type": "u8"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "executed",
+            "type": "bool"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/helium-lib/idls/voter_stake_registry.json
+++ b/helium-lib/idls/voter_stake_registry.json
@@ -1,425 +1,31 @@
 {
-  "accounts": [
-    {
-      "discriminator": [
-        152,
-        131,
-        154,
-        46,
-        158,
-        42,
-        31,
-        233
-      ],
-      "name": "PositionV0"
-    },
-    {
-      "discriminator": [
-        162,
-        41,
-        210,
-        200,
-        205,
-        177,
-        228,
-        11
-      ],
-      "name": "ProposalConfigV0"
-    },
-    {
-      "discriminator": [
-        254,
-        194,
-        16,
-        171,
-        214,
-        20,
-        192,
-        81
-      ],
-      "name": "ProposalV0"
-    },
-    {
-      "discriminator": [
-        196,
-        152,
-        78,
-        155,
-        132,
-        136,
-        147,
-        55
-      ],
-      "name": "ProxyAssignmentV0"
-    },
-    {
-      "discriminator": [
-        187,
-        22,
-        143,
-        173,
-        201,
-        68,
-        34,
-        64
-      ],
-      "name": "ProxyConfigV0"
-    },
-    {
-      "discriminator": [
-        83,
-        225,
-        185,
-        120,
-        185,
-        31,
-        200,
-        178
-      ],
-      "name": "ProxyMarkerV0"
-    },
-    {
-      "discriminator": [
-        193,
-        202,
-        205,
-        51,
-        78,
-        168,
-        150,
-        128
-      ],
-      "name": "Registrar"
-    },
-    {
-      "discriminator": [
-        83,
-        205,
-        59,
-        215,
-        144,
-        234,
-        43,
-        70
-      ],
-      "name": "VoteMarkerV0"
-    }
-  ],
   "address": "hvsrNC3NKbcryqDs2DocYHZ9yPKEVzdSjQG6RVtK1s8",
-  "errors": [
-    {
-      "code": 6000,
-      "msg": "Exchange rate must be greater than zero",
-      "name": "InvalidRate"
-    },
-    {
-      "code": 6001,
-      "msg": "",
-      "name": "RatesFull"
-    },
-    {
-      "code": 6002,
-      "msg": "",
-      "name": "VotingMintNotFound"
-    },
-    {
-      "code": 6003,
-      "msg": "",
-      "name": "DepositEntryNotFound"
-    },
-    {
-      "code": 6004,
-      "msg": "",
-      "name": "DepositEntryFull"
-    },
-    {
-      "code": 6005,
-      "msg": "",
-      "name": "VotingTokenNonZero"
-    },
-    {
-      "code": 6006,
-      "msg": "",
-      "name": "OutOfBoundsDepositEntryIndex"
-    },
-    {
-      "code": 6007,
-      "msg": "",
-      "name": "UnusedDepositEntryIndex"
-    },
-    {
-      "code": 6008,
-      "msg": "",
-      "name": "InsufficientUnlockedTokens"
-    },
-    {
-      "code": 6009,
-      "msg": "",
-      "name": "UnableToConvert"
-    },
-    {
-      "code": 6010,
-      "msg": "",
-      "name": "InvalidLockupPeriod"
-    },
-    {
-      "code": 6011,
-      "msg": "",
-      "name": "InvalidEndTs"
-    },
-    {
-      "code": 6012,
-      "msg": "",
-      "name": "InvalidDays"
-    },
-    {
-      "code": 6013,
-      "msg": "",
-      "name": "VotingMintConfigIndexAlreadyInUse"
-    },
-    {
-      "code": 6014,
-      "msg": "",
-      "name": "OutOfBoundsVotingMintConfigIndex"
-    },
-    {
-      "code": 6015,
-      "msg": "Exchange rate decimals cannot be larger than registrar decimals",
-      "name": "InvalidDecimals"
-    },
-    {
-      "code": 6016,
-      "msg": "",
-      "name": "InvalidToDepositAndWithdrawInOneSlot"
-    },
-    {
-      "code": 6017,
-      "msg": "",
-      "name": "ShouldBeTheFirstIxInATx"
-    },
-    {
-      "code": 6018,
-      "msg": "",
-      "name": "ForbiddenCpi"
-    },
-    {
-      "code": 6019,
-      "msg": "",
-      "name": "InvalidMint"
-    },
-    {
-      "code": 6020,
-      "msg": "",
-      "name": "DebugInstruction"
-    },
-    {
-      "code": 6021,
-      "msg": "",
-      "name": "ClawbackNotAllowedOnDeposit"
-    },
-    {
-      "code": 6022,
-      "msg": "",
-      "name": "DepositStillLocked"
-    },
-    {
-      "code": 6023,
-      "msg": "",
-      "name": "InvalidAuthority"
-    },
-    {
-      "code": 6024,
-      "msg": "",
-      "name": "InvalidTokenOwnerRecord"
-    },
-    {
-      "code": 6025,
-      "msg": "",
-      "name": "InvalidRealmAuthority"
-    },
-    {
-      "code": 6026,
-      "msg": "",
-      "name": "VoterWeightOverflow"
-    },
-    {
-      "code": 6027,
-      "msg": "",
-      "name": "LockupSaturationMustBePositive"
-    },
-    {
-      "code": 6028,
-      "msg": "",
-      "name": "VotingMintConfiguredWithDifferentIndex"
-    },
-    {
-      "code": 6029,
-      "msg": "",
-      "name": "InternalProgramError"
-    },
-    {
-      "code": 6030,
-      "msg": "",
-      "name": "InsufficientLockedTokens"
-    },
-    {
-      "code": 6031,
-      "msg": "",
-      "name": "MustKeepTokensLocked"
-    },
-    {
-      "code": 6032,
-      "msg": "",
-      "name": "InvalidLockupKind"
-    },
-    {
-      "code": 6033,
-      "msg": "",
-      "name": "InvalidChangeToClawbackDepositEntry"
-    },
-    {
-      "code": 6034,
-      "msg": "",
-      "name": "InternalErrorBadLockupVoteWeight"
-    },
-    {
-      "code": 6035,
-      "msg": "",
-      "name": "DepositStartTooFarInFuture"
-    },
-    {
-      "code": 6036,
-      "msg": "",
-      "name": "VaultTokenNonZero"
-    },
-    {
-      "code": 6037,
-      "msg": "",
-      "name": "InvalidTimestampArguments"
-    },
-    {
-      "code": 6038,
-      "msg": "Cast vote is not allowed on update_voter_weight_record_v0 endpoint",
-      "name": "CastVoteIsNotAllowed"
-    },
-    {
-      "code": 6039,
-      "msg": "Program id was not what was expected",
-      "name": "InvalidProgramId"
-    },
-    {
-      "code": 6040,
-      "msg": "",
-      "name": "InvalidMintOwner"
-    },
-    {
-      "code": 6041,
-      "msg": "",
-      "name": "InvalidMintAmount"
-    },
-    {
-      "code": 6042,
-      "msg": "",
-      "name": "DuplicatedNftDetected"
-    },
-    {
-      "code": 6043,
-      "msg": "",
-      "name": "InvalidTokenOwnerForVoterWeightRecord"
-    },
-    {
-      "code": 6044,
-      "msg": "",
-      "name": "NftAlreadyVoted"
-    },
-    {
-      "code": 6045,
-      "msg": "",
-      "name": "InvalidProposalForNftVoteRecord"
-    },
-    {
-      "code": 6046,
-      "msg": "",
-      "name": "InvalidTokenOwnerForNftVoteRecord"
-    },
-    {
-      "code": 6047,
-      "msg": "",
-      "name": "UninitializedAccount"
-    },
-    {
-      "code": 6048,
-      "msg": "",
-      "name": "PositionNotWritable"
-    },
-    {
-      "code": 6049,
-      "msg": "",
-      "name": "InvalidVoteRecordForNftVoteRecord"
-    },
-    {
-      "code": 6050,
-      "msg": "",
-      "name": "VoteRecordMustBeWithdrawn"
-    },
-    {
-      "code": 6051,
-      "msg": "",
-      "name": "VoterWeightRecordMustBeExpired"
-    },
-    {
-      "code": 6052,
-      "msg": "",
-      "name": "InvalidMintForPosition"
-    },
-    {
-      "code": 6053,
-      "msg": "",
-      "name": "InvalidOwner"
-    },
-    {
-      "code": 6054,
-      "msg": "You may not deposit additional tokens on a position created during the genesis period that still has the genesis multiplier",
-      "name": "NoDepositOnGenesisPositions"
-    },
-    {
-      "code": 6055,
-      "msg": "Cannot change a position while active votes exist",
-      "name": "ActiveVotesExist"
-    },
-    {
-      "code": 6056,
-      "msg": "Position update authority must sign off on this transaction",
-      "name": "UnauthorizedPositionUpdateAuthority"
-    },
-    {
-      "code": 6057,
-      "msg": "Cannot transfer to the same position",
-      "name": "SamePosition"
-    },
-    {
-      "code": 6058,
-      "name": "MaxChoicesExceeded"
-    },
-    {
-      "code": 6059,
-      "name": "NoVoteForThisChoice"
-    },
-    {
-      "code": 6060,
-      "msg": "No changes to count",
-      "name": "NoChangesToCount"
-    }
-  ],
+  "metadata": {
+    "name": "voter_stake_registry",
+    "version": "0.4.8",
+    "spec": "0.1.0",
+    "description": "Heliums voter weight plugin for spl-governance"
+  },
   "instructions": [
     {
+      "name": "clear_recent_proposals_v0",
+      "discriminator": [
+        149,
+        201,
+        192,
+        200,
+        184,
+        142,
+        146,
+        231
+      ],
       "accounts": [
         {
           "name": "registrar",
+          "writable": true,
           "relations": [
             "position"
-          ],
-          "writable": true
+          ]
         },
         {
           "name": "position",
@@ -427,7 +33,23 @@
         },
         {
           "name": "dao",
+          "signer": true,
           "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  97,
+                  111
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "registrar.realm_governing_token_mint",
+                "account": "Registrar"
+              }
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -464,24 +86,8 @@
                 204,
                 154
               ]
-            },
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  100,
-                  97,
-                  111
-                ]
-              },
-              {
-                "account": "Registrar",
-                "kind": "account",
-                "path": "registrar.realm_governing_token_mint"
-              }
-            ]
-          },
-          "signer": true
+            }
+          }
         }
       ],
       "args": [
@@ -493,20 +99,20 @@
             }
           }
         }
-      ],
-      "discriminator": [
-        149,
-        201,
-        192,
-        200,
-        184,
-        142,
-        146,
-        231
-      ],
-      "name": "clear_recent_proposals_v0"
+      ]
     },
     {
+      "name": "close_position_v0",
+      "discriminator": [
+        173,
+        188,
+        35,
+        215,
+        182,
+        237,
+        158,
+        7
+      ],
       "accounts": [
         {
           "name": "sol_destination",
@@ -514,6 +120,7 @@
         },
         {
           "name": "position",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -534,22 +141,21 @@
                 "path": "mint"
               }
             ]
-          },
-          "writable": true
+          }
         },
         {
           "name": "registrar",
+          "writable": true,
           "relations": [
             "position"
-          ],
-          "writable": true
+          ]
         },
         {
           "name": "mint",
+          "writable": true,
           "relations": [
             "position"
-          ],
-          "writable": true
+          ]
         },
         {
           "name": "position_token_account",
@@ -560,28 +166,28 @@
           "signer": true
         },
         {
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-          "name": "token_program"
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
-          "name": "token_metadata_program"
+          "name": "token_metadata_program",
+          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
         }
       ],
-      "args": [],
-      "discriminator": [
-        173,
-        188,
-        35,
-        215,
-        182,
-        237,
-        158,
-        7
-      ],
-      "name": "close_position_v0"
+      "args": []
     },
     {
+      "name": "configure_voting_mint_v0",
+      "discriminator": [
+        46,
+        52,
+        225,
+        144,
+        13,
+        214,
+        246,
+        100
+      ],
       "accounts": [
         {
           "name": "registrar",
@@ -589,25 +195,25 @@
         },
         {
           "name": "realm_authority",
+          "signer": true,
           "relations": [
             "registrar"
-          ],
-          "signer": true
+          ]
         },
         {
+          "name": "mint",
           "docs": [
             "Tokens of this mint will produce vote weight"
-          ],
-          "name": "mint"
+          ]
         },
         {
           "name": "payer",
-          "signer": true,
-          "writable": true
+          "writable": true,
+          "signer": true
         },
         {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
@@ -619,28 +225,29 @@
             }
           }
         }
-      ],
-      "discriminator": [
-        46,
-        52,
-        225,
-        144,
-        13,
-        214,
-        246,
-        100
-      ],
-      "name": "configure_voting_mint_v0"
+      ]
     },
     {
+      "name": "count_proxy_vote_v0",
+      "discriminator": [
+        82,
+        172,
+        157,
+        8,
+        73,
+        214,
+        168,
+        62
+      ],
       "accounts": [
         {
           "name": "payer",
-          "signer": true,
-          "writable": true
+          "writable": true,
+          "signer": true
         },
         {
           "name": "marker",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -655,24 +262,23 @@
                 ]
               },
               {
-                "account": "PositionV0",
                 "kind": "account",
-                "path": "position.mint"
+                "path": "position.mint",
+                "account": "PositionV0"
               },
               {
                 "kind": "account",
                 "path": "proposal"
               }
             ]
-          },
-          "writable": true
+          }
         },
         {
           "name": "registrar",
+          "writable": true,
           "relations": [
             "position"
-          ],
-          "writable": true
+          ]
         },
         {
           "name": "voter",
@@ -722,10 +328,10 @@
         },
         {
           "name": "proposal",
+          "writable": true,
           "relations": [
             "proxy_marker"
-          ],
-          "writable": true
+          ]
         },
         {
           "name": "proposal_config",
@@ -735,10 +341,10 @@
         },
         {
           "name": "state_controller",
+          "writable": true,
           "relations": [
             "proposal_config"
-          ],
-          "writable": true
+          ]
         },
         {
           "name": "on_vote_hook",
@@ -750,24 +356,24 @@
           "name": "proposal_program"
         },
         {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
-      "args": [],
-      "discriminator": [
-        82,
-        172,
-        157,
-        8,
-        73,
-        214,
-        168,
-        62
-      ],
-      "name": "count_proxy_vote_v0"
+      "args": []
     },
     {
+      "name": "deposit_v0",
+      "discriminator": [
+        174,
+        234,
+        80,
+        137,
+        26,
+        149,
+        244,
+        29
+      ],
       "accounts": [
         {
           "name": "registrar",
@@ -781,44 +387,8 @@
         },
         {
           "name": "vault",
+          "writable": true,
           "pda": {
-            "program": {
-              "kind": "const",
-              "value": [
-                140,
-                151,
-                37,
-                143,
-                78,
-                36,
-                137,
-                241,
-                187,
-                61,
-                16,
-                41,
-                20,
-                142,
-                13,
-                131,
-                11,
-                90,
-                19,
-                153,
-                218,
-                255,
-                16,
-                132,
-                4,
-                142,
-                123,
-                216,
-                219,
-                233,
-                248,
-                89
-              ]
-            },
             "seeds": [
               {
                 "kind": "account",
@@ -865,249 +435,7 @@
                 "kind": "account",
                 "path": "mint"
               }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "mint",
-          "relations": [
-            "deposit_token"
-          ]
-        },
-        {
-          "name": "deposit_token",
-          "writable": true
-        },
-        {
-          "name": "deposit_authority",
-          "signer": true
-        },
-        {
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-          "name": "token_program"
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "DepositArgsV0"
-            }
-          }
-        }
-      ],
-      "discriminator": [
-        174,
-        234,
-        80,
-        137,
-        26,
-        149,
-        244,
-        29
-      ],
-      "name": "deposit_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "registrar"
-        },
-        {
-          "name": "collection",
-          "relations": [
-            "registrar"
-          ]
-        },
-        {
-          "name": "collection_metadata",
-          "pda": {
-            "program": {
-              "kind": "account",
-              "path": "token_metadata_program"
-            },
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  109,
-                  101,
-                  116,
-                  97,
-                  100,
-                  97,
-                  116,
-                  97
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "token_metadata_program"
-              },
-              {
-                "kind": "account",
-                "path": "collection"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "collection_master_edition",
-          "pda": {
-            "program": {
-              "kind": "account",
-              "path": "token_metadata_program"
-            },
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  109,
-                  101,
-                  116,
-                  97,
-                  100,
-                  97,
-                  116,
-                  97
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "token_metadata_program"
-              },
-              {
-                "kind": "account",
-                "path": "collection"
-              },
-              {
-                "kind": "const",
-                "value": [
-                  101,
-                  100,
-                  105,
-                  116,
-                  105,
-                  111,
-                  110
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "name": "position",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  112,
-                  111,
-                  115,
-                  105,
-                  116,
-                  105,
-                  111,
-                  110
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "mint"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "mint",
-          "writable": true
-        },
-        {
-          "name": "metadata",
-          "pda": {
-            "program": {
-              "kind": "account",
-              "path": "token_metadata_program"
-            },
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  109,
-                  101,
-                  116,
-                  97,
-                  100,
-                  97,
-                  116,
-                  97
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "token_metadata_program"
-              },
-              {
-                "kind": "account",
-                "path": "mint"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "master_edition",
-          "pda": {
-            "program": {
-              "kind": "account",
-              "path": "token_metadata_program"
-            },
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  109,
-                  101,
-                  116,
-                  97,
-                  100,
-                  97,
-                  116,
-                  97
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "token_metadata_program"
-              },
-              {
-                "kind": "account",
-                "path": "mint"
-              },
-              {
-                "kind": "const",
-                "value": [
-                  101,
-                  100,
-                  105,
-                  116,
-                  105,
-                  111,
-                  110
-                ]
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "position_token_account",
-          "pda": {
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -1144,7 +472,249 @@
                 248,
                 89
               ]
-            },
+            }
+          }
+        },
+        {
+          "name": "mint",
+          "relations": [
+            "deposit_token"
+          ]
+        },
+        {
+          "name": "deposit_token",
+          "writable": true
+        },
+        {
+          "name": "deposit_authority",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "DepositArgsV0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_position_v0",
+      "discriminator": [
+        251,
+        173,
+        133,
+        198,
+        158,
+        35,
+        152,
+        97
+      ],
+      "accounts": [
+        {
+          "name": "registrar"
+        },
+        {
+          "name": "collection",
+          "relations": [
+            "registrar"
+          ]
+        },
+        {
+          "name": "collection_metadata",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_metadata_program"
+              },
+              {
+                "kind": "account",
+                "path": "collection"
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "token_metadata_program"
+            }
+          }
+        },
+        {
+          "name": "collection_master_edition",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_metadata_program"
+              },
+              {
+                "kind": "account",
+                "path": "collection"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  100,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "token_metadata_program"
+            }
+          }
+        },
+        {
+          "name": "position",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "writable": true
+        },
+        {
+          "name": "metadata",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_metadata_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "token_metadata_program"
+            }
+          }
+        },
+        {
+          "name": "master_edition",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_metadata_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  100,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "token_metadata_program"
+            }
+          }
+        },
+        {
+          "name": "position_token_account",
+          "writable": true,
+          "pda": {
             "seeds": [
               {
                 "kind": "account",
@@ -1191,16 +761,7 @@
                 "kind": "account",
                 "path": "mint"
               }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "recipient"
-        },
-        {
-          "name": "vault",
-          "pda": {
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -1237,7 +798,16 @@
                 248,
                 89
               ]
-            },
+            }
+          }
+        },
+        {
+          "name": "recipient"
+        },
+        {
+          "name": "vault",
+          "writable": true,
+          "pda": {
             "seeds": [
               {
                 "kind": "account",
@@ -1284,201 +854,7 @@
                 "kind": "account",
                 "path": "deposit_mint"
               }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "payer",
-          "signer": true,
-          "writable": true
-        },
-        {
-          "name": "deposit_mint"
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        },
-        {
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-          "name": "token_program"
-        },
-        {
-          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
-          "name": "associated_token_program"
-        },
-        {
-          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
-          "name": "token_metadata_program"
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "InitializePositionArgsV0"
-            }
-          }
-        }
-      ],
-      "discriminator": [
-        251,
-        173,
-        133,
-        198,
-        158,
-        35,
-        152,
-        97
-      ],
-      "name": "initialize_position_v0"
-    },
-    {
-      "accounts": [
-        {
-          "docs": [
-            "The voting registrar. There can only be a single registrar",
-            "per governance realm and governing mint."
-          ],
-          "name": "registrar",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "account",
-                "path": "realm"
-              },
-              {
-                "kind": "const",
-                "value": [
-                  114,
-                  101,
-                  103,
-                  105,
-                  115,
-                  116,
-                  114,
-                  97,
-                  114
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "realm_governing_token_mint"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "collection",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  99,
-                  111,
-                  108,
-                  108,
-                  101,
-                  99,
-                  116,
-                  105,
-                  111,
-                  110
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "registrar"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "metadata",
-          "pda": {
-            "program": {
-              "kind": "account",
-              "path": "token_metadata_program"
-            },
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  109,
-                  101,
-                  116,
-                  97,
-                  100,
-                  97,
-                  116,
-                  97
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "token_metadata_program"
-              },
-              {
-                "kind": "account",
-                "path": "collection"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "master_edition",
-          "pda": {
-            "program": {
-              "kind": "account",
-              "path": "token_metadata_program"
-            },
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  109,
-                  101,
-                  116,
-                  97,
-                  100,
-                  97,
-                  116,
-                  97
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "token_metadata_program"
-              },
-              {
-                "kind": "account",
-                "path": "collection"
-              },
-              {
-                "kind": "const",
-                "value": [
-                  101,
-                  100,
-                  105,
-                  116,
-                  105,
-                  111,
-                  110
-                ]
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "token_account",
-          "pda": {
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -1515,7 +891,201 @@
                 248,
                 89
               ]
-            },
+            }
+          }
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "deposit_mint"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "token_metadata_program",
+          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "InitializePositionArgsV0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_registrar_v0",
+      "discriminator": [
+        120,
+        90,
+        57,
+        8,
+        36,
+        255,
+        82,
+        25
+      ],
+      "accounts": [
+        {
+          "name": "registrar",
+          "docs": [
+            "The voting registrar. There can only be a single registrar",
+            "per governance realm and governing mint."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "realm"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  103,
+                  105,
+                  115,
+                  116,
+                  114,
+                  97,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "realm_governing_token_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "collection",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  108,
+                  108,
+                  101,
+                  99,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "registrar"
+              }
+            ]
+          }
+        },
+        {
+          "name": "metadata",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_metadata_program"
+              },
+              {
+                "kind": "account",
+                "path": "collection"
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "token_metadata_program"
+            }
+          }
+        },
+        {
+          "name": "master_edition",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_metadata_program"
+              },
+              {
+                "kind": "account",
+                "path": "collection"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  100,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "token_metadata_program"
+            }
+          }
+        },
+        {
+          "name": "token_account",
+          "writable": true,
+          "pda": {
             "seeds": [
               {
                 "kind": "account",
@@ -1562,126 +1132,7 @@
                 "kind": "account",
                 "path": "collection"
               }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "docs": [
-            "An spl-governance realm",
-            "",
-            "realm is validated in the instruction:",
-            "- realm is owned by the governance_program_id",
-            "- realm_governing_token_mint must be the community or council mint",
-            "- realm_authority is realm.authority"
-          ],
-          "name": "realm"
-        },
-        {
-          "docs": [
-            "The program id of the spl-governance program the realm belongs to."
-          ],
-          "name": "governance_program_id"
-        },
-        {
-          "docs": [
-            "Either the realm community mint or the council mint."
-          ],
-          "name": "realm_governing_token_mint"
-        },
-        {
-          "name": "realm_authority",
-          "signer": true
-        },
-        {
-          "name": "payer",
-          "signer": true,
-          "writable": true
-        },
-        {
-          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
-          "name": "token_metadata_program"
-        },
-        {
-          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
-          "name": "associated_token_program"
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        },
-        {
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-          "name": "token_program"
-        },
-        {
-          "name": "proxy_config",
-          "optional": true
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "InitializeRegistrarArgsV0"
-            }
-          }
-        }
-      ],
-      "discriminator": [
-        120,
-        90,
-        57,
-        8,
-        36,
-        255,
-        82,
-        25
-      ],
-      "name": "initialize_registrar_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "payer",
-          "signer": true,
-          "writable": true
-        },
-        {
-          "name": "position",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  112,
-                  111,
-                  115,
-                  105,
-                  116,
-                  105,
-                  111,
-                  110
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "mint"
-              }
-            ]
-          }
-        },
-        {
-          "name": "mint",
-          "relations": [
-            "position"
-          ],
-          "writable": true
-        },
-        {
-          "name": "from_token_account",
-          "pda": {
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -1718,7 +1169,126 @@
                 248,
                 89
               ]
-            },
+            }
+          }
+        },
+        {
+          "name": "realm",
+          "docs": [
+            "An spl-governance realm",
+            "",
+            "realm is validated in the instruction:",
+            "- realm is owned by the governance_program_id",
+            "- realm_governing_token_mint must be the community or council mint",
+            "- realm_authority is realm.authority"
+          ]
+        },
+        {
+          "name": "governance_program_id",
+          "docs": [
+            "The program id of the spl-governance program the realm belongs to."
+          ]
+        },
+        {
+          "name": "realm_governing_token_mint",
+          "docs": [
+            "Either the realm community mint or the council mint."
+          ]
+        },
+        {
+          "name": "realm_authority",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_metadata_program",
+          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "proxy_config",
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "InitializeRegistrarArgsV0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "ledger_transfer_position_v0",
+      "discriminator": [
+        6,
+        11,
+        51,
+        147,
+        93,
+        231,
+        39,
+        35
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "from_token_account",
+          "writable": true,
+          "pda": {
             "seeds": [
               {
                 "kind": "account",
@@ -1765,13 +1335,7 @@
                 "kind": "account",
                 "path": "mint"
               }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "to_token_account",
-          "pda": {
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -1808,7 +1372,13 @@
                 248,
                 89
               ]
-            },
+            }
+          }
+        },
+        {
+          "name": "to_token_account",
+          "writable": true,
+          "pda": {
             "seeds": [
               {
                 "kind": "account",
@@ -1855,575 +1425,7 @@
                 "kind": "account",
                 "path": "mint"
               }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "from",
-          "signer": true
-        },
-        {
-          "name": "to",
-          "signer": true
-        },
-        {
-          "name": "approver",
-          "signer": true
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        },
-        {
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-          "name": "token_program"
-        },
-        {
-          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
-          "name": "associated_token_program"
-        }
-      ],
-      "args": [],
-      "discriminator": [
-        6,
-        11,
-        51,
-        147,
-        93,
-        231,
-        39,
-        35
-      ],
-      "name": "ledger_transfer_position_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "rent_refund",
-          "relations": [
-            "marker"
-          ],
-          "writable": true
-        },
-        {
-          "name": "marker",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  109,
-                  97,
-                  114,
-                  107,
-                  101,
-                  114
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "mint"
-              },
-              {
-                "kind": "account",
-                "path": "proposal"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "registrar",
-          "relations": [
-            "marker",
-            "position"
-          ],
-          "writable": true
-        },
-        {
-          "name": "voter",
-          "relations": [
-            "proxy_assignment"
-          ],
-          "signer": true
-        },
-        {
-          "name": "proxy_assignment"
-        },
-        {
-          "name": "position",
-          "writable": true
-        },
-        {
-          "name": "mint",
-          "relations": [
-            "marker",
-            "position"
-          ]
-        },
-        {
-          "name": "proposal",
-          "writable": true
-        },
-        {
-          "name": "proposal_config",
-          "relations": [
-            "proposal"
-          ]
-        },
-        {
-          "name": "state_controller",
-          "relations": [
-            "proposal_config"
-          ],
-          "writable": true
-        },
-        {
-          "name": "on_vote_hook",
-          "relations": [
-            "proposal_config"
-          ]
-        },
-        {
-          "name": "proposal_program"
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "RelinquishVoteArgsV1"
-            }
-          }
-        }
-      ],
-      "discriminator": [
-        233,
-        48,
-        26,
-        36,
-        62,
-        170,
-        79,
-        158
-      ],
-      "name": "proxied_relinquish_vote_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "marker",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  112,
-                  114,
-                  111,
-                  120,
-                  121,
-                  95,
-                  109,
-                  97,
-                  114,
-                  107,
-                  101,
-                  114
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "voter"
-              },
-              {
-                "kind": "account",
-                "path": "proposal"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "voter",
-          "signer": true
-        },
-        {
-          "name": "proposal",
-          "writable": true
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "VoteArgsV0"
-            }
-          }
-        }
-      ],
-      "discriminator": [
-        68,
-        205,
-        48,
-        30,
-        164,
-        62,
-        0,
-        70
-      ],
-      "name": "proxied_relinquish_vote_v1"
-    },
-    {
-      "accounts": [
-        {
-          "name": "payer",
-          "signer": true,
-          "writable": true
-        },
-        {
-          "name": "marker",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  109,
-                  97,
-                  114,
-                  107,
-                  101,
-                  114
-                ]
-              },
-              {
-                "account": "PositionV0",
-                "kind": "account",
-                "path": "position.mint"
-              },
-              {
-                "kind": "account",
-                "path": "proposal"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "registrar",
-          "relations": [
-            "position"
-          ],
-          "writable": true
-        },
-        {
-          "name": "voter",
-          "relations": [
-            "proxy_assignment"
-          ],
-          "signer": true
-        },
-        {
-          "name": "position",
-          "writable": true
-        },
-        {
-          "name": "proxy_assignment"
-        },
-        {
-          "name": "proposal",
-          "writable": true
-        },
-        {
-          "name": "proposal_config",
-          "relations": [
-            "proposal"
-          ]
-        },
-        {
-          "name": "state_controller",
-          "relations": [
-            "proposal_config"
-          ],
-          "writable": true
-        },
-        {
-          "name": "on_vote_hook",
-          "relations": [
-            "proposal_config"
-          ]
-        },
-        {
-          "name": "proposal_program"
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "VoteArgsV0"
-            }
-          }
-        }
-      ],
-      "discriminator": [
-        138,
-        145,
-        60,
-        51,
-        185,
-        167,
-        162,
-        158
-      ],
-      "name": "proxied_vote_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "payer",
-          "signer": true,
-          "writable": true
-        },
-        {
-          "name": "marker",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  112,
-                  114,
-                  111,
-                  120,
-                  121,
-                  95,
-                  109,
-                  97,
-                  114,
-                  107,
-                  101,
-                  114
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "voter"
-              },
-              {
-                "kind": "account",
-                "path": "proposal"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "voter",
-          "signer": true
-        },
-        {
-          "name": "proposal"
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "VoteArgsV0"
-            }
-          }
-        }
-      ],
-      "discriminator": [
-        190,
-        176,
-        85,
-        200,
-        29,
-        248,
-        0,
-        127
-      ],
-      "name": "proxied_vote_v1"
-    },
-    {
-      "accounts": [
-        {
-          "name": "rent_refund",
-          "relations": [
-            "marker"
-          ],
-          "writable": true
-        },
-        {
-          "name": "marker",
-          "writable": true
-        },
-        {
-          "name": "proposal",
-          "relations": [
-            "marker"
-          ]
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        }
-      ],
-      "args": [],
-      "discriminator": [
-        171,
-        115,
-        190,
-        138,
-        152,
-        254,
-        238,
-        148
-      ],
-      "name": "relinquish_expired_proxy_vote_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "rent_refund",
-          "relations": [
-            "marker"
-          ],
-          "writable": true
-        },
-        {
-          "name": "marker",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  109,
-                  97,
-                  114,
-                  107,
-                  101,
-                  114
-                ]
-              },
-              {
-                "account": "VoteMarkerV0",
-                "kind": "account",
-                "path": "marker.mint"
-              },
-              {
-                "kind": "account",
-                "path": "proposal"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "position",
-          "writable": true
-        },
-        {
-          "name": "proposal",
-          "relations": [
-            "marker"
-          ]
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        }
-      ],
-      "args": [],
-      "discriminator": [
-        202,
-        184,
-        88,
-        82,
-        245,
-        20,
-        104,
-        178
-      ],
-      "name": "relinquish_expired_vote_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "marker",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  109,
-                  97,
-                  114,
-                  107,
-                  101,
-                  114
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "mint"
-              },
-              {
-                "kind": "account",
-                "path": "proposal"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "registrar",
-          "relations": [
-            "marker",
-            "position"
-          ],
-          "writable": true
-        },
-        {
-          "name": "voter",
-          "signer": true
-        },
-        {
-          "name": "position",
-          "writable": true
-        },
-        {
-          "name": "mint",
-          "relations": [
-            "position"
-          ]
-        },
-        {
-          "name": "token_account",
-          "pda": {
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -2460,7 +1462,544 @@
                 248,
                 89
               ]
-            },
+            }
+          }
+        },
+        {
+          "name": "from",
+          "signer": true
+        },
+        {
+          "name": "to",
+          "signer": true
+        },
+        {
+          "name": "approver",
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "proxied_relinquish_vote_v0",
+      "discriminator": [
+        233,
+        48,
+        26,
+        36,
+        62,
+        170,
+        79,
+        158
+      ],
+      "accounts": [
+        {
+          "name": "rent_refund",
+          "writable": true,
+          "relations": [
+            "marker"
+          ]
+        },
+        {
+          "name": "marker",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  97,
+                  114,
+                  107,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "registrar",
+          "writable": true,
+          "relations": [
+            "marker",
+            "position"
+          ]
+        },
+        {
+          "name": "voter",
+          "signer": true,
+          "relations": [
+            "proxy_assignment"
+          ]
+        },
+        {
+          "name": "proxy_assignment"
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "mint",
+          "relations": [
+            "marker",
+            "position"
+          ]
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "proposal_config",
+          "relations": [
+            "proposal"
+          ]
+        },
+        {
+          "name": "state_controller",
+          "writable": true,
+          "relations": [
+            "proposal_config"
+          ]
+        },
+        {
+          "name": "on_vote_hook",
+          "relations": [
+            "proposal_config"
+          ]
+        },
+        {
+          "name": "proposal_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "RelinquishVoteArgsV1"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "proxied_relinquish_vote_v1",
+      "discriminator": [
+        68,
+        205,
+        48,
+        30,
+        164,
+        62,
+        0,
+        70
+      ],
+      "accounts": [
+        {
+          "name": "marker",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  120,
+                  121,
+                  95,
+                  109,
+                  97,
+                  114,
+                  107,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "voter"
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "voter",
+          "signer": true
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "VoteArgsV0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "proxied_vote_v0",
+      "discriminator": [
+        138,
+        145,
+        60,
+        51,
+        185,
+        167,
+        162,
+        158
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "marker",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  97,
+                  114,
+                  107,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position.mint",
+                "account": "PositionV0"
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "registrar",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "voter",
+          "signer": true,
+          "relations": [
+            "proxy_assignment"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "proxy_assignment"
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "proposal_config",
+          "relations": [
+            "proposal"
+          ]
+        },
+        {
+          "name": "state_controller",
+          "writable": true,
+          "relations": [
+            "proposal_config"
+          ]
+        },
+        {
+          "name": "on_vote_hook",
+          "relations": [
+            "proposal_config"
+          ]
+        },
+        {
+          "name": "proposal_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "VoteArgsV0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "proxied_vote_v1",
+      "discriminator": [
+        190,
+        176,
+        85,
+        200,
+        29,
+        248,
+        0,
+        127
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "marker",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  120,
+                  121,
+                  95,
+                  109,
+                  97,
+                  114,
+                  107,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "voter"
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "voter",
+          "signer": true
+        },
+        {
+          "name": "proposal"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "VoteArgsV0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "relinquish_expired_proxy_vote_v0",
+      "discriminator": [
+        171,
+        115,
+        190,
+        138,
+        152,
+        254,
+        238,
+        148
+      ],
+      "accounts": [
+        {
+          "name": "rent_refund",
+          "writable": true,
+          "relations": [
+            "marker"
+          ]
+        },
+        {
+          "name": "marker",
+          "writable": true
+        },
+        {
+          "name": "proposal",
+          "relations": [
+            "marker"
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "relinquish_expired_vote_v0",
+      "discriminator": [
+        202,
+        184,
+        88,
+        82,
+        245,
+        20,
+        104,
+        178
+      ],
+      "accounts": [
+        {
+          "name": "rent_refund",
+          "writable": true
+        },
+        {
+          "name": "marker",
+          "writable": true
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "proposal"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "relinquish_vote_v1",
+      "discriminator": [
+        142,
+        201,
+        65,
+        226,
+        112,
+        136,
+        248,
+        102
+      ],
+      "accounts": [
+        {
+          "name": "marker",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  97,
+                  114,
+                  107,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "registrar",
+          "writable": true,
+          "relations": [
+            "marker",
+            "position"
+          ]
+        },
+        {
+          "name": "voter",
+          "signer": true
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "mint",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "token_account",
+          "pda": {
             "seeds": [
               {
                 "kind": "account",
@@ -2507,260 +2046,7 @@
                 "kind": "account",
                 "path": "mint"
               }
-            ]
-          }
-        },
-        {
-          "name": "proposal",
-          "writable": true
-        },
-        {
-          "name": "proposal_config",
-          "relations": [
-            "proposal"
-          ]
-        },
-        {
-          "name": "state_controller",
-          "relations": [
-            "proposal_config"
-          ],
-          "writable": true
-        },
-        {
-          "name": "on_vote_hook",
-          "relations": [
-            "proposal_config"
-          ]
-        },
-        {
-          "name": "proposal_program"
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        },
-        {
-          "name": "rent_refund",
-          "relations": [
-            "marker"
-          ],
-          "writable": true
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "RelinquishVoteArgsV1"
-            }
-          }
-        }
-      ],
-      "discriminator": [
-        142,
-        201,
-        65,
-        226,
-        112,
-        136,
-        248,
-        102
-      ],
-      "name": "relinquish_vote_v1"
-    },
-    {
-      "accounts": [
-        {
-          "name": "registrar",
-          "relations": [
-            "position"
-          ]
-        },
-        {
-          "name": "position_update_authority",
-          "signer": true
-        },
-        {
-          "name": "position",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  112,
-                  111,
-                  115,
-                  105,
-                  116,
-                  105,
-                  111,
-                  110
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "mint"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "mint",
-          "relations": [
-            "position"
-          ]
-        },
-        {
-          "name": "position_token_account"
-        },
-        {
-          "name": "position_authority",
-          "signer": true
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "ResetLockupArgsV0"
-            }
-          }
-        }
-      ],
-      "discriminator": [
-        163,
-        196,
-        86,
-        249,
-        96,
-        116,
-        236,
-        194
-      ],
-      "name": "reset_lockup_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "registrar",
-          "writable": true
-        },
-        {
-          "name": "realm_authority",
-          "relations": [
-            "registrar"
-          ],
-          "signer": true
-        }
-      ],
-      "args": [
-        {
-          "name": "time_offset",
-          "type": "i64"
-        }
-      ],
-      "discriminator": [
-        173,
-        231,
-        217,
-        226,
-        178,
-        247,
-        144,
-        87
-      ],
-      "name": "set_time_offset_v0"
-    },
-    {
-      "accounts": [
-        {
-          "address": "hprdnjkbziK8NqhThmAn5Gu4XqrBbctX8du4PfJdgvW",
-          "name": "authority",
-          "signer": true
-        },
-        {
-          "name": "position",
-          "writable": true
-        }
-      ],
-      "args": [],
-      "discriminator": [
-        18,
-        41,
-        232,
-        50,
-        253,
-        184,
-        27,
-        43
-      ],
-      "name": "temp_release_position_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "registrar",
-          "relations": [
-            "source_position",
-            "target_position"
-          ]
-        },
-        {
-          "name": "position_update_authority",
-          "signer": true
-        },
-        {
-          "name": "source_position",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  112,
-                  111,
-                  115,
-                  105,
-                  116,
-                  105,
-                  111,
-                  110
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "mint"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "mint",
-          "relations": [
-            "source_position"
-          ]
-        },
-        {
-          "name": "position_token_account"
-        },
-        {
-          "name": "position_authority",
-          "signer": true
-        },
-        {
-          "name": "target_position",
-          "writable": true
-        },
-        {
-          "name": "deposit_mint"
-        },
-        {
-          "name": "source_vault",
-          "pda": {
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -2797,7 +2083,512 @@
                 248,
                 89
               ]
-            },
+            }
+          }
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "proposal_config",
+          "relations": [
+            "proposal"
+          ]
+        },
+        {
+          "name": "state_controller",
+          "writable": true,
+          "relations": [
+            "proposal_config"
+          ]
+        },
+        {
+          "name": "on_vote_hook",
+          "relations": [
+            "proposal_config"
+          ]
+        },
+        {
+          "name": "proposal_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent_refund",
+          "writable": true,
+          "relations": [
+            "marker"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "RelinquishVoteArgsV1"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "reset_lockup_v0",
+      "discriminator": [
+        163,
+        196,
+        86,
+        249,
+        96,
+        116,
+        236,
+        194
+      ],
+      "accounts": [
+        {
+          "name": "registrar",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position_update_authority",
+          "signer": true
+        },
+        {
+          "name": "position",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position_token_account"
+        },
+        {
+          "name": "position_authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "ResetLockupArgsV0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "set_time_offset_v0",
+      "discriminator": [
+        173,
+        231,
+        217,
+        226,
+        178,
+        247,
+        144,
+        87
+      ],
+      "accounts": [
+        {
+          "name": "registrar",
+          "writable": true
+        },
+        {
+          "name": "realm_authority",
+          "signer": true,
+          "relations": [
+            "registrar"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "time_offset",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "temp_release_position_v0",
+      "discriminator": [
+        18,
+        41,
+        232,
+        50,
+        253,
+        184,
+        27,
+        43
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true,
+          "address": "hprdnjkbziK8NqhThmAn5Gu4XqrBbctX8du4PfJdgvW"
+        },
+        {
+          "name": "position",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "transfer_position_v0",
+      "discriminator": [
+        13,
+        19,
+        112,
+        27,
+        248,
+        208,
+        38,
+        145
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "from_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "from"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "to_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "to"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "from",
+          "signer": true
+        },
+        {
+          "name": "to"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "transfer_v0",
+      "discriminator": [
+        162,
+        182,
+        193,
+        97,
+        102,
+        85,
+        127,
+        189
+      ],
+      "accounts": [
+        {
+          "name": "registrar",
+          "relations": [
+            "source_position",
+            "target_position"
+          ]
+        },
+        {
+          "name": "position_update_authority",
+          "signer": true
+        },
+        {
+          "name": "source_position",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "relations": [
+            "source_position"
+          ]
+        },
+        {
+          "name": "position_token_account"
+        },
+        {
+          "name": "position_authority",
+          "signer": true
+        },
+        {
+          "name": "target_position",
+          "writable": true
+        },
+        {
+          "name": "deposit_mint"
+        },
+        {
+          "name": "source_vault",
+          "writable": true,
+          "pda": {
             "seeds": [
               {
                 "kind": "account",
@@ -2844,13 +2635,7 @@
                 "kind": "account",
                 "path": "deposit_mint"
               }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "target_vault",
-          "pda": {
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -2887,7 +2672,13 @@
                 248,
                 89
               ]
-            },
+            }
+          }
+        },
+        {
+          "name": "target_vault",
+          "writable": true,
+          "pda": {
             "seeds": [
               {
                 "kind": "account",
@@ -2934,166 +2725,7 @@
                 "kind": "account",
                 "path": "deposit_mint"
               }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-          "name": "token_program"
-        },
-        {
-          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
-          "name": "associated_token_program"
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "TransferArgsV0"
-            }
-          }
-        }
-      ],
-      "discriminator": [
-        162,
-        182,
-        193,
-        97,
-        102,
-        85,
-        127,
-        189
-      ],
-      "name": "transfer_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "registrar",
-          "writable": true
-        },
-        {
-          "name": "realm_authority",
-          "relations": [
-            "registrar"
-          ],
-          "signer": true
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "UpdateRegistrarAuthorityArgsV0"
-            }
-          }
-        }
-      ],
-      "discriminator": [
-        121,
-        25,
-        97,
-        199,
-        89,
-        77,
-        38,
-        40
-      ],
-      "name": "update_registrar_authority_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "registrar",
-          "writable": true
-        },
-        {
-          "name": "realm_authority",
-          "relations": [
-            "registrar"
-          ],
-          "signer": true
-        },
-        {
-          "name": "proxy_config",
-          "optional": true
-        }
-      ],
-      "args": [],
-      "discriminator": [
-        74,
-        102,
-        193,
-        203,
-        108,
-        169,
-        140,
-        97
-      ],
-      "name": "update_registrar_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "payer",
-          "signer": true,
-          "writable": true
-        },
-        {
-          "name": "marker",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  109,
-                  97,
-                  114,
-                  107,
-                  101,
-                  114
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "mint"
-              },
-              {
-                "kind": "account",
-                "path": "proposal"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "registrar",
-          "relations": [
-            "position"
-          ],
-          "writable": true
-        },
-        {
-          "name": "voter",
-          "signer": true
-        },
-        {
-          "name": "position",
-          "writable": true
-        },
-        {
-          "name": "mint",
-          "relations": [
-            "position"
-          ]
-        },
-        {
-          "name": "token_account",
-          "pda": {
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -3130,7 +2762,165 @@
                 248,
                 89
               ]
-            },
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "TransferArgsV0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_registrar_authority_v0",
+      "discriminator": [
+        121,
+        25,
+        97,
+        199,
+        89,
+        77,
+        38,
+        40
+      ],
+      "accounts": [
+        {
+          "name": "registrar",
+          "writable": true
+        },
+        {
+          "name": "realm_authority",
+          "signer": true,
+          "relations": [
+            "registrar"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "UpdateRegistrarAuthorityArgsV0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_registrar_v0",
+      "discriminator": [
+        74,
+        102,
+        193,
+        203,
+        108,
+        169,
+        140,
+        97
+      ],
+      "accounts": [
+        {
+          "name": "registrar",
+          "writable": true
+        },
+        {
+          "name": "realm_authority",
+          "signer": true,
+          "relations": [
+            "registrar"
+          ]
+        },
+        {
+          "name": "proxy_config",
+          "optional": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "vote_v0",
+      "discriminator": [
+        82,
+        47,
+        20,
+        22,
+        108,
+        59,
+        245,
+        115
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "marker",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  97,
+                  114,
+                  107,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "registrar",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "voter",
+          "signer": true
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "mint",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "token_account",
+          "pda": {
             "seeds": [
               {
                 "kind": "account",
@@ -3177,109 +2967,7 @@
                 "kind": "account",
                 "path": "mint"
               }
-            ]
-          }
-        },
-        {
-          "name": "proposal",
-          "writable": true
-        },
-        {
-          "name": "proposal_config",
-          "relations": [
-            "proposal"
-          ]
-        },
-        {
-          "name": "state_controller",
-          "relations": [
-            "proposal_config"
-          ],
-          "writable": true
-        },
-        {
-          "name": "on_vote_hook",
-          "relations": [
-            "proposal_config"
-          ]
-        },
-        {
-          "name": "proposal_program"
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": {
-              "name": "VoteArgsV0"
-            }
-          }
-        }
-      ],
-      "discriminator": [
-        82,
-        47,
-        20,
-        22,
-        108,
-        59,
-        245,
-        115
-      ],
-      "name": "vote_v0"
-    },
-    {
-      "accounts": [
-        {
-          "name": "position_authority",
-          "signer": true,
-          "writable": true
-        },
-        {
-          "name": "registrar",
-          "relations": [
-            "position"
-          ]
-        },
-        {
-          "name": "position",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  112,
-                  111,
-                  115,
-                  105,
-                  116,
-                  105,
-                  111,
-                  110
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "mint"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "mint",
-          "relations": [
-            "position"
-          ]
-        },
-        {
-          "name": "position_token_account",
-          "pda": {
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -3316,7 +3004,110 @@
                 248,
                 89
               ]
-            },
+            }
+          }
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "proposal_config",
+          "relations": [
+            "proposal"
+          ]
+        },
+        {
+          "name": "state_controller",
+          "writable": true,
+          "relations": [
+            "proposal_config"
+          ]
+        },
+        {
+          "name": "on_vote_hook",
+          "relations": [
+            "proposal_config"
+          ]
+        },
+        {
+          "name": "proposal_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "VoteArgsV0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "withdraw_v0",
+      "discriminator": [
+        240,
+        127,
+        207,
+        228,
+        69,
+        25,
+        253,
+        97
+      ],
+      "accounts": [
+        {
+          "name": "position_authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "registrar",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position_token_account",
+          "writable": true,
+          "pda": {
             "seeds": [
               {
                 "kind": "account",
@@ -3363,13 +3154,7 @@
                 "kind": "account",
                 "path": "mint"
               }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "vault",
-          "pda": {
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -3406,7 +3191,13 @@
                 248,
                 89
               ]
-            },
+            }
+          }
+        },
+        {
+          "name": "vault",
+          "writable": true,
+          "pda": {
             "seeds": [
               {
                 "kind": "account",
@@ -3453,16 +3244,7 @@
                 "kind": "account",
                 "path": "deposit_mint"
               }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "deposit_mint"
-        },
-        {
-          "name": "destination",
-          "pda": {
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -3499,7 +3281,16 @@
                 248,
                 89
               ]
-            },
+            }
+          }
+        },
+        {
+          "name": "deposit_mint"
+        },
+        {
+          "name": "destination",
+          "writable": true,
+          "pda": {
             "seeds": [
               {
                 "kind": "account",
@@ -3546,21 +3337,57 @@
                 "kind": "account",
                 "path": "deposit_mint"
               }
-            ]
-          },
-          "writable": true
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
         },
         {
-          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
-          "name": "associated_token_program"
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
         },
         {
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-          "name": "token_program"
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
@@ -3572,30 +3399,425 @@
             }
           }
         }
-      ],
-      "discriminator": [
-        240,
-        127,
-        207,
-        228,
-        69,
-        25,
-        253,
-        97
-      ],
-      "name": "withdraw_v0"
+      ]
     }
   ],
-  "metadata": {
-    "description": "Heliums voter weight plugin for spl-governance",
-    "name": "voter_stake_registry",
-    "spec": "0.1.0",
-    "version": "0.4.4"
-  },
+  "accounts": [
+    {
+      "name": "PositionV0",
+      "discriminator": [
+        152,
+        131,
+        154,
+        46,
+        158,
+        42,
+        31,
+        233
+      ]
+    },
+    {
+      "name": "ProposalConfigV0",
+      "discriminator": [
+        162,
+        41,
+        210,
+        200,
+        205,
+        177,
+        228,
+        11
+      ]
+    },
+    {
+      "name": "ProposalV0",
+      "discriminator": [
+        254,
+        194,
+        16,
+        171,
+        214,
+        20,
+        192,
+        81
+      ]
+    },
+    {
+      "name": "ProxyAssignmentV0",
+      "discriminator": [
+        196,
+        152,
+        78,
+        155,
+        132,
+        136,
+        147,
+        55
+      ]
+    },
+    {
+      "name": "ProxyConfigV0",
+      "discriminator": [
+        187,
+        22,
+        143,
+        173,
+        201,
+        68,
+        34,
+        64
+      ]
+    },
+    {
+      "name": "ProxyMarkerV0",
+      "discriminator": [
+        83,
+        225,
+        185,
+        120,
+        185,
+        31,
+        200,
+        178
+      ]
+    },
+    {
+      "name": "Registrar",
+      "discriminator": [
+        193,
+        202,
+        205,
+        51,
+        78,
+        168,
+        150,
+        128
+      ]
+    },
+    {
+      "name": "VoteMarkerV0",
+      "discriminator": [
+        83,
+        205,
+        59,
+        215,
+        144,
+        234,
+        43,
+        70
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidRate",
+      "msg": "Exchange rate must be greater than zero"
+    },
+    {
+      "code": 6001,
+      "name": "RatesFull",
+      "msg": ""
+    },
+    {
+      "code": 6002,
+      "name": "VotingMintNotFound",
+      "msg": ""
+    },
+    {
+      "code": 6003,
+      "name": "DepositEntryNotFound",
+      "msg": ""
+    },
+    {
+      "code": 6004,
+      "name": "DepositEntryFull",
+      "msg": ""
+    },
+    {
+      "code": 6005,
+      "name": "VotingTokenNonZero",
+      "msg": ""
+    },
+    {
+      "code": 6006,
+      "name": "OutOfBoundsDepositEntryIndex",
+      "msg": ""
+    },
+    {
+      "code": 6007,
+      "name": "UnusedDepositEntryIndex",
+      "msg": ""
+    },
+    {
+      "code": 6008,
+      "name": "InsufficientUnlockedTokens",
+      "msg": ""
+    },
+    {
+      "code": 6009,
+      "name": "UnableToConvert",
+      "msg": ""
+    },
+    {
+      "code": 6010,
+      "name": "InvalidLockupPeriod",
+      "msg": ""
+    },
+    {
+      "code": 6011,
+      "name": "InvalidEndTs",
+      "msg": ""
+    },
+    {
+      "code": 6012,
+      "name": "InvalidDays",
+      "msg": ""
+    },
+    {
+      "code": 6013,
+      "name": "VotingMintConfigIndexAlreadyInUse",
+      "msg": ""
+    },
+    {
+      "code": 6014,
+      "name": "OutOfBoundsVotingMintConfigIndex",
+      "msg": ""
+    },
+    {
+      "code": 6015,
+      "name": "InvalidDecimals",
+      "msg": "Exchange rate decimals cannot be larger than registrar decimals"
+    },
+    {
+      "code": 6016,
+      "name": "InvalidToDepositAndWithdrawInOneSlot",
+      "msg": ""
+    },
+    {
+      "code": 6017,
+      "name": "ShouldBeTheFirstIxInATx",
+      "msg": ""
+    },
+    {
+      "code": 6018,
+      "name": "ForbiddenCpi",
+      "msg": ""
+    },
+    {
+      "code": 6019,
+      "name": "InvalidMint",
+      "msg": ""
+    },
+    {
+      "code": 6020,
+      "name": "DebugInstruction",
+      "msg": ""
+    },
+    {
+      "code": 6021,
+      "name": "ClawbackNotAllowedOnDeposit",
+      "msg": ""
+    },
+    {
+      "code": 6022,
+      "name": "DepositStillLocked",
+      "msg": ""
+    },
+    {
+      "code": 6023,
+      "name": "InvalidAuthority",
+      "msg": ""
+    },
+    {
+      "code": 6024,
+      "name": "InvalidTokenOwnerRecord",
+      "msg": ""
+    },
+    {
+      "code": 6025,
+      "name": "InvalidRealmAuthority",
+      "msg": ""
+    },
+    {
+      "code": 6026,
+      "name": "VoterWeightOverflow",
+      "msg": ""
+    },
+    {
+      "code": 6027,
+      "name": "LockupSaturationMustBePositive",
+      "msg": ""
+    },
+    {
+      "code": 6028,
+      "name": "VotingMintConfiguredWithDifferentIndex",
+      "msg": ""
+    },
+    {
+      "code": 6029,
+      "name": "InternalProgramError",
+      "msg": ""
+    },
+    {
+      "code": 6030,
+      "name": "InsufficientLockedTokens",
+      "msg": ""
+    },
+    {
+      "code": 6031,
+      "name": "MustKeepTokensLocked",
+      "msg": ""
+    },
+    {
+      "code": 6032,
+      "name": "InvalidLockupKind",
+      "msg": ""
+    },
+    {
+      "code": 6033,
+      "name": "InvalidChangeToClawbackDepositEntry",
+      "msg": ""
+    },
+    {
+      "code": 6034,
+      "name": "InternalErrorBadLockupVoteWeight",
+      "msg": ""
+    },
+    {
+      "code": 6035,
+      "name": "DepositStartTooFarInFuture",
+      "msg": ""
+    },
+    {
+      "code": 6036,
+      "name": "VaultTokenNonZero",
+      "msg": ""
+    },
+    {
+      "code": 6037,
+      "name": "InvalidTimestampArguments",
+      "msg": ""
+    },
+    {
+      "code": 6038,
+      "name": "CastVoteIsNotAllowed",
+      "msg": "Cast vote is not allowed on update_voter_weight_record_v0 endpoint"
+    },
+    {
+      "code": 6039,
+      "name": "InvalidProgramId",
+      "msg": "Program id was not what was expected"
+    },
+    {
+      "code": 6040,
+      "name": "InvalidMintOwner",
+      "msg": ""
+    },
+    {
+      "code": 6041,
+      "name": "InvalidMintAmount",
+      "msg": ""
+    },
+    {
+      "code": 6042,
+      "name": "DuplicatedNftDetected",
+      "msg": ""
+    },
+    {
+      "code": 6043,
+      "name": "InvalidTokenOwnerForVoterWeightRecord",
+      "msg": ""
+    },
+    {
+      "code": 6044,
+      "name": "NftAlreadyVoted",
+      "msg": ""
+    },
+    {
+      "code": 6045,
+      "name": "InvalidProposalForNftVoteRecord",
+      "msg": ""
+    },
+    {
+      "code": 6046,
+      "name": "InvalidTokenOwnerForNftVoteRecord",
+      "msg": ""
+    },
+    {
+      "code": 6047,
+      "name": "UninitializedAccount",
+      "msg": ""
+    },
+    {
+      "code": 6048,
+      "name": "PositionNotWritable",
+      "msg": ""
+    },
+    {
+      "code": 6049,
+      "name": "InvalidVoteRecordForNftVoteRecord",
+      "msg": ""
+    },
+    {
+      "code": 6050,
+      "name": "VoteRecordMustBeWithdrawn",
+      "msg": ""
+    },
+    {
+      "code": 6051,
+      "name": "VoterWeightRecordMustBeExpired",
+      "msg": ""
+    },
+    {
+      "code": 6052,
+      "name": "InvalidMintForPosition",
+      "msg": ""
+    },
+    {
+      "code": 6053,
+      "name": "InvalidOwner",
+      "msg": ""
+    },
+    {
+      "code": 6054,
+      "name": "NoDepositOnGenesisPositions",
+      "msg": "You may not deposit additional tokens on a position created during the genesis period that still has the genesis multiplier"
+    },
+    {
+      "code": 6055,
+      "name": "ActiveVotesExist",
+      "msg": "Cannot change a position while active votes exist"
+    },
+    {
+      "code": 6056,
+      "name": "UnauthorizedPositionUpdateAuthority",
+      "msg": "Position update authority must sign off on this transaction"
+    },
+    {
+      "code": 6057,
+      "name": "SamePosition",
+      "msg": "Cannot transfer to the same position"
+    },
+    {
+      "code": 6058,
+      "name": "MaxChoicesExceeded"
+    },
+    {
+      "code": 6059,
+      "name": "NoVoteForThisChoice"
+    },
+    {
+      "code": 6060,
+      "name": "NoChangesToCount",
+      "msg": "No changes to count"
+    }
+  ],
   "types": [
     {
       "name": "Choice",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "weight",
@@ -3611,13 +3833,13 @@
               "option": "string"
             }
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "ClearRecentProposalsArgsV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "ts",
@@ -3627,13 +3849,13 @@
             "name": "dao_bump",
             "type": "u8"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "ConfigureVotingMintArgsV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "idx",
@@ -3659,25 +3881,25 @@
             "name": "lockup_saturation_secs",
             "type": "u64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "DepositArgsV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "amount",
             "type": "u64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "InitializePositionArgsV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "kind",
@@ -3691,13 +3913,13 @@
             "name": "periods",
             "type": "u32"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "InitializeRegistrarArgsV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "position_update_authority",
@@ -3705,13 +3927,13 @@
               "option": "pubkey"
             }
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "Lockup",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "start_ts",
@@ -3729,8 +3951,7 @@
               }
             }
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
@@ -3756,6 +3977,7 @@
     {
       "name": "PositionV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "registrar",
@@ -3811,13 +4033,13 @@
               }
             }
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "ProposalConfigV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "vote_controller",
@@ -3839,8 +4061,7 @@
             "name": "bump_seed",
             "type": "u8"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
@@ -3855,15 +4076,16 @@
             "name": "Cancelled"
           },
           {
+            "name": "Voting",
             "fields": [
               {
                 "name": "start_ts",
                 "type": "i64"
               }
-            ],
-            "name": "Voting"
+            ]
           },
           {
+            "name": "Resolved",
             "fields": [
               {
                 "name": "choices",
@@ -3875,10 +4097,10 @@
                 "name": "end_ts",
                 "type": "i64"
               }
-            ],
-            "name": "Resolved"
+            ]
           },
           {
+            "name": "Custom",
             "fields": [
               {
                 "name": "name",
@@ -3888,8 +4110,7 @@
                 "name": "bin",
                 "type": "bytes"
               }
-            ],
-            "name": "Custom"
+            ]
           }
         ]
       }
@@ -3897,6 +4118,7 @@
     {
       "name": "ProposalV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "namespace",
@@ -3958,13 +4180,13 @@
             "name": "bump_seed",
             "type": "u8"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "ProxyAssignmentV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "voter",
@@ -3998,13 +4220,13 @@
             "name": "bump_seed",
             "type": "u8"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "ProxyConfigV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "authority",
@@ -4028,17 +4250,17 @@
               }
             }
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "ProxyMarkerV0",
       "docs": [
         "Marker to indicate that a proxy intends to vote this way on a proposal,",
         "all votes of proxies are permissionless based on this marker"
       ],
-      "name": "ProxyMarkerV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "voter",
@@ -4062,13 +4284,13 @@
             "name": "rent_refund",
             "type": "pubkey"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "RecentProposal",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "proposal",
@@ -4078,13 +4300,13 @@
             "name": "ts",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "Registrar",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "governance_program_id",
@@ -4156,25 +4378,25 @@
               }
             }
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "RelinquishVoteArgsV1",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "choice",
             "type": "u16"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "ResetLockupArgsV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "kind",
@@ -4188,13 +4410,13 @@
             "name": "periods",
             "type": "u32"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "SeasonV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "start",
@@ -4204,49 +4426,49 @@
             "name": "end",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "TransferArgsV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "amount",
             "type": "u64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "UpdateRegistrarAuthorityArgsV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "authority",
             "type": "pubkey"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "VoteArgsV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "choice",
             "type": "u16"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "VoteMarkerV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "voter",
@@ -4279,11 +4501,11 @@
             "type": "u8"
           },
           {
+            "name": "_deprecated_relinquished",
             "docs": [
               "Whether this vote has been cleared on the position after proposal expired",
               "DEPRECATED. New votes will have markers closed after the vote completes."
             ],
-            "name": "_deprecated_relinquished",
             "type": "bool"
           },
           {
@@ -4294,13 +4516,13 @@
             "name": "rent_refund",
             "type": "pubkey"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "VotingMintConfigV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "mint",
@@ -4330,20 +4552,19 @@
             "name": "reserved",
             "type": "i8"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "WithdrawArgsV0",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "amount",
             "type": "u64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     }
   ]

--- a/helium-lib/idls/welcome_pack.json
+++ b/helium-lib/idls/welcome_pack.json
@@ -1,0 +1,945 @@
+{
+  "address": "we1cGnTxTkDP9Sk49dw1d3T7ik7V2NfnY4qDGCDHXfC",
+  "metadata": {
+    "name": "welcome_pack",
+    "version": "0.0.3",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "claim_welcome_pack_v0",
+      "discriminator": [
+        193,
+        189,
+        189,
+        219,
+        97,
+        176,
+        82,
+        231
+      ],
+      "accounts": [
+        {
+          "name": "claimer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent_refund",
+          "writable": true
+        },
+        {
+          "name": "asset_return_address"
+        },
+        {
+          "name": "owner",
+          "relations": [
+            "welcome_pack"
+          ]
+        },
+        {
+          "name": "welcome_pack",
+          "writable": true
+        },
+        {
+          "name": "rewards_mint",
+          "relations": [
+            "welcome_pack"
+          ]
+        },
+        {
+          "name": "recipient",
+          "writable": true
+        },
+        {
+          "name": "rewards_recipient",
+          "writable": true
+        },
+        {
+          "name": "token_account",
+          "writable": true
+        },
+        {
+          "name": "queue_authority"
+        },
+        {
+          "name": "task_queue",
+          "writable": true
+        },
+        {
+          "name": "task_queue_authority"
+        },
+        {
+          "name": "task",
+          "writable": true
+        },
+        {
+          "name": "pre_task",
+          "writable": true
+        },
+        {
+          "name": "tree_authority"
+        },
+        {
+          "name": "merkle_tree",
+          "writable": true
+        },
+        {
+          "name": "log_wrapper",
+          "address": "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV"
+        },
+        {
+          "name": "compression_program",
+          "address": "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "mini_fanout_program",
+          "address": "mfanLprNnaiP4RX9Zz1BMcDosYHCqnG24H1fMEbi9Gn"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "bubblegum_program",
+          "address": "BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY"
+        },
+        {
+          "name": "tuktuk_program",
+          "address": "tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA"
+        },
+        {
+          "name": "lazy_distributor_program",
+          "address": "1azyuavdMyvsivtNxPoz6SucD18eDHeXzFCUPq5XU7w"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "ClaimWelcomePackArgsV0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_welcome_pack_v0",
+      "discriminator": [
+        220,
+        222,
+        184,
+        125,
+        100,
+        243,
+        243,
+        172
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": [
+            "welcome_pack",
+            "user_welcome_packs"
+          ]
+        },
+        {
+          "name": "welcome_pack",
+          "writable": true
+        },
+        {
+          "name": "user_welcome_packs"
+        },
+        {
+          "name": "rent_refund",
+          "writable": true
+        },
+        {
+          "name": "merkle_tree",
+          "writable": true
+        },
+        {
+          "name": "tree_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "merkle_tree"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                152,
+                139,
+                128,
+                235,
+                121,
+                53,
+                40,
+                105,
+                178,
+                36,
+                116,
+                95,
+                89,
+                221,
+                191,
+                138,
+                38,
+                88,
+                202,
+                19,
+                220,
+                104,
+                129,
+                33,
+                38,
+                53,
+                28,
+                174,
+                7,
+                193,
+                165,
+                165
+              ]
+            }
+          }
+        },
+        {
+          "name": "log_wrapper",
+          "address": "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV"
+        },
+        {
+          "name": "compression_program",
+          "address": "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "bubblegum_program",
+          "address": "BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY"
+        },
+        {
+          "name": "recipient",
+          "writable": true
+        },
+        {
+          "name": "lazy_distributor_program",
+          "address": "1azyuavdMyvsivtNxPoz6SucD18eDHeXzFCUPq5XU7w"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "CloseWelcomePackArgsV0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_welcome_pack_v0",
+      "discriminator": [
+        30,
+        11,
+        218,
+        24,
+        48,
+        198,
+        32,
+        90
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent_refund"
+        },
+        {
+          "name": "lazy_distributor",
+          "relations": [
+            "recipient"
+          ]
+        },
+        {
+          "name": "recipient",
+          "writable": true
+        },
+        {
+          "name": "asset_return_address"
+        },
+        {
+          "name": "user_welcome_packs",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  115,
+                  101,
+                  114,
+                  95,
+                  119,
+                  101,
+                  108,
+                  99,
+                  111,
+                  109,
+                  101,
+                  95,
+                  112,
+                  97,
+                  99,
+                  107,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              }
+            ]
+          }
+        },
+        {
+          "name": "welcome_pack",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  119,
+                  101,
+                  108,
+                  99,
+                  111,
+                  109,
+                  101,
+                  95,
+                  112,
+                  97,
+                  99,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "account",
+                "path": "user_welcome_packs.next_id",
+                "account": "UserWelcomePacksV0"
+              }
+            ]
+          }
+        },
+        {
+          "name": "tree_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "merkle_tree"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                152,
+                139,
+                128,
+                235,
+                121,
+                53,
+                40,
+                105,
+                178,
+                36,
+                116,
+                95,
+                89,
+                221,
+                191,
+                138,
+                38,
+                88,
+                202,
+                19,
+                220,
+                104,
+                129,
+                33,
+                38,
+                53,
+                28,
+                174,
+                7,
+                193,
+                165,
+                165
+              ]
+            }
+          }
+        },
+        {
+          "name": "leaf_owner",
+          "signer": true
+        },
+        {
+          "name": "merkle_tree",
+          "writable": true
+        },
+        {
+          "name": "log_wrapper",
+          "address": "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV"
+        },
+        {
+          "name": "compression_program",
+          "address": "cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "bubblegum_program",
+          "address": "BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY"
+        },
+        {
+          "name": "lazy_distributor_program",
+          "address": "1azyuavdMyvsivtNxPoz6SucD18eDHeXzFCUPq5XU7w"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "InitializeWelcomePackArgsV0"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "LazyDistributorV0",
+      "discriminator": [
+        135,
+        186,
+        185,
+        252,
+        10,
+        77,
+        99,
+        167
+      ]
+    },
+    {
+      "name": "RecipientV0",
+      "discriminator": [
+        174,
+        14,
+        199,
+        217,
+        206,
+        108,
+        154,
+        50
+      ]
+    },
+    {
+      "name": "UserWelcomePacksV0",
+      "discriminator": [
+        207,
+        221,
+        75,
+        20,
+        104,
+        235,
+        208,
+        172
+      ]
+    },
+    {
+      "name": "WelcomePackV0",
+      "discriminator": [
+        240,
+        173,
+        154,
+        20,
+        194,
+        189,
+        93,
+        7
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidAssetReturnAddress",
+      "msg": "Invalid asset return address"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidAsset",
+      "msg": "Invalid asset"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidRewardsRecipient",
+      "msg": "Invalid rewards recipient"
+    },
+    {
+      "code": 6003,
+      "name": "ClaimApprovalExpired",
+      "msg": "Claim approval expired"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidClaimApprovalSignature",
+      "msg": "Invalid claim approval signature"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidRentRefund",
+      "msg": "Invalid rent refund"
+    },
+    {
+      "code": 6006,
+      "name": "InvalidRewardsSplit",
+      "msg": "Invalid rewards split"
+    },
+    {
+      "code": 6007,
+      "name": "InvalidSchedule",
+      "msg": "Invalid schedule"
+    }
+  ],
+  "types": [
+    {
+      "name": "ClaimWelcomePackArgsV0",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "creator_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "root",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "index",
+            "type": "u32"
+          },
+          {
+            "name": "approval_expiration_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "claim_signature",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "task_id",
+            "type": "u16"
+          },
+          {
+            "name": "pre_task_id",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CloseWelcomePackArgsV0",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "creator_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "root",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "index",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializeWelcomePackArgsV0",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "sol_amount",
+            "type": "u64"
+          },
+          {
+            "name": "rewards_split",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "MiniFanoutShareArgV0"
+                }
+              }
+            }
+          },
+          {
+            "name": "rewards_schedule",
+            "type": "string"
+          },
+          {
+            "name": "data_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "creator_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "root",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "index",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LazyDistributorV0",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "type": "u16"
+          },
+          {
+            "name": "rewards_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "rewards_escrow",
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "oracles",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "OracleConfigV0"
+                }
+              }
+            }
+          },
+          {
+            "name": "bump_seed",
+            "type": "u8"
+          },
+          {
+            "name": "approver",
+            "type": {
+              "option": "pubkey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MiniFanoutShareArgV0",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "share",
+            "type": {
+              "defined": {
+                "name": "Share"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleConfigV0",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "url",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RecipientV0",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lazy_distributor",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset",
+            "type": "pubkey"
+          },
+          {
+            "name": "total_rewards",
+            "type": "u64"
+          },
+          {
+            "name": "current_config_version",
+            "type": "u16"
+          },
+          {
+            "name": "current_rewards",
+            "type": {
+              "vec": {
+                "option": "u64"
+              }
+            }
+          },
+          {
+            "name": "bump_seed",
+            "type": "u8"
+          },
+          {
+            "name": "reserved",
+            "type": "u64"
+          },
+          {
+            "name": "destination",
+            "docs": [
+              "Pubkey::Default if not being used."
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Share",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Share",
+            "fields": [
+              {
+                "name": "amount",
+                "type": "u32"
+              }
+            ]
+          },
+          {
+            "name": "Fixed",
+            "fields": [
+              {
+                "name": "amount",
+                "type": "u64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserWelcomePacksV0",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "next_id",
+            "type": "u32"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump_seed",
+            "type": "u8"
+          },
+          {
+            "name": "next_unique_id",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WelcomePackV0",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "u32"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset",
+            "type": "pubkey"
+          },
+          {
+            "name": "lazy_distributor",
+            "type": "pubkey"
+          },
+          {
+            "name": "rewards_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "rent_refund",
+            "type": "pubkey"
+          },
+          {
+            "name": "sol_amount",
+            "type": "u64"
+          },
+          {
+            "name": "rewards_split",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "MiniFanoutShareArgV0"
+                }
+              }
+            }
+          },
+          {
+            "name": "rewards_schedule",
+            "type": "string"
+          },
+          {
+            "name": "asset_return_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump_seed",
+            "type": "u8"
+          },
+          {
+            "name": "unique_id",
+            "type": "u32"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -462,6 +462,23 @@ pub fn transfer_instruction(
     Ok(ix)
 }
 
+/// Fetch the asset + Merkle proof and return the bare bubblegum
+/// transfer instruction (no compute-budget framing). Asserts the
+/// asset's current owner matches `expected_owner` — for Squads-mode
+/// wrappers this prevents shipping a proposal whose `leaf_owner`
+/// can't be satisfied at execute time (the vault PDA is the only
+/// signer the program can produce via `invoke_signed`).
+pub async fn fetch_transfer_instruction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
+    client: &C,
+    pubkey: &Pubkey,
+    recipient: &Pubkey,
+    expected_owner: &Pubkey,
+) -> Result<Instruction, Error> {
+    let (asset, asset_proof) = get_with_proof(client, pubkey).await?;
+    check_owner(pubkey, &asset, expected_owner)?;
+    transfer_instruction(recipient, &asset, &asset_proof)
+}
+
 /// Gets an unsigned transaction for an asset transfer.
 ///
 /// The asset is transferred from the owner to the given recipient
@@ -503,18 +520,16 @@ pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     Ok((txn, block_height))
 }
 
-/// Gets an unsigned burn transaction for an asset.
-pub async fn burn_message<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
-    client: &C,
-    pubkey: &Pubkey,
-    opts: &TransactionOpts,
-) -> Result<(message::VersionedMessage, u64), Error> {
+/// Build the bare Bubblegum burn instruction from a fetched asset and
+/// its Merkle proof. The proof siblings are appended to the account
+/// list — `mpl-bubblegum`'s on-chain `burn` handler forwards
+/// `remaining_accounts` straight into `replace_leaf`, so without them
+/// the CPI fails Merkle proof verification.
+pub fn burn_instruction(asset: &Asset, asset_proof: &AssetProof) -> Result<Instruction, Error> {
     use bubblegum::client::{accounts::Burn as BurnAccounts, args::Burn as BurnArgs};
-    let (asset, asset_proof) = get_with_proof(client, pubkey).await?;
-
     let leaf_delegate = asset.ownership.delegate.unwrap_or(asset.ownership.owner);
 
-    let burn = BurnAccounts {
+    let mut accounts = BurnAccounts {
         leaf_owner: asset.ownership.owner,
         leaf_delegate,
         merkle_tree: asset_proof.tree_id,
@@ -522,29 +537,66 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
         log_wrapper: SPL_NOOP_PROGRAM_ID,
         compression_program: spl_account_compression::ID,
         system_program: solana_sdk::system_program::id(),
-    };
+    }
+    .to_account_metas(None);
+    accounts.extend(asset_proof.proof()?);
 
-    let args = BurnArgs {
+    let data = BurnArgs {
         creator_hash: asset.compression.creator_hash,
         root: asset_proof.root.to_bytes(),
         data_hash: asset.compression.data_hash,
         index: asset.compression.leaf_id()?,
         nonce: asset.compression.leaf_id,
-    };
+    }
+    .data();
 
-    let ix = Instruction {
+    Ok(Instruction {
         program_id: bubblegum::ID,
-        accounts: burn.to_account_metas(None),
-        data: args.data(),
-    };
+        accounts,
+        data,
+    })
+}
 
-    let mut priority_fee_accounts = ix.accounts.clone();
-    priority_fee_accounts.extend(asset_proof.proof()?);
+/// Fetch the asset + Merkle proof and return the bare bubblegum burn
+/// instruction. Asserts the asset's current owner matches
+/// `expected_owner` — same rationale as `fetch_transfer_instruction`.
+pub async fn fetch_burn_instruction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
+    client: &C,
+    pubkey: &Pubkey,
+    expected_owner: &Pubkey,
+) -> Result<Instruction, Error> {
+    let (asset, asset_proof) = get_with_proof(client, pubkey).await?;
+    check_owner(pubkey, &asset, expected_owner)?;
+    burn_instruction(&asset, &asset_proof)
+}
+
+/// Reject calls where the on-chain asset owner doesn't match the
+/// caller's expectation. Surfaces a clear error with both addresses
+/// so the user can compare against the Squads UI.
+fn check_owner(asset_id: &Pubkey, asset: &Asset, expected: &Pubkey) -> Result<(), Error> {
+    if asset.ownership.owner != *expected {
+        return Err(crate::squads::SquadsError::WrongAssetOwner {
+            asset: *asset_id,
+            actual: asset.ownership.owner,
+            expected: *expected,
+        }
+        .into());
+    }
+    Ok(())
+}
+
+/// Gets an unsigned burn transaction for an asset.
+pub async fn burn_message<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
+    client: &C,
+    pubkey: &Pubkey,
+    opts: &TransactionOpts,
+) -> Result<(message::VersionedMessage, u64), Error> {
+    let (asset, asset_proof) = get_with_proof(client, pubkey).await?;
+    let ix = burn_instruction(&asset, &asset_proof)?;
 
     let ixs = &[
         compute_budget_instruction(100_000),
-        compute_price_instruction_for_accounts(client, &priority_fee_accounts, opts.fee_range())
-            .await?,
+        compute_price_instruction_for_accounts(client, &ix.accounts, opts.fee_range()).await?,
         ix,
     ];
 
@@ -757,5 +809,115 @@ pub mod serde_hash {
             .as_slice()
             .try_into()
             .map_err(|_| de::Error::custom("invalid hash"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synthetic_asset(owner: Pubkey, tree: Pubkey) -> Asset {
+        Asset {
+            id: Pubkey::new_unique(),
+            compression: AssetCompression {
+                data_hash: [1u8; 32],
+                creator_hash: [2u8; 32],
+                leaf_id: 7,
+                tree,
+            },
+            creators: vec![],
+            ownership: AssetOwnership {
+                owner,
+                delegate: None,
+            },
+            content: AssetContent {
+                metadata: AssetMetadata {
+                    attributes: vec![],
+                    name: "test".to_string(),
+                    symbol: "TEST".to_string(),
+                },
+                json_uri: url::Url::parse("https://example.test/x").unwrap(),
+            },
+            grouping: vec![],
+            burnt: false,
+        }
+    }
+
+    fn synthetic_proof(tree: Pubkey, siblings: &[Pubkey]) -> AssetProof {
+        AssetProof {
+            proof: siblings.iter().map(ToString::to_string).collect(),
+            root: Pubkey::new_unique(),
+            tree_id: tree,
+            canopy_height: None,
+        }
+    }
+
+    /// `burn_instruction` must extend the bubblegum `Burn` accounts
+    /// with the asset's Merkle proof siblings — bubblegum's on-chain
+    /// `burn` handler forwards `remaining_accounts` straight into
+    /// `replace_leaf` for proof verification, so missing siblings
+    /// would fail the CPI on-chain. Pin both the count and the
+    /// trailing-account ordering so a regression that drops the
+    /// `accounts.extend(asset_proof.proof()?)` line surfaces here.
+    #[test]
+    fn burn_instruction_appends_proof_siblings() {
+        let owner = Pubkey::new_unique();
+        let tree = Pubkey::new_unique();
+        let siblings = [
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+        ];
+        let asset = synthetic_asset(owner, tree);
+        let proof = synthetic_proof(tree, &siblings);
+
+        let ix = burn_instruction(&asset, &proof).expect("burn_instruction");
+
+        // Bubblegum `Burn` has 7 base accounts; the proof siblings
+        // append after them in order.
+        assert_eq!(
+            ix.accounts.len(),
+            7 + siblings.len(),
+            "expected 7 base + {} proof siblings; got {} total",
+            siblings.len(),
+            ix.accounts.len(),
+        );
+        let trailing = &ix.accounts[7..];
+        for (i, sibling) in siblings.iter().enumerate() {
+            assert_eq!(
+                trailing[i].pubkey, *sibling,
+                "trailing account {i} must be sibling {sibling}",
+            );
+            assert!(
+                !trailing[i].is_signer && !trailing[i].is_writable,
+                "proof siblings must be readonly non-signers",
+            );
+        }
+    }
+
+    /// Canopy-height truncation: if the tree has a canopy, the proof
+    /// vec carries the full path but only the part above the canopy
+    /// goes on-chain (the canopy is verified inside the program).
+    /// `AssetProof::proof` already truncates; this test pins that
+    /// `burn_instruction` honors it instead of e.g. cloning the raw
+    /// `proof` vec.
+    #[test]
+    fn burn_instruction_respects_canopy_height() {
+        let owner = Pubkey::new_unique();
+        let tree = Pubkey::new_unique();
+        let siblings = [
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+        ];
+        let asset = synthetic_asset(owner, tree);
+        let mut proof = synthetic_proof(tree, &siblings);
+        proof.canopy_height = Some(2);
+
+        let ix = burn_instruction(&asset, &proof).expect("burn_instruction");
+        // 5 siblings - 2 canopy = 3 on-chain proof entries.
+        assert_eq!(ix.accounts.len(), 7 + 3);
     }
 }

--- a/helium-lib/src/dc.rs
+++ b/helium-lib/src/dc.rs
@@ -15,7 +15,55 @@ use crate::{
     TransactionOpts,
 };
 
-/// Builds a message that mints data credits by burning HNT.
+/// Build the bare DC-mint instruction (no compute-budget framing). Used
+/// by both `mint_message` and Squads-mode wrappers; same args/accounts,
+/// just stripped of the outer envelope.
+pub async fn mint_instruction<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    amount: TokenAmount,
+    payee: &Pubkey,
+    payer: &Pubkey,
+) -> Result<Instruction, Error> {
+    let mint_args = match amount.token {
+        Token::Hnt => data_credits::types::MintDataCreditsArgsV0 {
+            hnt_amount: Some(amount.amount),
+            dc_amount: None,
+        },
+        Token::Dc => data_credits::types::MintDataCreditsArgsV0 {
+            hnt_amount: None,
+            dc_amount: Some(amount.amount),
+        },
+        other => {
+            return Err(DecodeError::other(format!("Invalid token type: {other}")).into());
+        }
+    };
+    let hnt_price_oracle = client
+        .as_ref()
+        .anchor_account::<data_credits::accounts::DataCreditsV0>(&Dao::dc_key())
+        .await?
+        .hnt_price_oracle;
+    let accounts = data_credits::client::accounts::MintDataCreditsV0 {
+        data_credits: Dao::dc_key(),
+        owner: *payer,
+        hnt_mint: *Token::Hnt.mint(),
+        dc_mint: *Token::Dc.mint(),
+        recipient: *payee,
+        recipient_token_account: Token::Dc.associated_token_address(payee),
+        system_program: solana_sdk::system_program::ID,
+        token_program: anchor_spl::token::ID,
+        associated_token_program: anchor_spl::associated_token::ID,
+        hnt_price_oracle,
+        circuit_breaker_program: circuit_breaker::ID,
+        circuit_breaker: Token::Dc.mint_circuit_breaker_address(),
+        burner: Token::Hnt.associated_token_address(payer),
+    };
+    Ok(Instruction {
+        program_id: data_credits::ID,
+        accounts: accounts.to_account_metas(None),
+        data: data_credits::client::args::MintDataCreditsV0 { args: mint_args }.data(),
+    })
+}
+
 pub async fn mint_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: TokenAmount,
@@ -23,58 +71,7 @@ pub async fn mint_message<C: AsRef<SolanaRpcClient>>(
     payer: &Pubkey,
     opts: &TransactionOpts,
 ) -> Result<(message::VersionedMessage, u64), Error> {
-    fn token_amount_to_mint_args(
-        amount: TokenAmount,
-    ) -> Result<data_credits::types::MintDataCreditsArgsV0, DecodeError> {
-        match amount.token {
-            Token::Hnt => Ok(data_credits::types::MintDataCreditsArgsV0 {
-                hnt_amount: Some(amount.amount),
-                dc_amount: None,
-            }),
-            Token::Dc => Ok(data_credits::types::MintDataCreditsArgsV0 {
-                hnt_amount: None,
-                dc_amount: Some(amount.amount),
-            }),
-            other => Err(DecodeError::other(format!("Invalid token type: {other}"))),
-        }
-    }
-    fn mk_accounts(
-        owner: &Pubkey,
-        recipient: Pubkey,
-        hnt_price_oracle: Pubkey,
-    ) -> impl ToAccountMetas {
-        data_credits::client::accounts::MintDataCreditsV0 {
-            data_credits: Dao::dc_key(),
-            owner: *owner,
-            hnt_mint: *Token::Hnt.mint(),
-            dc_mint: *Token::Dc.mint(),
-            recipient,
-            recipient_token_account: Token::Dc.associated_token_address(&recipient),
-            system_program: solana_sdk::system_program::ID,
-            token_program: anchor_spl::token::ID,
-            associated_token_program: anchor_spl::associated_token::ID,
-            hnt_price_oracle,
-            circuit_breaker_program: circuit_breaker::ID,
-            circuit_breaker: Token::Dc.mint_circuit_breaker_address(),
-            burner: Token::Hnt.associated_token_address(owner),
-        }
-    }
-
-    let hnt_price_oracle = client
-        .as_ref()
-        .anchor_account::<data_credits::accounts::DataCreditsV0>(&Dao::dc_key())
-        .await?
-        .hnt_price_oracle;
-
-    let ix = Instruction {
-        program_id: data_credits::ID,
-        accounts: mk_accounts(payer, *payee, hnt_price_oracle).to_account_metas(None),
-        data: data_credits::client::args::MintDataCreditsV0 {
-            args: token_amount_to_mint_args(amount)?,
-        }
-        .data(),
-    };
-
+    let ix = mint_instruction(client, amount, payee, payer).await?;
     let ixs = &[
         priority_fee::compute_budget_instruction(300_000),
         priority_fee::compute_price_instruction_for_accounts(
@@ -85,7 +82,6 @@ pub async fn mint_message<C: AsRef<SolanaRpcClient>>(
         .await?,
         ix,
     ];
-
     message::mk_message(client, ixs, &opts.lut_addresses, payer).await
 }
 
@@ -102,6 +98,42 @@ pub async fn mint<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
+/// Build the bare DC-delegate instruction (no compute-budget framing).
+/// Used by both `delegate_message` and Squads-mode wrappers.
+pub fn delegate_instruction(
+    subdao: SubDao,
+    payer_key: &str,
+    amount: u64,
+    owner: &Pubkey,
+) -> Instruction {
+    let delegated_dc_key = subdao.delegated_dc_key(&payer_key);
+    let accounts = data_credits::client::accounts::DelegateDataCreditsV0 {
+        delegated_data_credits: delegated_dc_key,
+        data_credits: Dao::dc_key(),
+        dc_mint: *Token::Dc.mint(),
+        dao: Dao::Hnt.key(),
+        sub_dao: subdao.key(),
+        owner: *owner,
+        from_account: Token::Dc.associated_token_address(owner),
+        escrow_account: subdao.escrow_key(&delegated_dc_key),
+        payer: *owner,
+        associated_token_program: anchor_spl::associated_token::ID,
+        token_program: anchor_spl::token::ID,
+        system_program: solana_sdk::system_program::ID,
+    };
+    Instruction {
+        program_id: data_credits::ID,
+        accounts: accounts.to_account_metas(None),
+        data: data_credits::client::args::DelegateDataCreditsV0 {
+            args: data_credits::types::DelegateDataCreditsArgsV0 {
+                amount,
+                router_key: payer_key.to_string(),
+            },
+        }
+        .data(),
+    }
+}
+
 /// Builds a message that delegates data credits to a router/OUI.
 pub async fn delegate_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
@@ -111,35 +143,7 @@ pub async fn delegate_message<C: AsRef<SolanaRpcClient>>(
     owner: &Pubkey,
     opts: &TransactionOpts,
 ) -> Result<(message::VersionedMessage, u64), Error> {
-    fn mk_accounts(delegated_dc_key: Pubkey, subdao: SubDao, owner: Pubkey) -> impl ToAccountMetas {
-        data_credits::client::accounts::DelegateDataCreditsV0 {
-            delegated_data_credits: delegated_dc_key,
-            data_credits: Dao::dc_key(),
-            dc_mint: *Token::Dc.mint(),
-            dao: Dao::Hnt.key(),
-            sub_dao: subdao.key(),
-            owner,
-            from_account: Token::Dc.associated_token_address(&owner),
-            escrow_account: subdao.escrow_key(&delegated_dc_key),
-            payer: owner,
-            associated_token_program: anchor_spl::associated_token::ID,
-            token_program: anchor_spl::token::ID,
-            system_program: solana_sdk::system_program::ID,
-        }
-    }
-
-    let delegated_dc_key = subdao.delegated_dc_key(&payer_key);
-    let ix = Instruction {
-        program_id: data_credits::ID,
-        accounts: mk_accounts(delegated_dc_key, subdao, *owner).to_account_metas(None),
-        data: data_credits::client::args::DelegateDataCreditsV0 {
-            args: data_credits::types::DelegateDataCreditsArgsV0 {
-                amount,
-                router_key: payer_key.to_string(),
-            },
-        }
-        .data(),
-    };
+    let ix = delegate_instruction(subdao, payer_key, amount, owner);
 
     let ixs = &[
         priority_fee::compute_budget_instruction(150_000),
@@ -169,6 +173,30 @@ pub async fn delegate<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
+/// Build the bare DC-burn instruction (no compute-budget framing).
+/// Used by both `burn_message` and Squads-mode wrappers.
+pub fn burn_instruction(amount: u64, owner: &Pubkey) -> Instruction {
+    let accounts = data_credits::client::accounts::BurnWithoutTrackingV0 {
+        burn_accounts: data_credits::client::accounts::BurnAccounts {
+            burner: Token::Dc.associated_token_address(owner),
+            dc_mint: *Token::Dc.mint(),
+            data_credits: Dao::dc_key(),
+            token_program: anchor_spl::token::ID,
+            system_program: solana_sdk::system_program::ID,
+            associated_token_program: anchor_spl::associated_token::ID,
+            owner: *owner,
+        },
+    };
+    Instruction {
+        program_id: data_credits::ID,
+        accounts: accounts.to_account_metas(None),
+        data: data_credits::client::args::BurnWithoutTrackingV0 {
+            args: data_credits::types::BurnWithoutTrackingArgsV0 { amount },
+        }
+        .data(),
+    }
+}
+
 /// Builds a message that burns data credits without tracking.
 pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
@@ -176,28 +204,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
     owner: &Pubkey,
     opts: &TransactionOpts,
 ) -> Result<(message::VersionedMessage, u64), Error> {
-    fn mk_accounts(owner: Pubkey) -> impl ToAccountMetas {
-        data_credits::client::accounts::BurnWithoutTrackingV0 {
-            burn_accounts: data_credits::client::accounts::BurnAccounts {
-                burner: Token::Dc.associated_token_address(&owner),
-                dc_mint: *Token::Dc.mint(),
-                data_credits: Dao::dc_key(),
-                token_program: anchor_spl::token::ID,
-                system_program: solana_sdk::system_program::ID,
-                associated_token_program: anchor_spl::associated_token::ID,
-                owner,
-            },
-        }
-    }
-
-    let ix = Instruction {
-        program_id: data_credits::ID,
-        accounts: mk_accounts(*owner).to_account_metas(None),
-        data: data_credits::client::args::BurnWithoutTrackingV0 {
-            args: data_credits::types::BurnWithoutTrackingArgsV0 { amount },
-        }
-        .data(),
-    };
+    let ix = burn_instruction(amount, owner);
 
     let ixs = &[
         priority_fee::compute_budget_instruction(150_000),

--- a/helium-lib/src/error.rs
+++ b/helium-lib/src/error.rs
@@ -1,5 +1,6 @@
 use crate::{
-    anchor_client, anchor_lang, client, hotspot::cert, jupiter, onboarding, solana_client, token,
+    anchor_client, anchor_lang, client, hotspot::cert, jupiter, onboarding, solana_client, squads,
+    token,
 };
 use solana_sdk::signature::Signature;
 use std::{array::TryFromSliceError, num::TryFromIntError, time::Duration};
@@ -57,6 +58,8 @@ pub enum Error {
     Tuktuk(#[from] tuktuk_sdk::error::Error),
     #[error("jupiter: {0}")]
     Jupiter(#[from] jupiter::JupiterError),
+    #[error("squads: {0}")]
+    Squads(#[from] squads::SquadsError),
 }
 
 impl From<solana_client::client_error::ClientError> for Error {
@@ -118,6 +121,8 @@ pub enum EncodeError {
     Bincode(#[from] bincode::Error),
     #[error("h3: {0}")]
     H3(#[from] h3o::error::InvalidLatLng),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
     #[error("encode: {0}")]
     Encode(String),
 }
@@ -125,6 +130,14 @@ pub enum EncodeError {
 impl EncodeError {
     pub fn other<S: ToString>(reason: S) -> Self {
         Self::Encode(reason.to_string())
+    }
+
+    /// Wraps a Borsh / Anchor serialize failure with the type's name
+    /// for context. Used at instruction-data construction sites where
+    /// the borsh error alone wouldn't tell the user which arg struct
+    /// failed.
+    pub fn borsh<E: std::fmt::Display>(type_name: &str, source: E) -> Self {
+        Self::Encode(format!("{type_name}: {source}"))
     }
 }
 
@@ -164,6 +177,32 @@ pub enum DecodeError {
 impl DecodeError {
     pub fn other<S: ToString>(reason: S) -> Self {
         Self::Decode(reason.to_string())
+    }
+
+    /// Account isn't owned by the expected program.
+    pub fn wrong_owner(
+        address: &solana_sdk::pubkey::Pubkey,
+        expected: &str,
+        got: &solana_sdk::pubkey::Pubkey,
+    ) -> Self {
+        Self::Decode(format!("{address} owner is {got}, expected {expected}"))
+    }
+
+    /// Account doesn't match the 8-byte Anchor discriminator for the
+    /// expected type.
+    pub fn wrong_discriminator(address: &solana_sdk::pubkey::Pubkey, account_type: &str) -> Self {
+        Self::Decode(format!(
+            "{address} is not a {account_type} account (bad discriminator)"
+        ))
+    }
+
+    /// Borsh / Anchor deserialize failure for a specific account.
+    pub fn deserialize<E: std::fmt::Display>(
+        address: &solana_sdk::pubkey::Pubkey,
+        account_type: &str,
+        source: E,
+    ) -> Self {
+        Self::Decode(format!("{account_type} {address}: {source}"))
     }
 }
 

--- a/helium-lib/src/hotspot/mod.rs
+++ b/helium-lib/src/hotspot/mod.rs
@@ -289,6 +289,33 @@ pub async fn update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     Ok(tx)
 }
 
+/// Resolve the hotspot's underlying asset and return the bare
+/// bubblegum transfer instruction. Asserts the hotspot's current
+/// owner matches `expected_owner` (typically the Squads vault) —
+/// see `asset::fetch_transfer_instruction`.
+pub async fn fetch_transfer_instruction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
+    client: &C,
+    hotspot_key: &helium_crypto::PublicKey,
+    recipient: &Pubkey,
+    expected_owner: &Pubkey,
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    let kta = kta::for_entity_key(hotspot_key).await?;
+    asset::fetch_transfer_instruction(client, &kta.asset, recipient, expected_owner).await
+}
+
+/// Resolve the hotspot's underlying asset and return the bare
+/// bubblegum burn instruction. Asserts the hotspot's current owner
+/// matches `expected_owner` (typically the Squads vault) — see
+/// `asset::fetch_burn_instruction`.
+pub async fn fetch_burn_instruction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
+    client: &C,
+    hotspot_key: &helium_crypto::PublicKey,
+    expected_owner: &Pubkey,
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    let kta = kta::for_entity_key(hotspot_key).await?;
+    asset::fetch_burn_instruction(client, &kta.asset, expected_owner).await
+}
+
 /// Gets an unsigned transaction for a hotspot transfer.
 ///
 /// The Hotspot is transferred from the owner of the Hotspot to the given recipient

--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -49,6 +49,8 @@ pub mod queue;
 pub mod reward;
 /// Cron-based scheduled reward claiming.
 pub mod schedule;
+/// Squads multisig integration (v3 + v4): proposal building, voting, decoding.
+pub mod squads;
 /// Token operations: transfers, burns, balances, and prices.
 pub mod token;
 /// Transaction building, signing, and confirmation.

--- a/helium-lib/src/programs.rs
+++ b/helium-lib/src/programs.rs
@@ -6,6 +6,13 @@ pub const TOKEN_METADATA_PROGRAM_ID: Pubkey =
 
 pub const SPL_NOOP_PROGRAM_ID: Pubkey = pubkey!("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
 
+/// Treasury management program ID, hardcoded because `declare_program!` can't
+/// digest its IDL (cross-program type reference to `circuit_breaker::state::
+/// ThresholdType`). We can still recognize the program in inspect output even
+/// without typed instruction decoding.
+pub const TREASURY_MANAGEMENT_PROGRAM_ID: Pubkey =
+    pubkey!("treaf4wWBBty3fHdyBpo35Mz84M8k3heKXmjmi9vFt5");
+
 declare_program!(helium_sub_daos);
 declare_program!(lazy_distributor);
 declare_program!(circuit_breaker);
@@ -18,3 +25,835 @@ declare_program!(bubblegum);
 declare_program!(mobile_entity_manager);
 declare_program!(price_oracle);
 declare_program!(hpl_crons);
+declare_program!(squads_mpl);
+declare_program!(voter_stake_registry);
+declare_program!(fanout);
+declare_program!(lazy_transactions);
+declare_program!(welcome_pack);
+
+/// A program we recognize by pubkey: HPL programs we generate types for, the
+/// Squads multisig programs (v3 and v4), and the most common Solana platform
+/// programs that show up in transaction decoding.
+///
+/// Used by transaction inspectors and instruction decoders to map a raw
+/// program ID to a structured identity. Variants serialize to snake_case
+/// strings (`"helium_sub_daos"`, `"squads_v4"`, …).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KnownProgram {
+    HeliumSubDaos,
+    LazyDistributor,
+    CircuitBreaker,
+    HeliumEntityManager,
+    DataCredits,
+    Hexboosting,
+    RewardsOracle,
+    SplAccountCompression,
+    Bubblegum,
+    MobileEntityManager,
+    PriceOracle,
+    HplCrons,
+    VoterStakeRegistry,
+    Fanout,
+    LazyTransactions,
+    TreasuryManagement,
+    WelcomePack,
+    /// Squads v3 (`SMPLecH…`).
+    SquadsMpl,
+    /// Squads v4 (`SQDS4ep…`). The upstream crate calls this
+    /// `squads_multisig_program`; we alias to a friendlier name.
+    SquadsV4,
+    SplToken,
+    SplAssociatedToken,
+    SystemProgram,
+    ComputeBudget,
+    AddressLookupTable,
+    BpfLoaderUpgradeable,
+    TokenMetadata,
+    SplNoop,
+}
+
+impl KnownProgram {
+    /// All variants in declaration order. Useful for iteration and for
+    /// building forward lookup tables.
+    pub const ALL: &'static [Self] = &[
+        Self::HeliumSubDaos,
+        Self::LazyDistributor,
+        Self::CircuitBreaker,
+        Self::HeliumEntityManager,
+        Self::DataCredits,
+        Self::Hexboosting,
+        Self::RewardsOracle,
+        Self::SplAccountCompression,
+        Self::Bubblegum,
+        Self::MobileEntityManager,
+        Self::PriceOracle,
+        Self::HplCrons,
+        Self::VoterStakeRegistry,
+        Self::Fanout,
+        Self::LazyTransactions,
+        Self::TreasuryManagement,
+        Self::WelcomePack,
+        Self::SquadsMpl,
+        Self::SquadsV4,
+        Self::SplToken,
+        Self::SplAssociatedToken,
+        Self::SystemProgram,
+        Self::ComputeBudget,
+        Self::AddressLookupTable,
+        Self::BpfLoaderUpgradeable,
+        Self::TokenMetadata,
+        Self::SplNoop,
+    ];
+
+    /// Solana program ID for this program.
+    pub fn id(&self) -> Pubkey {
+        match self {
+            Self::HeliumSubDaos => helium_sub_daos::ID,
+            Self::LazyDistributor => lazy_distributor::ID,
+            Self::CircuitBreaker => circuit_breaker::ID,
+            Self::HeliumEntityManager => helium_entity_manager::ID,
+            Self::DataCredits => data_credits::ID,
+            Self::Hexboosting => hexboosting::ID,
+            Self::RewardsOracle => rewards_oracle::ID,
+            Self::SplAccountCompression => spl_account_compression::ID,
+            Self::Bubblegum => bubblegum::ID,
+            Self::MobileEntityManager => mobile_entity_manager::ID,
+            Self::PriceOracle => price_oracle::ID,
+            Self::HplCrons => hpl_crons::ID,
+            Self::VoterStakeRegistry => voter_stake_registry::ID,
+            Self::Fanout => fanout::ID,
+            Self::LazyTransactions => lazy_transactions::ID,
+            Self::TreasuryManagement => TREASURY_MANAGEMENT_PROGRAM_ID,
+            Self::WelcomePack => welcome_pack::ID,
+            Self::SquadsMpl => squads_mpl::ID,
+            Self::SquadsV4 => squads_multisig_program::ID,
+            Self::SplToken => anchor_spl::token::ID,
+            Self::SplAssociatedToken => anchor_spl::associated_token::ID,
+            Self::SystemProgram => solana_sdk::system_program::ID,
+            Self::ComputeBudget => solana_sdk::compute_budget::ID,
+            Self::AddressLookupTable => solana_sdk::address_lookup_table::program::ID,
+            Self::BpfLoaderUpgradeable => solana_sdk::bpf_loader_upgradeable::ID,
+            Self::TokenMetadata => TOKEN_METADATA_PROGRAM_ID,
+            Self::SplNoop => SPL_NOOP_PROGRAM_ID,
+        }
+    }
+
+    /// Snake-cased name suitable for display or JSON output.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::HeliumSubDaos => "helium_sub_daos",
+            Self::LazyDistributor => "lazy_distributor",
+            Self::CircuitBreaker => "circuit_breaker",
+            Self::HeliumEntityManager => "helium_entity_manager",
+            Self::DataCredits => "data_credits",
+            Self::Hexboosting => "hexboosting",
+            Self::RewardsOracle => "rewards_oracle",
+            Self::SplAccountCompression => "spl_account_compression",
+            Self::Bubblegum => "bubblegum",
+            Self::MobileEntityManager => "mobile_entity_manager",
+            Self::PriceOracle => "price_oracle",
+            Self::HplCrons => "hpl_crons",
+            Self::VoterStakeRegistry => "voter_stake_registry",
+            Self::Fanout => "fanout",
+            Self::LazyTransactions => "lazy_transactions",
+            Self::TreasuryManagement => "treasury_management",
+            Self::WelcomePack => "welcome_pack",
+            Self::SquadsMpl => "squads_mpl",
+            Self::SquadsV4 => "squads_v4",
+            Self::SplToken => "spl_token",
+            Self::SplAssociatedToken => "spl_associated_token",
+            Self::SystemProgram => "system_program",
+            Self::ComputeBudget => "compute_budget",
+            Self::AddressLookupTable => "address_lookup_table",
+            Self::BpfLoaderUpgradeable => "bpf_loader_upgradeable",
+            Self::TokenMetadata => "token_metadata",
+            Self::SplNoop => "spl_noop",
+        }
+    }
+
+    /// Reverse lookup: given a program ID, return the variant that matches,
+    /// or `None` if we don't recognize it.
+    pub fn from_pubkey(pubkey: &Pubkey) -> Option<Self> {
+        Self::ALL.iter().copied().find(|kp| kp.id() == *pubkey)
+    }
+
+    /// Resolve a snake-cased instruction method name from an Anchor 8-byte
+    /// discriminator, when this program ships a parseable IDL. Returns
+    /// `None` for programs without an IDL (Squads v3/v4, SPL Token, etc.)
+    /// or instructions not present in the IDL. Anchor framework
+    /// instructions (e.g. on-chain IDL management) are recognized for any
+    /// program in the registry.
+    pub fn method_name(&self, discriminator: &[u8; 8]) -> Option<&'static str> {
+        idl::method_name(*self, discriminator)
+    }
+
+    /// Like `method_name`, but with access to the instruction body so the
+    /// returned name can include the Anchor IDL sub-op when applicable
+    /// (e.g. `"anchor:idl_set_buffer"` instead of just `"anchor:idl"`).
+    pub fn method_name_with_body(
+        &self,
+        discriminator: &[u8; 8],
+        body: &[u8],
+    ) -> Option<&'static str> {
+        idl::method_name_with_body(*self, discriminator, body)
+    }
+
+    /// True for programs whose IDL we ship and parse. Lets callers
+    /// distinguish "method unknown because we don't decode this program"
+    /// from "method unknown despite having the IDL" — the latter signals
+    /// either a stale IDL or a since-removed instruction.
+    pub fn has_idl(&self) -> bool {
+        idl::has_idl(*self)
+    }
+
+    /// Decode an Anchor instruction's args by walking this program's IDL
+    /// against the borsh-encoded body (everything after the 8-byte
+    /// discriminator). Returns `None` if the discriminator isn't in the
+    /// IDL or if any field fails to decode (truncated bytes, unsupported
+    /// type, etc.). Output is structured JSON with field names from the
+    /// IDL; consumers serialize it as part of their own response shape.
+    pub fn decode_instruction_args(
+        &self,
+        discriminator: &[u8; 8],
+        body: &[u8],
+    ) -> Option<serde_json::Value> {
+        idl::decode_instruction_args(*self, discriminator, body)
+    }
+}
+
+/// Discriminator → method-name resolution and IDL-driven Borsh arg decoding,
+/// backed by the embedded HPL IDL JSONs in `helium-lib/idls/`. Each program's
+/// IDL is parsed once on first use and held for process lifetime.
+mod idl {
+    use super::KnownProgram;
+    use serde_json::{Map, Value};
+    use solana_sdk::pubkey::Pubkey;
+    use std::{collections::HashMap, sync::LazyLock};
+
+    /// One row per HPL program with an IDL we can decode. Programs whose
+    /// IDLs we don't ship — Squads v3/v4, SPL Token, etc. — simply aren't
+    /// in this list.
+    const IDLS: &[(KnownProgram, &str)] = &[
+        (
+            KnownProgram::HeliumSubDaos,
+            include_str!("../idls/helium_sub_daos.json"),
+        ),
+        (
+            KnownProgram::LazyDistributor,
+            include_str!("../idls/lazy_distributor.json"),
+        ),
+        (
+            KnownProgram::CircuitBreaker,
+            include_str!("../idls/circuit_breaker.json"),
+        ),
+        (
+            KnownProgram::HeliumEntityManager,
+            include_str!("../idls/helium_entity_manager.json"),
+        ),
+        (
+            KnownProgram::DataCredits,
+            include_str!("../idls/data_credits.json"),
+        ),
+        (
+            KnownProgram::Hexboosting,
+            include_str!("../idls/hexboosting.json"),
+        ),
+        (
+            KnownProgram::RewardsOracle,
+            include_str!("../idls/rewards_oracle.json"),
+        ),
+        (
+            KnownProgram::SplAccountCompression,
+            include_str!("../idls/spl_account_compression.json"),
+        ),
+        (
+            KnownProgram::Bubblegum,
+            include_str!("../idls/bubblegum.json"),
+        ),
+        (
+            KnownProgram::MobileEntityManager,
+            include_str!("../idls/mobile_entity_manager.json"),
+        ),
+        (
+            KnownProgram::PriceOracle,
+            include_str!("../idls/price_oracle.json"),
+        ),
+        (
+            KnownProgram::HplCrons,
+            include_str!("../idls/hpl_crons.json"),
+        ),
+        (
+            KnownProgram::VoterStakeRegistry,
+            include_str!("../idls/voter_stake_registry.json"),
+        ),
+        (KnownProgram::Fanout, include_str!("../idls/fanout.json")),
+        (
+            KnownProgram::LazyTransactions,
+            include_str!("../idls/lazy_transactions.json"),
+        ),
+        (
+            KnownProgram::WelcomePack,
+            include_str!("../idls/welcome_pack.json"),
+        ),
+    ];
+
+    /// Parsed view of one program's IDL: instruction dispatch table by
+    /// discriminator, plus the named-type table needed to decode `defined`
+    /// references inside instruction args.
+    pub(super) struct ProgramIdl {
+        pub instructions: HashMap<[u8; 8], Instruction>,
+        pub types: HashMap<String, TypeDef>,
+    }
+
+    pub(super) struct Instruction {
+        pub name: String,
+        pub args: Vec<Field>,
+    }
+
+    pub(super) struct Field {
+        pub name: String,
+        pub ty: Type,
+    }
+
+    pub(super) enum TypeDef {
+        Struct(Vec<Field>),
+        Enum(Vec<EnumVariant>),
+    }
+
+    pub(super) struct EnumVariant {
+        pub name: String,
+        pub fields: VariantFields,
+    }
+
+    pub(super) enum VariantFields {
+        Unit,
+        Named(Vec<Field>),
+        Tuple(Vec<Type>),
+    }
+
+    /// Anchor IDL types we can decode. Anchor's full type set is broader
+    /// (HashMap, BTreeMap, generics, etc.) but Helium IDLs use only the
+    /// subset listed here. Unrecognized types fall through to `None`.
+    pub(super) enum Type {
+        Bool,
+        U8,
+        U16,
+        U32,
+        U64,
+        U128,
+        I8,
+        I16,
+        I32,
+        I64,
+        I128,
+        F32,
+        F64,
+        String,
+        Bytes,
+        Pubkey,
+        Vec(Box<Type>),
+        Option(Box<Type>),
+        Array(Box<Type>, usize),
+        Defined(String),
+    }
+
+    static IDL_DATA: LazyLock<HashMap<KnownProgram, ProgramIdl>> = LazyLock::new(|| {
+        IDLS.iter()
+            .map(|(program, json)| (*program, parse(json)))
+            .collect()
+    });
+
+    fn parse(idl: &str) -> ProgramIdl {
+        // IDLs are bundled via include_str! at compile time. A parse
+        // failure here means the shipped IDL is malformed — refresh
+        // it via gen_idl.sh rather than letting every method/arg
+        // lookup silently inflate `unknown_methods`.
+        let v: Value = serde_json::from_str(idl)
+            .expect("compile-time-bundled IDL must parse — refresh via gen_idl.sh");
+        let instructions = v
+            .get("instructions")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|inst| {
+                        let name = inst.get("name")?.as_str()?.to_owned();
+                        let disc = inst.get("discriminator")?.as_array()?;
+                        let bytes: Vec<u8> = disc
+                            .iter()
+                            .filter_map(|v| u8::try_from(v.as_u64()?).ok())
+                            .collect();
+                        let key: [u8; 8] = bytes.try_into().ok()?;
+                        let args = inst
+                            .get("args")
+                            .and_then(Value::as_array)
+                            .map(|a| a.iter().filter_map(parse_field).collect())
+                            .unwrap_or_default();
+                        Some((key, Instruction { name, args }))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let types = v
+            .get("types")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|td| {
+                        let name = td.get("name")?.as_str()?.to_owned();
+                        let body = td.get("type")?;
+                        let kind = body.get("kind")?.as_str()?;
+                        let parsed = match kind {
+                            "struct" => TypeDef::Struct(
+                                body.get("fields")
+                                    .and_then(Value::as_array)?
+                                    .iter()
+                                    .filter_map(parse_field)
+                                    .collect(),
+                            ),
+                            "enum" => TypeDef::Enum(
+                                body.get("variants")
+                                    .and_then(Value::as_array)?
+                                    .iter()
+                                    .filter_map(parse_enum_variant)
+                                    .collect(),
+                            ),
+                            _ => return None,
+                        };
+                        Some((name, parsed))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        ProgramIdl {
+            instructions,
+            types,
+        }
+    }
+
+    fn parse_field(v: &Value) -> Option<Field> {
+        Some(Field {
+            name: v.get("name")?.as_str()?.to_owned(),
+            ty: parse_type(v.get("type")?)?,
+        })
+    }
+
+    fn parse_enum_variant(v: &Value) -> Option<EnumVariant> {
+        let name = v.get("name")?.as_str()?.to_owned();
+        let fields = match v.get("fields") {
+            None => VariantFields::Unit,
+            Some(Value::Array(arr)) => {
+                // Two shapes: array of {name, type} for named-field
+                // variants, or array of bare types for tuple variants.
+                if arr.iter().all(|f| f.get("name").is_some()) {
+                    VariantFields::Named(arr.iter().filter_map(parse_field).collect())
+                } else {
+                    VariantFields::Tuple(arr.iter().filter_map(parse_type).collect())
+                }
+            }
+            _ => VariantFields::Unit,
+        };
+        Some(EnumVariant { name, fields })
+    }
+
+    fn parse_type(v: &Value) -> Option<Type> {
+        if let Some(prim) = v.as_str() {
+            return primitive_type(prim);
+        }
+        if let Some(obj) = v.as_object() {
+            if let Some(inner) = obj.get("vec") {
+                return Some(Type::Vec(Box::new(parse_type(inner)?)));
+            }
+            if let Some(inner) = obj.get("option") {
+                return Some(Type::Option(Box::new(parse_type(inner)?)));
+            }
+            if let Some(arr) = obj.get("array").and_then(Value::as_array) {
+                if arr.len() == 2 {
+                    let inner = parse_type(&arr[0])?;
+                    let n = arr[1].as_u64()? as usize;
+                    return Some(Type::Array(Box::new(inner), n));
+                }
+            }
+            if let Some(def) = obj.get("defined") {
+                let name = def.get("name")?.as_str()?.to_owned();
+                return Some(Type::Defined(name));
+            }
+        }
+        None
+    }
+
+    fn primitive_type(s: &str) -> Option<Type> {
+        Some(match s {
+            "bool" => Type::Bool,
+            "u8" => Type::U8,
+            "u16" => Type::U16,
+            "u32" => Type::U32,
+            "u64" => Type::U64,
+            "u128" => Type::U128,
+            "i8" => Type::I8,
+            "i16" => Type::I16,
+            "i32" => Type::I32,
+            "i64" => Type::I64,
+            "i128" => Type::I128,
+            "f32" => Type::F32,
+            "f64" => Type::F64,
+            "string" => Type::String,
+            "bytes" => Type::Bytes,
+            "pubkey" | "publicKey" => Type::Pubkey,
+            _ => return None,
+        })
+    }
+
+    /// Anchor's framework-level IDL management instruction tag —
+    /// `sha256("anchor:idl")[..8]` interpreted as a little-endian u64.
+    /// Every Anchor program responds to this discriminator with its
+    /// built-in IDL ops (init, write, set_authority, set_buffer, close,
+    /// resize). The byte immediately after the tag selects which sub-op.
+    /// Showing up as a sibling instruction during program-upgrade
+    /// ceremonies is normal — devs upgrade the on-chain IDL alongside
+    /// the program binary.
+    const ANCHOR_IDL_IX_TAG: [u8; 8] = [64, 244, 188, 120, 167, 233, 105, 10];
+
+    fn anchor_idl_method_name(body: &[u8]) -> &'static str {
+        // Sub-op order matches anchor-lang's `IdlInstruction` enum.
+        match body.first() {
+            Some(0) => "anchor:idl_create",
+            Some(1) => "anchor:idl_create_buffer",
+            Some(2) => "anchor:idl_write",
+            Some(3) => "anchor:idl_set_authority",
+            Some(4) => "anchor:idl_set_buffer",
+            Some(5) => "anchor:idl_close",
+            Some(6) => "anchor:idl_resize",
+            _ => "anchor:idl",
+        }
+    }
+
+    pub(super) fn method_name(
+        program: KnownProgram,
+        discriminator: &[u8; 8],
+    ) -> Option<&'static str> {
+        // Framework-level IDL management is independent of any program's
+        // own instruction set — recognize it across every Anchor program,
+        // including those whose IDL we don't ship. Check this first so
+        // IDL-less programs still pick it up.
+        if *discriminator == ANCHOR_IDL_IX_TAG {
+            return Some("anchor:idl");
+        }
+        // The strings live inside the LazyLock, which is itself 'static —
+        // so the returned &str borrow is also 'static.
+        IDL_DATA
+            .get(&program)?
+            .instructions
+            .get(discriminator)
+            .map(|i| i.name.as_str())
+    }
+
+    /// Like `method_name` but with access to the full instruction body so
+    /// the returned name can include the IDL sub-op when applicable
+    /// (e.g. `"anchor:idl_set_buffer"`). Falls back to `method_name` for
+    /// regular Anchor user instructions.
+    pub(super) fn method_name_with_body(
+        program: KnownProgram,
+        discriminator: &[u8; 8],
+        body: &[u8],
+    ) -> Option<&'static str> {
+        if *discriminator == ANCHOR_IDL_IX_TAG {
+            return Some(anchor_idl_method_name(body));
+        }
+        method_name(program, discriminator)
+    }
+
+    pub(super) fn has_idl(program: KnownProgram) -> bool {
+        IDLS.iter().any(|(p, _)| *p == program)
+    }
+
+    pub(super) fn decode_instruction_args(
+        program: KnownProgram,
+        discriminator: &[u8; 8],
+        body: &[u8],
+    ) -> Option<Value> {
+        let idl = IDL_DATA.get(&program)?;
+        let inst = idl.instructions.get(discriminator)?;
+        let mut cursor = body;
+        let mut obj = Map::new();
+        for field in &inst.args {
+            let value = decode_value(&field.ty, &mut cursor, idl)?;
+            obj.insert(field.name.clone(), value);
+        }
+        Some(Value::Object(obj))
+    }
+
+    fn decode_value(ty: &Type, data: &mut &[u8], idl: &ProgramIdl) -> Option<Value> {
+        Some(match ty {
+            Type::Bool => Value::Bool(read_u8(data)? != 0),
+            Type::U8 => Value::from(read_u8(data)?),
+            Type::U16 => Value::from(read_u16(data)?),
+            Type::U32 => Value::from(read_u32(data)?),
+            Type::U64 => Value::from(read_u64(data)?),
+            Type::U128 => Value::String(read_u128(data)?.to_string()),
+            Type::I8 => Value::from(read_i8(data)?),
+            Type::I16 => Value::from(read_i16(data)?),
+            Type::I32 => Value::from(read_i32(data)?),
+            Type::I64 => Value::from(read_i64(data)?),
+            Type::I128 => Value::String(read_i128(data)?.to_string()),
+            Type::F32 => {
+                let bytes = take(data, 4)?;
+                Value::from(f64::from(f32::from_le_bytes(bytes.try_into().ok()?)))
+            }
+            Type::F64 => {
+                let bytes = take(data, 8)?;
+                Value::from(f64::from_le_bytes(bytes.try_into().ok()?))
+            }
+            Type::String => {
+                let len = read_u32(data)? as usize;
+                let bytes = take(data, len)?;
+                Value::String(String::from_utf8(bytes.to_vec()).ok()?)
+            }
+            Type::Bytes => {
+                let len = read_u32(data)? as usize;
+                let bytes = take(data, len)?;
+                Value::String(solana_sdk::bs58::encode(bytes).into_string())
+            }
+            Type::Pubkey => {
+                let bytes = take(data, 32)?;
+                let arr: [u8; 32] = bytes.try_into().ok()?;
+                Value::String(Pubkey::from(arr).to_string())
+            }
+            Type::Vec(inner) => {
+                let len = read_u32(data)? as usize;
+                let mut arr = Vec::with_capacity(len);
+                for _ in 0..len {
+                    arr.push(decode_value(inner, data, idl)?);
+                }
+                Value::Array(arr)
+            }
+            Type::Option(inner) => match read_u8(data)? {
+                0 => Value::Null,
+                _ => decode_value(inner, data, idl)?,
+            },
+            Type::Array(inner, n) => {
+                let mut arr = Vec::with_capacity(*n);
+                for _ in 0..*n {
+                    arr.push(decode_value(inner, data, idl)?);
+                }
+                Value::Array(arr)
+            }
+            Type::Defined(name) => decode_typedef(idl.types.get(name)?, data, idl)?,
+        })
+    }
+
+    fn decode_typedef(def: &TypeDef, data: &mut &[u8], idl: &ProgramIdl) -> Option<Value> {
+        match def {
+            TypeDef::Struct(fields) => {
+                let mut obj = Map::new();
+                for field in fields {
+                    obj.insert(field.name.clone(), decode_value(&field.ty, data, idl)?);
+                }
+                Some(Value::Object(obj))
+            }
+            TypeDef::Enum(variants) => {
+                let tag = read_u8(data)? as usize;
+                let variant = variants.get(tag)?;
+                let mut obj = Map::new();
+                obj.insert("type".into(), Value::String(variant.name.clone()));
+                match &variant.fields {
+                    VariantFields::Unit => {}
+                    VariantFields::Named(fields) => {
+                        for field in fields {
+                            obj.insert(field.name.clone(), decode_value(&field.ty, data, idl)?);
+                        }
+                    }
+                    VariantFields::Tuple(types) => {
+                        let mut arr = Vec::with_capacity(types.len());
+                        for ty in types {
+                            arr.push(decode_value(ty, data, idl)?);
+                        }
+                        obj.insert("values".into(), Value::Array(arr));
+                    }
+                }
+                Some(Value::Object(obj))
+            }
+        }
+    }
+
+    fn take<'a>(data: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
+        if data.len() < n {
+            return None;
+        }
+        let (head, tail) = data.split_at(n);
+        *data = tail;
+        Some(head)
+    }
+
+    macro_rules! read_int {
+        ($name:ident, $ty:ty, $n:expr) => {
+            fn $name(data: &mut &[u8]) -> Option<$ty> {
+                let bytes = take(data, $n)?;
+                Some(<$ty>::from_le_bytes(bytes.try_into().ok()?))
+            }
+        };
+    }
+    read_int!(read_u8, u8, 1);
+    read_int!(read_u16, u16, 2);
+    read_int!(read_u32, u32, 4);
+    read_int!(read_u64, u64, 8);
+    read_int!(read_u128, u128, 16);
+    read_int!(read_i8, i8, 1);
+    read_int!(read_i16, i16, 2);
+    read_int!(read_i32, i32, 4);
+    read_int!(read_i64, i64, 8);
+    read_int!(read_i128, i128, 16);
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        /// Sanity check that every IDL we ship parses into a non-empty
+        /// instruction table — guards against a future IDL regen producing
+        /// JSON we can't read.
+        #[test]
+        fn every_idl_yields_methods() {
+            for (program, _) in IDLS {
+                let idl = IDL_DATA
+                    .get(program)
+                    .unwrap_or_else(|| panic!("no IDL parsed for {program:?}"));
+                assert!(
+                    !idl.instructions.is_empty(),
+                    "{program:?} parsed to an empty instruction table"
+                );
+            }
+        }
+
+        /// Spot-check one known instruction round-trip from the IDL.
+        #[test]
+        fn helium_sub_daos_resolves_known_instruction() {
+            assert_eq!(
+                method_name(
+                    KnownProgram::HeliumSubDaos,
+                    &[64, 233, 120, 46, 172, 83, 84, 163],
+                ),
+                Some("add_recent_proposal_to_dao_v0"),
+            );
+        }
+
+        /// Decode a tiny synthetic args body and confirm field names + values
+        /// come back as expected. Covers primitives + Option + Pubkey end to
+        /// end without depending on a specific real-world instruction.
+        #[test]
+        fn decoder_handles_primitives_and_option() {
+            let mut body: Vec<u8> = Vec::new();
+            body.extend_from_slice(&42u64.to_le_bytes()); // u64
+            body.push(1); // Option<u8> = Some(7)
+            body.push(7);
+            body.extend_from_slice(&[5u8; 32]); // Pubkey
+            let idl = ProgramIdl {
+                instructions: HashMap::new(),
+                types: HashMap::new(),
+            };
+            let fields = vec![
+                Field {
+                    name: "amount".into(),
+                    ty: Type::U64,
+                },
+                Field {
+                    name: "maybe".into(),
+                    ty: Type::Option(Box::new(Type::U8)),
+                },
+                Field {
+                    name: "key".into(),
+                    ty: Type::Pubkey,
+                },
+            ];
+            let mut cursor = body.as_slice();
+            let mut obj = serde_json::Map::new();
+            for f in &fields {
+                obj.insert(
+                    f.name.clone(),
+                    decode_value(&f.ty, &mut cursor, &idl).unwrap(),
+                );
+            }
+            assert_eq!(obj["amount"], Value::from(42u64));
+            assert_eq!(obj["maybe"], Value::from(7u8));
+            assert_eq!(
+                obj["key"].as_str().unwrap(),
+                Pubkey::from([5u8; 32]).to_string()
+            );
+        }
+
+        /// Vec<T> in Borsh is a `u32 LE length + N×T` payload. Verifies
+        /// the length-prefix read and per-element decode.
+        #[test]
+        fn decoder_handles_vec() {
+            let mut body: Vec<u8> = Vec::new();
+            body.extend_from_slice(&3u32.to_le_bytes());
+            body.extend_from_slice(&[1u8, 2, 3]);
+            let idl = ProgramIdl {
+                instructions: HashMap::new(),
+                types: HashMap::new(),
+            };
+            let mut cursor = body.as_slice();
+            let value = decode_value(&Type::Vec(Box::new(Type::U8)), &mut cursor, &idl).unwrap();
+            assert_eq!(value, Value::from(vec![1u8, 2, 3]));
+        }
+
+        /// Array<T, N> in Borsh has no length prefix — just N elements.
+        /// Regression: a swap to "u32 length first" would break here.
+        #[test]
+        fn decoder_handles_array() {
+            let body = vec![10u8, 20, 30, 40];
+            let idl = ProgramIdl {
+                instructions: HashMap::new(),
+                types: HashMap::new(),
+            };
+            let mut cursor = body.as_slice();
+            let value =
+                decode_value(&Type::Array(Box::new(Type::U8), 4), &mut cursor, &idl).unwrap();
+            assert_eq!(value, Value::from(vec![10u8, 20, 30, 40]));
+        }
+
+        /// `Type::Defined` resolves to a struct from the IDL's types map.
+        /// Decode the body field-by-field and confirm the JSON shape.
+        #[test]
+        fn decoder_handles_defined_struct() {
+            let mut types = HashMap::new();
+            types.insert(
+                "Inner".to_string(),
+                TypeDef::Struct(vec![
+                    Field {
+                        name: "a".into(),
+                        ty: Type::U8,
+                    },
+                    Field {
+                        name: "b".into(),
+                        ty: Type::U16,
+                    },
+                ]),
+            );
+            let idl = ProgramIdl {
+                instructions: HashMap::new(),
+                types,
+            };
+            let body = vec![7u8, 0xff, 0x00]; // u8=7, u16=255 LE
+            let mut cursor = body.as_slice();
+            let value =
+                decode_value(&Type::Defined("Inner".to_string()), &mut cursor, &idl).unwrap();
+            let obj = value.as_object().unwrap();
+            assert_eq!(obj["a"], Value::from(7u8));
+            assert_eq!(obj["b"], Value::from(255u16));
+        }
+
+        /// A truncated body must return `None` — the decode fails silently
+        /// at the inspect output (args omitted) rather than panicking or
+        /// decoding garbage. Test feeds a 4-byte buffer to a u64 read.
+        #[test]
+        fn decoder_short_buffer_returns_none() {
+            let body = vec![1u8, 2, 3, 4]; // Only 4 bytes, u64 needs 8.
+            let idl = ProgramIdl {
+                instructions: HashMap::new(),
+                types: HashMap::new(),
+            };
+            let mut cursor = body.as_slice();
+            assert!(decode_value(&Type::U64, &mut cursor, &idl).is_none());
+        }
+    }
+}

--- a/helium-lib/src/squads/cache.rs
+++ b/helium-lib/src/squads/cache.rs
@@ -1,0 +1,192 @@
+//! Persistent cache for vault → multisig pubkey mappings. The relationship
+//! is immutable (the multisig pubkey is a seed of the vault PDA), so cached
+//! entries never need invalidation. The cache is best-effort: a missing or
+//! unwritable file falls back to live resolution silently. A *corrupted*
+//! file is preserved (not overwritten) and surfaced via `tracing::warn!`,
+//! so a user can recover or hand-edit it instead of silently losing the
+//! whole cache because one byte was mangled.
+
+use crate::{
+    error::{EncodeError, Error},
+    keypair::Pubkey,
+};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+/// Resolves to the platform's standard cache directory:
+/// `~/Library/Caches/helium-wallet/...` on macOS,
+/// `~/.cache/helium-wallet/...` (or `$XDG_CACHE_HOME/helium-wallet/...`) on
+/// Linux, `%LOCALAPPDATA%\helium-wallet\...` on Windows.
+fn cache_path() -> Option<PathBuf> {
+    Some(
+        dirs::cache_dir()?
+            .join("helium-wallet")
+            .join("squads-vaults.json"),
+    )
+}
+
+/// Distinguish "no cache file yet" from "file exists but unreadable". The
+/// `Corrupted` arm carries a reason string so `tracing::warn!` can render
+/// the underlying io / parse error.
+enum LoadOutcome {
+    Loaded(BTreeMap<String, String>),
+    Missing,
+    Corrupted(String),
+}
+
+fn load(path: &Path) -> LoadOutcome {
+    let content = match fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return LoadOutcome::Missing,
+        Err(e) => return LoadOutcome::Corrupted(format!("io: {e}")),
+    };
+    match serde_json::from_str::<BTreeMap<String, String>>(&content) {
+        Ok(m) => LoadOutcome::Loaded(m),
+        Err(e) => LoadOutcome::Corrupted(format!("parse: {e}")),
+    }
+}
+
+pub fn lookup(vault: &Pubkey) -> Option<Pubkey> {
+    let path = cache_path()?;
+    lookup_at(&path, vault)
+}
+
+fn lookup_at(path: &Path, vault: &Pubkey) -> Option<Pubkey> {
+    match load(path) {
+        LoadOutcome::Loaded(entries) => entries
+            .get(&vault.to_string())
+            .and_then(|s| Pubkey::from_str(s).ok()),
+        LoadOutcome::Missing => None,
+        LoadOutcome::Corrupted(reason) => {
+            tracing::warn!(
+                cache = %path.display(),
+                reason = %reason,
+                "squads vault cache corrupted; ignoring this session",
+            );
+            None
+        }
+    }
+}
+
+pub fn store(vault: &Pubkey, multisig: &Pubkey) {
+    let Some(path) = cache_path() else {
+        return;
+    };
+    if let Err(error) = try_store_at(&path, vault, multisig) {
+        // Cache writes are best-effort, but surface the failure at
+        // debug level so a slow `--squads` workflow can be correlated
+        // with cache breakage (disk full, permissions, etc.) rather
+        // than re-running the 200-signature vault resolution scan
+        // every time.
+        tracing::debug!(
+            vault = %vault,
+            multisig = %multisig,
+            error = %error,
+            "squads vault cache write failed",
+        );
+    }
+}
+
+fn try_store_at(path: &Path, vault: &Pubkey, multisig: &Pubkey) -> Result<(), Error> {
+    let mut entries = match load(path) {
+        LoadOutcome::Loaded(m) => m,
+        LoadOutcome::Missing => BTreeMap::new(),
+        LoadOutcome::Corrupted(reason) => {
+            // Don't silently overwrite a corrupted cache — a single
+            // mangled byte shouldn't destroy a potentially large cache
+            // the user could otherwise inspect or recover. Skip the
+            // write; a healthy file from a future session will resume
+            // accumulating entries.
+            tracing::warn!(
+                cache = %path.display(),
+                reason = %reason,
+                "squads vault cache corrupted; refusing to overwrite",
+            );
+            return Ok(());
+        }
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(EncodeError::from)?;
+    }
+    entries.insert(vault.to_string(), multisig.to_string());
+    let serialized = serde_json::to_string_pretty(&entries).map_err(EncodeError::from)?;
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, serialized).map_err(EncodeError::from)?;
+    fs::rename(&tmp, path).map_err(EncodeError::from)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Round-trip: a `try_store_at` followed by `lookup_at` returns
+    /// the stored multisig. Pins the basic happy path.
+    #[test]
+    fn store_then_lookup_round_trip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("squads-vaults.json");
+        let vault = Pubkey::new_unique();
+        let multisig = Pubkey::new_unique();
+
+        try_store_at(&path, &vault, &multisig).expect("store");
+        assert_eq!(lookup_at(&path, &vault), Some(multisig));
+    }
+
+    /// Multiple `try_store_at` calls accumulate without losing prior
+    /// entries — `try_store_at` reads the existing file, merges the
+    /// new entry, and writes back.
+    #[test]
+    fn store_accumulates() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("squads-vaults.json");
+        let (v1, m1) = (Pubkey::new_unique(), Pubkey::new_unique());
+        let (v2, m2) = (Pubkey::new_unique(), Pubkey::new_unique());
+
+        try_store_at(&path, &v1, &m1).expect("store 1");
+        try_store_at(&path, &v2, &m2).expect("store 2");
+
+        assert_eq!(lookup_at(&path, &v1), Some(m1));
+        assert_eq!(lookup_at(&path, &v2), Some(m2));
+    }
+
+    /// A missing cache file is indistinguishable from "no entry" —
+    /// `lookup_at` returns None without panicking, and `try_store_at`
+    /// creates the file from scratch.
+    #[test]
+    fn missing_file_is_clean_state() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("squads-vaults.json");
+        assert_eq!(lookup_at(&path, &Pubkey::new_unique()), None);
+
+        let vault = Pubkey::new_unique();
+        let multisig = Pubkey::new_unique();
+        try_store_at(&path, &vault, &multisig).expect("store");
+        assert!(path.exists());
+        assert_eq!(lookup_at(&path, &vault), Some(multisig));
+    }
+
+    /// Corrupted JSON: `lookup_at` returns None (logging a warn), and
+    /// — critically — `try_store_at` refuses to overwrite the file.
+    /// Pins the "best-effort but never destroy" contract.
+    #[test]
+    fn corruption_preserves_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("squads-vaults.json");
+        let original = "{not valid json"; // intentionally truncated
+        fs::write(&path, original).unwrap();
+
+        // Lookups don't panic and don't return data.
+        assert_eq!(lookup_at(&path, &Pubkey::new_unique()), None);
+
+        // Store doesn't error (best-effort) but also doesn't
+        // overwrite — the corrupted contents survive for inspection.
+        try_store_at(&path, &Pubkey::new_unique(), &Pubkey::new_unique()).expect("store skips");
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+    }
+}

--- a/helium-lib/src/squads/error.rs
+++ b/helium-lib/src/squads/error.rs
@@ -1,0 +1,453 @@
+//! Squads-specific error types. Grouped into sub-enums per failure
+//! domain so call sites and tests can match at whichever level is most
+//! useful. Helper constructors on the outer `SquadsError` route to the
+//! right sub-enum so most call sites don't need to know the structure.
+//!
+//! Re-exported as `crate::squads::SquadsError` and friends via the
+//! parent module's `pub use self::error::*`.
+
+use crate::error::Error;
+use thiserror::Error;
+
+/// Closed set of fields that go through the Squads compactor's u8/u16
+/// length casts. Lifting these from `&'static str` to a typed enum
+/// gives compile-time enforcement at the ~13 `try_u8`/`try_u16` call
+/// sites — a typo (`"acount_keys"`) would silently change the error
+/// message under the string-based form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageField {
+    NumSigners,
+    NumWritableSigners,
+    NumWritableNonSigners,
+    AccountKeys,
+    Instructions,
+    InstructionAccounts,
+    InstructionDataLen,
+    LutCount,
+    LutWritableIndexes,
+    LutReadonlyIndexes,
+    LutResolvedIndex,
+    EphemeralSignerIndex,
+}
+
+impl std::fmt::Display for MessageField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::NumSigners => "num_signers",
+            Self::NumWritableSigners => "num_writable_signers",
+            Self::NumWritableNonSigners => "num_writable_non_signers",
+            Self::AccountKeys => "account_keys",
+            Self::Instructions => "instructions",
+            Self::InstructionAccounts => "instruction_accounts",
+            Self::InstructionDataLen => "instruction_data_len",
+            Self::LutCount => "lut_count",
+            Self::LutWritableIndexes => "lut_writable_indexes",
+            Self::LutReadonlyIndexes => "lut_readonly_indexes",
+            Self::LutResolvedIndex => "lut_resolved_index",
+            Self::EphemeralSignerIndex => "ephemeral_signer_index",
+        })
+    }
+}
+
+/// Index fields in `MultisigCompiledInstruction` validated against the
+/// resolved key list during inspect decode. Sibling to `MessageField`
+/// (which tracks wire-format *length* casts); separated to keep each
+/// enum's domain tight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompiledInstructionField {
+    ProgramIdIndex,
+    AccountIndex,
+}
+
+impl std::fmt::Display for CompiledInstructionField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::ProgramIdIndex => "program_id_index",
+            Self::AccountIndex => "account_index",
+        })
+    }
+}
+
+/// Kind of address the user passed when an `--index` is required.
+/// Closed set so the error message can't drift via typo and callers
+/// can build it from `Version` without a stringly-typed step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexKind {
+    V3Multisig,
+    V4Multisig,
+    Vault,
+}
+
+impl std::fmt::Display for IndexKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::V3Multisig => "v3 Multisig",
+            Self::V4Multisig => "v4 Multisig",
+            Self::Vault => "vault",
+        })
+    }
+}
+
+/// Squads multisig integration errors. Grouped into sub-enums per
+/// failure domain (RPC bypass, vault/multisig resolution, membership
+/// pre-flight, wire-format encoding) so call sites and tests can match
+/// at whichever level is most useful. Helper constructors route to the
+/// right sub-enum so most call sites don't need to know the structure.
+#[derive(Debug, Error)]
+pub enum SquadsError {
+    #[error("rpc: {0}")]
+    Rpc(#[from] SquadsRpcError),
+    #[error("resolution: {0}")]
+    Resolution(#[from] SquadsResolutionError),
+    #[error("membership: {0}")]
+    Membership(#[from] SquadsMembershipError),
+    #[error("encoding: {0}")]
+    Encoding(#[from] SquadsEncodingError),
+    /// Asset owner doesn't match the expected vault. The Squads-mode
+    /// asset/hotspot wrappers enforce this so a proposer can't ship
+    /// an un-executable proposal whose `leaf_owner` the vault can't
+    /// satisfy at execute time. Single-variant outlier — kept directly
+    /// on `SquadsError` rather than carved into a one-variant sub-enum.
+    #[error("asset {asset} is owned by {actual}, expected {expected}")]
+    WrongAssetOwner {
+        asset: solana_sdk::pubkey::Pubkey,
+        actual: solana_sdk::pubkey::Pubkey,
+        expected: solana_sdk::pubkey::Pubkey,
+    },
+}
+
+/// JSON-RPC failure modes the squads module surfaces from raw
+/// `getMultipleAccounts` calls. Distinct from the generic `Solana` /
+/// `solana_client::ClientError` shape because we bypass solana-client's
+/// decoder (its strict `rent_epoch: u64` deserializer trips on the
+/// rent-exempt sentinel).
+#[derive(Debug, Error)]
+pub enum SquadsRpcError {
+    /// JSON-RPC server returned an error response instead of a result.
+    /// Surfaces the server's own code + message rather than burying
+    /// them as "missing field `result`" deserialize errors.
+    #[error("{method} rpc error {code}: {message}")]
+    Server {
+        method: &'static str,
+        code: i64,
+        message: String,
+    },
+    /// JSON-RPC response had neither `result` nor `error` field.
+    /// Indicates a non-JSON-RPC-compliant server.
+    #[error("{method} response had neither result nor error field")]
+    Malformed { method: &'static str },
+}
+
+/// User-supplied address couldn't be resolved into the (multisig,
+/// transaction index) pair voter / executor / inspector commands need.
+#[derive(Debug, Error)]
+pub enum SquadsResolutionError {
+    /// User passed a multisig or vault PDA without `--index`.
+    #[error("{target} is a {kind} — pass --index <n> for the proposal")]
+    IndexRequired {
+        target: solana_sdk::pubkey::Pubkey,
+        kind: IndexKind,
+    },
+    /// Couldn't find a Squads transaction in the vault's recent
+    /// signatures during vault → multisig resolution.
+    #[error("could not resolve {vault} to a multisig from the last {scan_limit} signatures")]
+    VaultScanFailed {
+        vault: solana_sdk::pubkey::Pubkey,
+        scan_limit: usize,
+    },
+    /// A vault PDA resolved to a multisig, but that multisig's owner
+    /// isn't a Squads program. Distinct from the simple wrong-owner
+    /// case because the resolution went through the cache/scan path.
+    #[error("{address} resolved to {multisig} but owner is {got}, not Squads")]
+    OwnerMismatch {
+        address: solana_sdk::pubkey::Pubkey,
+        multisig: solana_sdk::pubkey::Pubkey,
+        got: solana_sdk::pubkey::Pubkey,
+    },
+}
+
+/// Wallet membership / permission failures, surfaced as pre-flight
+/// checks before submitting a vote / execute / propose to chain.
+#[derive(Debug, Error)]
+pub enum SquadsMembershipError {
+    /// Wallet's pubkey isn't in the multisig's member list. Surfaced
+    /// as a pre-flight check so the user gets a clear local error
+    /// rather than the on-chain program rejecting their submission.
+    #[error("{wallet} is not a member of multisig {multisig}")]
+    NotAMember {
+        wallet: solana_sdk::pubkey::Pubkey,
+        multisig: solana_sdk::pubkey::Pubkey,
+    },
+    /// Wallet is a member of the multisig but lacks the permission
+    /// the requested action needs (v4-only — v3 members have all
+    /// permissions implicitly).
+    #[error("{wallet} is a member of {multisig} but lacks {action} permission")]
+    MissingPermission {
+        wallet: solana_sdk::pubkey::Pubkey,
+        multisig: solana_sdk::pubkey::Pubkey,
+        action: &'static str,
+    },
+}
+
+/// Wire-format / on-chain encoding invariants the squads module
+/// enforces at compaction or decode time. Each variant captures a
+/// constraint that, if silently truncated or skipped, would either
+/// produce a corrupt on-chain proposal or render an opaque inspect
+/// view.
+#[derive(Debug, Error)]
+pub enum SquadsEncodingError {
+    /// User-supplied transaction index exceeds v3's u32 width.
+    #[error("v3 transaction index {index} exceeds u32 range")]
+    V3IndexOutOfRange { index: u64 },
+    /// On-chain `multisig.transaction_index + 1` would overflow u64.
+    /// Effectively never happens (would require ~10^19 proposals on
+    /// one multisig) but checked at the proposer side anyway.
+    #[error("multisig transaction_index overflow")]
+    TransactionIndexOverflow,
+    /// v3 execute_transaction's `account_list` u8 indexes overflowed.
+    /// 256+ unique accounts across all sub-instructions can't be
+    /// addressed by a single u8 index.
+    #[error("v3 execute remaining_accounts overflow ({count} > 255)")]
+    RemainingAccountsOverflow { count: usize },
+    /// Squads' inner-message wire format constrains many counts to u8
+    /// (account_keys, instructions, accounts-per-ix, LUTs) or u16
+    /// (instruction data length). Exceeding these limits would
+    /// silently truncate via `as u8`/`as u16` and produce a corrupted
+    /// `transaction_message` on-chain — surface a clean error at
+    /// compaction time instead.
+    #[error("squads message {field} {value} exceeds wire-format limit {limit}")]
+    MessageFieldOverflow {
+        field: MessageField,
+        value: usize,
+        limit: usize,
+    },
+    /// `MultisigCompiledInstruction.{program_id_index, account_indexes}`
+    /// pointed beyond the resolved key list — indicates a corrupt or
+    /// malformed on-chain proposal. Renders the proposal opaque rather
+    /// than silently falling back to `Pubkey::default()`.
+    #[error("compiled instruction {field} {index} out of range (resolved key count {count})")]
+    InstructionIndexOutOfRange {
+        field: CompiledInstructionField,
+        index: usize,
+        count: usize,
+    },
+    /// On-chain proposal status timestamp doesn't fit chrono's
+    /// representable range. Should never happen for a real Squads
+    /// proposal but flagged rather than silently rendered as 1970.
+    #[error("proposal status timestamp {timestamp} out of range")]
+    InvalidStatusTimestamp { timestamp: i64 },
+    /// LUT writable / readonly index referenced an entry past the end
+    /// of the resolved address table. Squads' on-chain handler reads
+    /// the same LUT but won't tolerate a missing slot — silently
+    /// dropping locally would produce a misaligned account list and
+    /// ship a tx the validator rejects (or, worse, mis-applies). Bail
+    /// loudly instead.
+    #[error("LUT {table} index {index} exceeds table size {size}")]
+    LutIndexOutOfRange {
+        table: solana_sdk::pubkey::Pubkey,
+        index: u8,
+        size: usize,
+    },
+}
+
+/// Lift each sub-enum into the workspace `Error` in one `?` step,
+/// alongside the `From<sub> -> SquadsError` derived by thiserror.
+macro_rules! sub_into_error {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl From<$ty> for Error {
+                fn from(value: $ty) -> Self {
+                    SquadsError::from(value).into()
+                }
+            }
+        )*
+    };
+}
+sub_into_error!(
+    SquadsRpcError,
+    SquadsResolutionError,
+    SquadsMembershipError,
+    SquadsEncodingError,
+);
+
+impl SquadsError {
+    pub fn rpc(method: &'static str, code: i64, message: impl Into<String>) -> Self {
+        SquadsRpcError::Server {
+            method,
+            code,
+            message: message.into(),
+        }
+        .into()
+    }
+
+    pub fn malformed_rpc(method: &'static str) -> Self {
+        SquadsRpcError::Malformed { method }.into()
+    }
+
+    pub fn index_required(target: solana_sdk::pubkey::Pubkey, kind: IndexKind) -> Self {
+        SquadsResolutionError::IndexRequired { target, kind }.into()
+    }
+
+    pub fn v3_index_out_of_range(index: u64) -> Self {
+        SquadsEncodingError::V3IndexOutOfRange { index }.into()
+    }
+
+    pub fn transaction_index_overflow() -> Self {
+        SquadsEncodingError::TransactionIndexOverflow.into()
+    }
+
+    pub fn vault_resolution_failed(vault: solana_sdk::pubkey::Pubkey, scan_limit: usize) -> Self {
+        SquadsResolutionError::VaultScanFailed { vault, scan_limit }.into()
+    }
+
+    pub fn remaining_accounts_overflow(count: usize) -> Self {
+        SquadsEncodingError::RemainingAccountsOverflow { count }.into()
+    }
+
+    pub fn resolved_owner_mismatch(
+        address: solana_sdk::pubkey::Pubkey,
+        multisig: solana_sdk::pubkey::Pubkey,
+        got: solana_sdk::pubkey::Pubkey,
+    ) -> Self {
+        SquadsResolutionError::OwnerMismatch {
+            address,
+            multisig,
+            got,
+        }
+        .into()
+    }
+
+    pub fn message_field_overflow(field: MessageField, value: usize, limit: usize) -> Self {
+        SquadsEncodingError::MessageFieldOverflow {
+            field,
+            value,
+            limit,
+        }
+        .into()
+    }
+
+    /// `u8::try_from` shorthand: route the overflow into a
+    /// `MessageFieldOverflow` with the correct limit (255).
+    pub fn try_u8(value: usize, field: MessageField) -> Result<u8, Self> {
+        u8::try_from(value)
+            .map_err(|_| Self::message_field_overflow(field, value, u8::MAX as usize))
+    }
+
+    /// `u16::try_from` shorthand for instruction data lengths.
+    pub fn try_u16(value: usize, field: MessageField) -> Result<u16, Self> {
+        u16::try_from(value)
+            .map_err(|_| Self::message_field_overflow(field, value, u16::MAX as usize))
+    }
+
+    pub fn instruction_index_out_of_range(
+        field: CompiledInstructionField,
+        index: usize,
+        count: usize,
+    ) -> Self {
+        SquadsEncodingError::InstructionIndexOutOfRange {
+            field,
+            index,
+            count,
+        }
+        .into()
+    }
+
+    pub fn invalid_status_timestamp(timestamp: i64) -> Self {
+        SquadsEncodingError::InvalidStatusTimestamp { timestamp }.into()
+    }
+
+    pub fn lut_index_out_of_range(
+        table: solana_sdk::pubkey::Pubkey,
+        index: u8,
+        size: usize,
+    ) -> Self {
+        SquadsEncodingError::LutIndexOutOfRange { table, index, size }.into()
+    }
+
+    pub fn not_a_member(
+        wallet: solana_sdk::pubkey::Pubkey,
+        multisig: solana_sdk::pubkey::Pubkey,
+    ) -> Self {
+        SquadsMembershipError::NotAMember { wallet, multisig }.into()
+    }
+
+    pub fn missing_permission(
+        wallet: solana_sdk::pubkey::Pubkey,
+        multisig: solana_sdk::pubkey::Pubkey,
+        action: &'static str,
+    ) -> Self {
+        SquadsMembershipError::MissingPermission {
+            wallet,
+            multisig,
+            action,
+        }
+        .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `try_u8` returns the cast on success and a structured
+    /// `MessageFieldOverflow` on overflow. Pins the field/value/limit
+    /// shape so a regression at any of the ~13 compactor call sites
+    /// surfaces here.
+    #[test]
+    fn try_u8_overflow() {
+        assert_eq!(
+            SquadsError::try_u8(255, MessageField::AccountKeys).unwrap(),
+            255u8,
+        );
+        let err = SquadsError::try_u8(256, MessageField::AccountKeys).unwrap_err();
+        match err {
+            SquadsError::Encoding(SquadsEncodingError::MessageFieldOverflow {
+                field,
+                value,
+                limit,
+            }) => {
+                assert_eq!(field, MessageField::AccountKeys);
+                assert_eq!(value, 256);
+                assert_eq!(limit, u8::MAX as usize);
+            }
+            other => panic!("expected MessageFieldOverflow, got {other:?}"),
+        }
+    }
+
+    /// `try_u16` mirrors the u8 helper for instruction data lengths.
+    #[test]
+    fn try_u16_overflow() {
+        assert_eq!(
+            SquadsError::try_u16(65_535, MessageField::InstructionDataLen).unwrap(),
+            u16::MAX,
+        );
+        let err = SquadsError::try_u16(65_536, MessageField::InstructionDataLen).unwrap_err();
+        match err {
+            SquadsError::Encoding(SquadsEncodingError::MessageFieldOverflow {
+                field,
+                value,
+                limit,
+            }) => {
+                assert_eq!(field, MessageField::InstructionDataLen);
+                assert_eq!(value, 65_536);
+                assert_eq!(limit, u16::MAX as usize);
+            }
+            other => panic!("expected MessageFieldOverflow, got {other:?}"),
+        }
+    }
+
+    /// `MessageField` Display output is part of error-message contract;
+    /// pin a couple of variants so accidental rename surfaces here.
+    #[test]
+    fn message_field_display_labels() {
+        assert_eq!(format!("{}", MessageField::AccountKeys), "account_keys");
+        assert_eq!(
+            format!("{}", MessageField::InstructionDataLen),
+            "instruction_data_len",
+        );
+        assert_eq!(
+            format!("{}", MessageField::LutResolvedIndex),
+            "lut_resolved_index",
+        );
+    }
+}

--- a/helium-lib/src/squads/mod.rs
+++ b/helium-lib/src/squads/mod.rs
@@ -1,0 +1,1144 @@
+//! Squads multisig integration.
+//!
+//! v4 types come from the upstream `squads-multisig-program` crate
+//! (`Squads-Protocol/v4` main). The crates.io release pins anchor 0.29 / solana
+//! 1.x and is incompatible; main branch is on anchor 0.32 / solana 2.2.
+//!
+//! v3 types come from the on-chain IDL via `declare_program!(squads_mpl)`. The
+//! `squads-mpl` crate is archived on a Solana 1.x toolchain incompatible with
+//! this workspace; the IDL path works because v3 doesn't use parameterized
+//! types (unlike v4's `SmallVec<L,T>`).
+
+mod cache;
+pub mod error;
+pub mod v3;
+pub mod v4;
+
+pub use self::error::{
+    CompiledInstructionField, IndexKind, MessageField, SquadsEncodingError, SquadsError,
+    SquadsMembershipError, SquadsResolutionError, SquadsRpcError,
+};
+
+use crate::{
+    client::SolanaRpcClient, error::DecodeError, error::Error, keypair::Pubkey,
+    programs::KnownProgram,
+};
+
+/// Multisig PDA — the Squads-program-owned account that holds member
+/// list, threshold, and `transaction_index`. Distinct newtype from
+/// `VaultKey` so a vault can't be silently passed where a multisig is
+/// expected (or vice versa) — both are `Pubkey` under the hood and the
+/// confusion is the kind of bug that grows roots before anyone notices.
+///
+/// `from_pubkey` is non-validating; the trusted source of `MultisigKey`
+/// values is `resolve_to_multisig`, which checks the on-chain owner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MultisigKey(Pubkey);
+
+/// Vault PDA — the system-program-owned authority that holds funds and
+/// signs CPI calls on behalf of the multisig. Distinct newtype from
+/// `MultisigKey` (see that type's doc).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VaultKey(Pubkey);
+
+macro_rules! impl_pubkey_newtype {
+    ($ty:ident) => {
+        impl $ty {
+            /// Wrap a pubkey, asserting it's the corresponding kind.
+            /// Non-validating; trusted internal sources only.
+            pub fn from_pubkey(pubkey: Pubkey) -> Self {
+                Self(pubkey)
+            }
+            /// Borrow the wrapped pubkey for APIs that take `&Pubkey`.
+            pub fn as_pubkey(&self) -> &Pubkey {
+                &self.0
+            }
+            /// Unwrap into the bare pubkey. Use when crossing into
+            /// helium-lib instruction builders that work with Pubkey.
+            pub fn into_pubkey(self) -> Pubkey {
+                self.0
+            }
+        }
+        impl AsRef<Pubkey> for $ty {
+            fn as_ref(&self) -> &Pubkey {
+                &self.0
+            }
+        }
+        impl AsRef<[u8]> for $ty {
+            fn as_ref(&self) -> &[u8] {
+                self.0.as_ref()
+            }
+        }
+        impl std::fmt::Display for $ty {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+        impl serde::Serialize for $ty {
+            fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+                crate::keypair::serde_pubkey::serialize(&self.0, s)
+            }
+        }
+    };
+}
+
+impl_pubkey_newtype!(MultisigKey);
+impl_pubkey_newtype!(VaultKey);
+
+/// Either-version structured view of a proposal returned by the top-level
+/// `get_proposal_info`. The internally-tagged `version` field makes the
+/// V3/V4 distinction explicit in the JSON output rather than relying on
+/// field-set differences between the two arms (which a future shape
+/// change could quietly invalidate). Downstream consumers can pivot on
+/// `version: "v3" | "v4"`.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(tag = "version", rename_all = "lowercase")]
+pub enum ProposalView {
+    V3(v3::ProposalInfo),
+    V4(v4::ProposalInfo),
+}
+
+/// At-a-glance signals a reviewer needs to triage a proposal: did it hit
+/// threshold, has the multisig config changed since this proposal was
+/// created (which silently invalidates it), what programs does it touch,
+/// and is anything unrecognized. v3 always reports `stale: false` — v3
+/// doesn't record the multisig change index on its transaction accounts
+/// so we can't detect staleness from the transaction alone.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ProposalSummary {
+    /// `"3/3"` etc. — votes-approved / threshold required.
+    pub approvals: String,
+    /// True if v4 `transaction_index <= multisig.stale_transaction_index`.
+    /// Always false on v3 (see struct doc).
+    pub stale: bool,
+    /// Deduped, in-order list of programs the proposal will invoke. Maps
+    /// to friendly names for known programs; unknown program IDs go to
+    /// `unknown_programs` instead.
+    pub programs: Vec<KnownProgram>,
+    /// Program IDs not in the recognized set. Any non-empty value here is
+    /// a red flag worth investigating before approving.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub unknown_programs: Vec<String>,
+    /// Count of instructions where the program ships an IDL but the
+    /// instruction's discriminator wasn't found in it. Either the shipped
+    /// IDL is stale (re-run `gen_idl.sh`) or the proposal calls an
+    /// instruction that's been removed from the program. Either way,
+    /// non-zero is a flag to investigate before approving.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub unknown_methods: u32,
+}
+
+fn is_zero(n: &u32) -> bool {
+    *n == 0
+}
+
+/// Build a `ProposalSummary` from a fully-decoded instruction list and the
+/// version-specific approvals/stale signals. Used by both v3 and v4 paths
+/// so the summary shape stays consistent.
+pub(crate) fn build_summary(
+    approvals: String,
+    stale: bool,
+    instructions: &[InstructionInfo],
+) -> ProposalSummary {
+    let mut programs: Vec<KnownProgram> = Vec::new();
+    let mut unknown_programs: Vec<String> = Vec::new();
+    let mut unknown_methods: u32 = 0;
+    for ix in instructions {
+        match ix.program {
+            Some(kp) => {
+                if !programs.contains(&kp) {
+                    programs.push(kp);
+                }
+                if ix.method.is_none() && kp.has_idl() {
+                    unknown_methods += 1;
+                }
+            }
+            None => {
+                let id = ix.program_id.to_string();
+                if !unknown_programs.contains(&id) {
+                    unknown_programs.push(id);
+                }
+            }
+        }
+    }
+    ProposalSummary {
+        approvals,
+        stale,
+        programs,
+        unknown_programs,
+        unknown_methods,
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ProposalVotes {
+    pub approved: usize,
+    pub rejected: usize,
+    pub cancelled: usize,
+}
+
+/// One row in the output of `list_open_proposals` — minimal context to
+/// triage and feed back into `inspect`/`approve`/etc. Inner instructions
+/// aren't decoded here; reach for `inspect <transaction>` when you need
+/// to verify what a proposal will do.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ProposalListEntry {
+    pub index: u64,
+    /// Transaction PDA — pass to `inspect`/`approve`/`reject`/`cancel`/
+    /// `execute` to act on the proposal without re-deriving from index.
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub transaction: Pubkey,
+    /// Lowercase status: `draft`, `active`, `approved` (v4),
+    /// `execute_ready` (v3), `executing` (v4 transient).
+    pub status: &'static str,
+    /// ISO8601 timestamp of the current status (v4 only — v3
+    /// `MsTransaction` doesn't carry per-status timestamps). Lets a
+    /// reviewer eyeball the age of a still-pending proposal without
+    /// running `inspect`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    pub votes: ProposalVotes,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct InstructionInfo {
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub program_id: Pubkey,
+    /// Recognized program identity, when known. `None` falls back to
+    /// displaying the raw `program_id`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub program: Option<KnownProgram>,
+    /// Snake-cased method name resolved from the program's IDL when both
+    /// the program is recognized and the discriminator matches a known
+    /// instruction. The raw `discriminator` stays alongside as a binary
+    /// identity check.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<&'static str>,
+    /// Decoded args as structured JSON, populated when the program ships
+    /// an IDL we can decode AND the body bytes round-trip successfully
+    /// against the instruction's args definition. Field names and shapes
+    /// come straight from the IDL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<serde_json::Value>,
+    pub accounts: Vec<InstructionAccountRef>,
+    pub data_len: usize,
+    /// Anchor instruction discriminator (first 8 data bytes), base58-encoded.
+    /// Useful for matching against known program IDLs.
+    pub discriminator: Option<String>,
+    pub data_b58: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct InstructionAccountRef {
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub pubkey: Pubkey,
+    pub writable: bool,
+    pub signer: bool,
+}
+use futures::stream::{self, StreamExt};
+use serde::Serialize;
+use solana_client::rpc_client::GetConfirmedSignaturesForAddress2Config;
+use solana_sdk::{commitment_config::CommitmentConfig, signature::Signature};
+use solana_transaction_status::{
+    option_serializer::OptionSerializer, UiLoadedAddresses, UiTransactionEncoding,
+};
+use std::{collections::HashSet, str::FromStr};
+
+/// Squads program version controlling a multisig.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Version {
+    V3,
+    V4,
+}
+
+impl From<Version> for IndexKind {
+    fn from(v: Version) -> Self {
+        match v {
+            Version::V3 => Self::V3Multisig,
+            Version::V4 => Self::V4Multisig,
+        }
+    }
+}
+
+/// First 8 bytes of an account's data as an Anchor discriminator
+/// array. `None` if the slice is shorter than 8 bytes. Used by every
+/// Squads decode path that branches on the discriminator.
+pub(crate) fn read_discriminator(data: &[u8]) -> Option<[u8; 8]> {
+    data.get(..8)?.try_into().ok()
+}
+
+/// Unified multisig summary across v3 and v4.
+#[derive(Debug, Clone, Serialize)]
+pub struct MultisigInfo {
+    pub address: MultisigKey,
+    pub version: Version,
+    pub threshold: u16,
+    /// v4: last transaction index. v3: same field, widened to u64.
+    pub transaction_index: u64,
+    pub members: Vec<MemberInfo>,
+    /// Set when `address` was originally passed in as a vault PDA and we
+    /// resolved it to its parent multisig.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub resolved_from_vault: Option<VaultKey>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MemberInfo {
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub key: Pubkey,
+    pub permissions: MemberPermissions,
+}
+
+/// Permissions a member has on a multisig. v3 has no per-member permissions —
+/// all listed keys can do everything — so v3 members report all three as true.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub struct MemberPermissions {
+    pub propose: bool,
+    pub vote: bool,
+    pub execute: bool,
+}
+
+impl MemberPermissions {
+    pub const ALL: Self = Self {
+        propose: true,
+        vote: true,
+        execute: true,
+    };
+
+    /// Encode as Squads' on-chain `Permissions::mask` byte. Upstream
+    /// `Permission` discriminants ARE the bit values
+    /// (`Initiate = 1<<0`, `Vote = 1<<1`, `Execute = 1<<2`), so we
+    /// cast and OR directly — no allocations, no duplicated constants.
+    pub fn to_mask(self) -> u8 {
+        use squads_multisig_program::state::Permission;
+        let mut mask = 0u8;
+        if self.propose {
+            mask |= Permission::Initiate as u8;
+        }
+        if self.vote {
+            mask |= Permission::Vote as u8;
+        }
+        if self.execute {
+            mask |= Permission::Execute as u8;
+        }
+        mask
+    }
+
+    /// Decode from Squads' on-chain `Permissions::mask` byte. Bits
+    /// outside the recognized set are ignored — surfacing them would
+    /// force every caller to handle a hypothetical.
+    pub fn from_mask(mask: u8) -> Self {
+        use squads_multisig_program::state::Permission;
+        let bit = |p: Permission| mask & (p as u8) != 0;
+        Self {
+            propose: bit(Permission::Initiate),
+            vote: bit(Permission::Vote),
+            execute: bit(Permission::Execute),
+        }
+    }
+}
+
+/// Action the wallet is about to take on a multisig. Used to map a
+/// CLI command (`squads approve`, `transfer --squads ...`, etc.) to
+/// the per-member permission bit Squads' on-chain program will
+/// validate, so we can pre-flight the check locally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemberAction {
+    /// Cast a vote on a proposal — `proposal_approve`,
+    /// `proposal_reject`, `proposal_cancel` (v4) or the v3 equivalents.
+    Vote,
+    /// Execute an approved proposal — `vault_transaction_execute`
+    /// (v4) or `execute_transaction` (v3).
+    Execute,
+    /// Create a new proposal — `vault_transaction_create` +
+    /// `proposal_create` (v4 only). v3's `create_transaction` is
+    /// covered by the same Initiate permission.
+    Initiate,
+}
+
+impl MemberAction {
+    /// Stable label for error messages.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Vote => "vote",
+            Self::Execute => "execute",
+            Self::Initiate => "initiate",
+        }
+    }
+
+    /// True when `perms` grant this action. v3 members report
+    /// permissions as all-true so v3 calls always pass.
+    pub fn is_granted(self, perms: &MemberPermissions) -> bool {
+        match self {
+            Self::Vote => perms.vote,
+            Self::Execute => perms.execute,
+            Self::Initiate => perms.propose,
+        }
+    }
+}
+
+/// Pure membership + permission check against a fetched
+/// `MultisigInfo`. Split out from `check_member_permission` so the
+/// dispatch can be unit-tested without RPC.
+pub fn validate_membership(
+    info: &MultisigInfo,
+    wallet: &Pubkey,
+    action: MemberAction,
+) -> Result<(), Error> {
+    let entry = info.members.iter().find(|m| m.key == *wallet);
+    let multisig_pubkey = info.address.into_pubkey();
+    match entry {
+        None => Err(SquadsError::not_a_member(*wallet, multisig_pubkey).into()),
+        Some(m) if !action.is_granted(&m.permissions) => {
+            Err(SquadsError::missing_permission(*wallet, multisig_pubkey, action.label()).into())
+        }
+        Some(_) => Ok(()),
+    }
+}
+
+/// Pre-flight check: verify the wallet's pubkey is a member of the
+/// multisig and holds the permission `action` requires. Catches "wrong
+/// wallet" and "missing permission" before the user pays simulation /
+/// compute fees on a doomed submission. Costs one extra RPC call
+/// (the multisig account); call sites already have the multisig
+/// pubkey from `resolve_proposal_target` or `squads_vault`.
+pub async fn check_member_permission<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig: &MultisigKey,
+    wallet: &Pubkey,
+    action: MemberAction,
+) -> Result<(), Error> {
+    let info = get_multisig_info(client, multisig.as_pubkey()).await?;
+    validate_membership(&info, wallet, action)
+}
+
+/// Fetch a multisig and return a unified summary. If `address` is a v3 or v4
+/// Multisig PDA, it's decoded directly. If it's a system-owned PDA (typically
+/// a Squads vault, which is what users normally see in URLs and explorers),
+/// we look it up in the local vault cache and fall back to scanning recent
+/// transactions; either way we recurse on the resolved multisig.
+pub async fn get_multisig_info<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    address: &Pubkey,
+) -> Result<MultisigInfo, Error> {
+    // `resolve` returns both the resolved multisig and the original
+    // vault (if the input was a vault PDA), so we don't pay an extra
+    // `get_account(address)` to figure out what the input was.
+    let Resolution {
+        multisig,
+        vault: resolved_from,
+    } = resolve(client, address).await?;
+    let account = client.as_ref().get_account(multisig.as_pubkey()).await?;
+    match account.owner {
+        v4::PROGRAM_ID => v4::decode_multisig(multisig, &account.data, resolved_from),
+        v3::PROGRAM_ID => v3::decode_multisig(multisig, &account.data, resolved_from),
+        other => Err(
+            SquadsError::resolved_owner_mismatch(*address, multisig.into_pubkey(), other).into(),
+        ),
+    }
+}
+
+/// (Version, multisig, transaction_index) triple used by the voter-side
+/// CLI commands. Built by `resolve_proposal_target` from the same
+/// targets that `inspect_target` accepts. `multisig` is typed as
+/// `MultisigKey` so downstream ix builders can't be passed a vault PDA
+/// by accident.
+#[derive(Debug, Clone, Copy)]
+pub struct ProposalTarget {
+    pub version: Version,
+    pub multisig: MultisigKey,
+    pub index: u64,
+}
+
+/// Identification of a Squads-relevant address by its owner and (for
+/// Squads-owned accounts) the discriminator at the head of its body.
+/// Drives the dispatch shared by `resolve_proposal_target` and
+/// `inspect_target`.
+#[derive(Debug)]
+enum TargetKind {
+    /// A v3 or v4 transaction-bearing account that self-identifies its
+    /// multisig and index — Proposal / VaultTransaction /
+    /// ConfigTransaction / Batch on v4, MsTransaction on v3.
+    Transaction {
+        version: Version,
+        multisig: MultisigKey,
+        index: u64,
+    },
+    /// A Squads multisig PDA — caller must supply the index out of band.
+    Multisig { version: Version },
+    /// A vault / authority PDA (system-owned) — caller must supply
+    /// both the index and resolve the multisig separately.
+    Vault,
+}
+
+fn classify_target(target: &Pubkey, owner: &Pubkey, data: &[u8]) -> Result<TargetKind, Error> {
+    if *owner == v4::PROGRAM_ID {
+        Ok(match v4::extract_target(target, data)? {
+            Some((multisig, index)) => TargetKind::Transaction {
+                version: Version::V4,
+                multisig: MultisigKey::from_pubkey(multisig),
+                index,
+            },
+            None => TargetKind::Multisig {
+                version: Version::V4,
+            },
+        })
+    } else if *owner == v3::PROGRAM_ID {
+        Ok(match v3::extract_target(target, data)? {
+            Some((multisig, index)) => TargetKind::Transaction {
+                version: Version::V3,
+                multisig: MultisigKey::from_pubkey(multisig),
+                index,
+            },
+            None => TargetKind::Multisig {
+                version: Version::V3,
+            },
+        })
+    } else if *owner == solana_sdk::system_program::ID {
+        Ok(TargetKind::Vault)
+    } else {
+        Err(DecodeError::wrong_owner(target, "Squads", owner).into())
+    }
+}
+
+fn index_required(target: &Pubkey, kind: IndexKind) -> Error {
+    SquadsError::index_required(*target, kind).into()
+}
+
+/// Resolve any user-provided pointer to a proposal — multisig+index,
+/// vault+index, or a self-identifying transaction/proposal PDA — into
+/// the (version, multisig, index) triple needed by voter-side
+/// instruction builders.
+pub async fn resolve_proposal_target<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    target: &Pubkey,
+    index: Option<u64>,
+) -> Result<ProposalTarget, Error> {
+    let account = client.as_ref().get_account(target).await?;
+    match classify_target(target, &account.owner, &account.data)? {
+        TargetKind::Transaction {
+            version,
+            multisig,
+            index,
+        } => Ok(ProposalTarget {
+            version,
+            multisig,
+            index,
+        }),
+        TargetKind::Multisig { version } => {
+            let index = index.ok_or_else(|| index_required(target, IndexKind::from(version)))?;
+            Ok(ProposalTarget {
+                version,
+                multisig: MultisigKey::from_pubkey(*target),
+                index,
+            })
+        }
+        TargetKind::Vault => {
+            let index = index.ok_or_else(|| index_required(target, IndexKind::Vault))?;
+            let multisig = resolve_to_multisig(client, target).await?;
+            let ms_account = client.as_ref().get_account(multisig.as_pubkey()).await?;
+            let version = match ms_account.owner {
+                o if o == v4::PROGRAM_ID => Version::V4,
+                o if o == v3::PROGRAM_ID => Version::V3,
+                other => {
+                    return Err(
+                        DecodeError::wrong_owner(multisig.as_pubkey(), "Squads", &other).into(),
+                    )
+                }
+            };
+            Ok(ProposalTarget {
+                version,
+                multisig,
+                index,
+            })
+        }
+    }
+}
+
+/// Fetch and decode a proposal given any one of:
+/// - a multisig PDA + explicit index (v3 or v4),
+/// - a vault PDA + explicit index (resolved through cache/scan to multisig),
+/// - a transaction PDA on its own (v4 VaultTransaction, ConfigTransaction,
+///   Batch, or Proposal; v3 MsTransaction) — the multisig and index are
+///   read from the account body.
+pub async fn inspect_target<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    target: &Pubkey,
+    index: Option<u64>,
+) -> Result<ProposalView, Error> {
+    if let Some(index) = index {
+        return get_proposal_info(client, target, index).await;
+    }
+    let account = client.as_ref().get_account(target).await?;
+    let (multisig, idx) = match classify_target(target, &account.owner, &account.data)? {
+        TargetKind::Transaction {
+            multisig, index, ..
+        } => (multisig, index),
+        TargetKind::Multisig { version } => {
+            return Err(index_required(target, IndexKind::from(version)));
+        }
+        TargetKind::Vault => return Err(index_required(target, IndexKind::Vault)),
+    };
+    get_proposal_info(client, multisig.as_pubkey(), idx).await
+}
+
+/// Fetch and decode a proposal at the given transaction index, dispatching
+/// to v3 or v4 based on the multisig's program owner. Vault addresses
+/// resolve through the same cache + scan path as `get_multisig_info`.
+///
+/// `transaction_index` is u64 to match what users see in Squads UIs;
+/// values outside u32 range are rejected for v3 multisigs (where the
+/// underlying field is u32).
+pub async fn get_proposal_info<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig_or_vault: &Pubkey,
+    transaction_index: u64,
+) -> Result<ProposalView, Error> {
+    let multisig = resolve_to_multisig(client, multisig_or_vault).await?;
+    let account = client.as_ref().get_account(multisig.as_pubkey()).await?;
+    match account.owner {
+        v4::PROGRAM_ID => v4::get_proposal_info(client, multisig.as_pubkey(), transaction_index)
+            .await
+            .map(ProposalView::V4),
+        v3::PROGRAM_ID => {
+            let index_u32 = u32::try_from(transaction_index)
+                .map_err(|_| SquadsError::v3_index_out_of_range(transaction_index))?;
+            v3::get_proposal_info(client, multisig.as_pubkey(), index_u32)
+                .await
+                .map(ProposalView::V3)
+        }
+        owner => Err(DecodeError::wrong_owner(multisig.as_pubkey(), "Squads", &owner).into()),
+    }
+}
+
+/// List all open proposals on a multisig — anything still subject to
+/// member action: voting (Draft/Active) or execution (v4 Approved, v3
+/// ExecuteReady). Finalized states (Executed, Rejected, Cancelled) are
+/// not returned. v4 stale proposals (index ≤ `stale_transaction_index`)
+/// are skipped — once the multisig config changes, those can no longer
+/// be voted on or executed.
+pub async fn list_open_proposals<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig_or_vault: &Pubkey,
+) -> Result<Vec<ProposalListEntry>, Error> {
+    let multisig = resolve_to_multisig(client, multisig_or_vault).await?;
+    let account = client.as_ref().get_account(multisig.as_pubkey()).await?;
+    match account.owner {
+        v4::PROGRAM_ID => v4::list_open_proposals(client, &multisig).await,
+        v3::PROGRAM_ID => v3::list_open_proposals(client, &multisig).await,
+        owner => Err(DecodeError::wrong_owner(multisig.as_pubkey(), "Squads", &owner).into()),
+    }
+}
+
+/// Result of resolving any Squads-related address to its multisig.
+/// `vault` is set only when `address` was itself a vault PDA — for
+/// multisig or transaction-bearing inputs, only the multisig matters
+/// and `vault` is `None`.
+pub struct Resolution {
+    pub multisig: MultisigKey,
+    pub vault: Option<VaultKey>,
+}
+
+/// Resolve a multisig pubkey from any Squads-related address: a
+/// multisig PDA, a vault PDA, or a transaction-bearing account (v4
+/// Proposal / VaultTransaction / ConfigTransaction / Batch, v3
+/// MsTransaction). Multisig PDAs return themselves; vault PDAs go
+/// through the local cache + fallback recent-transaction scan;
+/// transaction-bearing accounts have the multisig in their body and
+/// are decoded directly via `extract_target`.
+pub async fn resolve_to_multisig<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    address: &Pubkey,
+) -> Result<MultisigKey, Error> {
+    Ok(resolve(client, address).await?.multisig)
+}
+
+/// Sibling of `resolve_to_multisig` that also surfaces the original
+/// vault PDA when the input was a vault. Callers that need both
+/// (e.g. `get_multisig_info`) avoid a second `get_account(address)`
+/// to reclassify the input.
+pub async fn resolve<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    address: &Pubkey,
+) -> Result<Resolution, Error> {
+    let account = client.as_ref().get_account(address).await?;
+    let multisig_only = |multisig: Pubkey| Resolution {
+        multisig: MultisigKey::from_pubkey(multisig),
+        vault: None,
+    };
+    match account.owner {
+        v4::PROGRAM_ID => match v4::extract_target(address, &account.data)? {
+            Some((multisig, _index)) => Ok(multisig_only(multisig)),
+            None => Ok(multisig_only(*address)),
+        },
+        v3::PROGRAM_ID => match v3::extract_target(address, &account.data)? {
+            Some((multisig, _index)) => Ok(multisig_only(multisig)),
+            None => Ok(multisig_only(*address)),
+        },
+        owner if owner == solana_sdk::system_program::ID => {
+            let multisig = match cache::lookup(address) {
+                Some(cached) => cached,
+                None => {
+                    let resolved = resolve_vault_to_multisig(client, address).await?;
+                    cache::store(address, &resolved);
+                    resolved
+                }
+            };
+            Ok(Resolution {
+                multisig: MultisigKey::from_pubkey(multisig),
+                vault: Some(VaultKey::from_pubkey(*address)),
+            })
+        }
+        other => Err(DecodeError::wrong_owner(address, "Squads multisig or vault", &other).into()),
+    }
+}
+
+/// Maximum number of recent signatures to scan when resolving a vault. Most
+/// active vaults have a Squads transaction execution within the latest few
+/// hundred signatures; idle vaults that only receive deposits may need more,
+/// but this cap keeps the resolution bounded.
+const VAULT_RESOLUTION_SCAN_LIMIT: usize = 200;
+
+/// Per-call upper bound for `getMultipleAccounts`. Most public Solana RPC
+/// providers reject requests with more than 100 keys; we chunk every batch
+/// fetch in the squads module by this constant.
+pub(crate) const MAX_GET_ACCOUNTS: usize = 100;
+
+/// Concurrency for transaction fetches during vault resolution. RPC providers
+/// vary in throughput; 20 is a balance between throughput and rate-limiting.
+const VAULT_RESOLUTION_FETCH_CONCURRENCY: usize = 20;
+
+/// Find the multisig that owns `vault` by scanning its recent transactions
+/// for one that invoked a Squads program, then identifying the Multisig PDA
+/// among the transaction's accounts by discriminator. Transactions are
+/// fetched in parallel and candidate accounts are checked in batches via
+/// `getMultipleAccounts`.
+async fn resolve_vault_to_multisig<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    vault: &Pubkey,
+) -> Result<Pubkey, Error> {
+    let rpc = client.as_ref();
+    let signatures = rpc
+        .get_signatures_for_address_with_config(
+            vault,
+            GetConfirmedSignaturesForAddress2Config {
+                limit: Some(VAULT_RESOLUTION_SCAN_LIMIT),
+                commitment: Some(CommitmentConfig::confirmed()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let signatures: Vec<Signature> = signatures
+        .into_iter()
+        .filter(|s| s.err.is_none())
+        .filter_map(|s| Signature::from_str(&s.signature).ok())
+        .collect();
+
+    let txn_config = solana_client::rpc_config::RpcTransactionConfig {
+        encoding: Some(UiTransactionEncoding::Json),
+        commitment: Some(CommitmentConfig::confirmed()),
+        max_supported_transaction_version: Some(0),
+    };
+
+    let mut tried: HashSet<Pubkey> = HashSet::new();
+    let mut tx_stream = stream::iter(signatures)
+        .map(|sig| async move { rpc.get_transaction_with_config(&sig, txn_config).await })
+        .buffered(VAULT_RESOLUTION_FETCH_CONCURRENCY);
+
+    while let Some(txn_result) = tx_stream.next().await {
+        let Ok(txn) = txn_result else { continue };
+        let keys = collect_account_keys(&txn);
+        // Skip transactions that don't reference a Squads program at all —
+        // they can't contain the multisig.
+        if !keys
+            .iter()
+            .any(|k| *k == v3::PROGRAM_ID || *k == v4::PROGRAM_ID)
+        {
+            continue;
+        }
+
+        let candidates: Vec<Pubkey> = keys
+            .into_iter()
+            .filter(|k| !is_known_non_multisig(k, vault))
+            .filter(|k| tried.insert(*k))
+            .collect();
+        if candidates.is_empty() {
+            continue;
+        }
+
+        // Chunk to the 100-key `getMultipleAccounts` limit most public
+        // RPC providers enforce. A LUT-heavy transaction can plausibly
+        // produce >100 candidates after the filter; a single-shot call
+        // would be rejected mid-resolution.
+        for chunk in candidates.chunks(MAX_GET_ACCOUNTS) {
+            let accounts = raw_get_multiple_accounts(&rpc.url(), chunk).await?;
+            for (candidate, account) in chunk.iter().zip(accounts) {
+                let Some(account) = account else { continue };
+                if v4::is_multisig_account(&account.owner, &account.data)
+                    || v3::is_multisig_account(&account.owner, &account.data)
+                {
+                    return Ok(*candidate);
+                }
+            }
+        }
+    }
+
+    Err(SquadsError::vault_resolution_failed(*vault, VAULT_RESOLUTION_SCAN_LIMIT).into())
+}
+
+/// Pre-filter candidates that obviously can't be the multisig: the vault
+/// itself and any program / common SPL utility account we already recognize.
+/// Cuts wasted `getMultipleAccounts` work — multisig PDAs are never one of
+/// these.
+fn is_known_non_multisig(key: &Pubkey, vault: &Pubkey) -> bool {
+    *key == *vault || KnownProgram::from_pubkey(key).is_some()
+}
+
+/// Just enough of an account to check ownership and discriminator.
+pub(crate) struct RawAccount {
+    pub owner: Pubkey,
+    pub data: Vec<u8>,
+}
+
+/// `getMultipleAccounts` via raw JSON-RPC, bypassing solana-client's response
+/// decoder. The official decoder fails on accounts with `rent_epoch = u64::MAX`
+/// (the rent-exempt sentinel) because the RPC encodes that value as a JSON
+/// float that overflows the strict u64 deserializer. We don't need
+/// `rent_epoch` at all, so we parse only the fields we use.
+pub(crate) async fn raw_get_multiple_accounts(
+    rpc_url: &str,
+    keys: &[Pubkey],
+) -> Result<Vec<Option<RawAccount>>, Error> {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+
+    #[derive(serde::Deserialize)]
+    struct AccountInfo {
+        owner: String,
+        data: (String, String), // (base64 payload, encoding tag)
+    }
+    #[derive(serde::Deserialize)]
+    struct Value {
+        value: Vec<Option<AccountInfo>>,
+    }
+    #[derive(serde::Deserialize)]
+    struct RpcError {
+        code: i64,
+        message: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct Response {
+        // Successful responses carry `result`; error responses carry
+        // `error` instead. Both fields are optional so we can surface
+        // the RPC's own error message rather than decoding-only fields
+        // and bubbling up "missing field `result`".
+        result: Option<Value>,
+        error: Option<RpcError>,
+    }
+
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getMultipleAccounts",
+        "params": [
+            keys.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            { "encoding": "base64", "commitment": "confirmed" },
+        ],
+    });
+    let resp: Response = reqwest::Client::new()
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    if let Some(err) = resp.error {
+        return Err(SquadsError::rpc("getMultipleAccounts", err.code, err.message).into());
+    }
+    let value = resp
+        .result
+        .ok_or_else(|| SquadsError::malformed_rpc("getMultipleAccounts"))?;
+
+    value
+        .value
+        .into_iter()
+        .map(|maybe| match maybe {
+            None => Ok(None),
+            Some(info) => {
+                let owner = Pubkey::from_str(&info.owner).map_err(DecodeError::from)?;
+                let data = STANDARD.decode(info.data.0).map_err(DecodeError::from)?;
+                Ok(Some(RawAccount { owner, data }))
+            }
+        })
+        .collect()
+}
+
+/// All account keys involved in a transaction, including those resolved via
+/// address lookup tables (which `VersionedTransaction::static_account_keys`
+/// alone misses).
+fn collect_account_keys(
+    txn: &solana_transaction_status::EncodedConfirmedTransactionWithStatusMeta,
+) -> Vec<Pubkey> {
+    let mut out = Vec::new();
+    if let solana_transaction_status::EncodedTransaction::Json(ui_tx) = &txn.transaction.transaction
+    {
+        if let solana_transaction_status::UiMessage::Raw(raw) = &ui_tx.message {
+            out.extend(
+                raw.account_keys
+                    .iter()
+                    .filter_map(|s| Pubkey::from_str(s).ok()),
+            );
+        }
+    }
+    if let Some(meta) = &txn.transaction.meta {
+        if let OptionSerializer::Some(UiLoadedAddresses { writable, readonly }) =
+            &meta.loaded_addresses
+        {
+            out.extend(writable.iter().filter_map(|s| Pubkey::from_str(s).ok()));
+            out.extend(readonly.iter().filter_map(|s| Pubkey::from_str(s).ok()));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::programs::squads_mpl;
+
+    /// Construct a fully-shaped v3 `MsTransaction` body so
+    /// `extract_target` can deserialize it end-to-end. The Active
+    /// status, empty vote vecs, and zeroed bumps are placeholders —
+    /// classify_target only reads `ms` and `transaction_index`.
+    fn v3_ms_transaction_body(multisig: Pubkey, index: u32) -> Vec<u8> {
+        use anchor_lang::AnchorSerialize;
+        let mut body = v3::MS_TRANSACTION_DISCRIMINATOR.to_vec();
+        let tx = squads_mpl::accounts::MsTransaction {
+            creator: Pubkey::new_unique(),
+            ms: multisig,
+            transaction_index: index,
+            authority_index: 0,
+            authority_bump: 0,
+            status: squads_mpl::types::MsTransactionStatus::Active,
+            instruction_index: 0,
+            bump: 0,
+            approved: vec![],
+            rejected: vec![],
+            cancelled: vec![],
+            executed_index: 0,
+        };
+        tx.serialize(&mut body).unwrap();
+        body
+    }
+
+    /// `classify_target` dispatches by account owner and (for
+    /// Squads-owned accounts) the body discriminator. Pins each arm:
+    /// v4 owner + multisig disc → Multisig{V4}; v3 owner + multisig
+    /// disc → Multisig{V3}; v3 owner + valid MsTransaction body →
+    /// Transaction{V3, multisig, index}; system-program-owned → Vault;
+    /// unknown owner → Err.
+    ///
+    /// Skips constructing a synthetic v4 VaultTransaction body — the
+    /// upstream `squads-multisig-program::state::VaultTransaction`
+    /// has a long field list and we'd be testing Borsh decoding more
+    /// than dispatch. The v3 MsTransaction case exercises the
+    /// "Transaction" arm; v4's equivalent dispatch is the same shape.
+    #[test]
+    fn classify_target_dispatch() {
+        let target = Pubkey::new_unique();
+        let multisig = Pubkey::new_unique();
+
+        // v4 Multisig discriminator returns Multisig{V4} without
+        // attempting body decode.
+        let body = v4::MULTISIG_DISCRIMINATOR.to_vec();
+        match classify_target(&target, &v4::PROGRAM_ID, &body).unwrap() {
+            TargetKind::Multisig {
+                version: Version::V4,
+            } => {}
+            other => panic!("expected Multisig {{V4}}, got {other:?}"),
+        }
+
+        // v3 Ms discriminator → Multisig{V3}.
+        let body = v3::MS_DISCRIMINATOR.to_vec();
+        match classify_target(&target, &v3::PROGRAM_ID, &body).unwrap() {
+            TargetKind::Multisig {
+                version: Version::V3,
+            } => {}
+            other => panic!("expected Multisig {{V3}}, got {other:?}"),
+        }
+
+        // v3 MsTransaction with a valid body → Transaction{V3, ...}.
+        let body = v3_ms_transaction_body(multisig, 7);
+        match classify_target(&target, &v3::PROGRAM_ID, &body).unwrap() {
+            TargetKind::Transaction {
+                version: Version::V3,
+                multisig: m,
+                index,
+            } => {
+                assert_eq!(m.into_pubkey(), multisig);
+                assert_eq!(index, 7);
+            }
+            other => panic!("expected Transaction {{V3}}, got {other:?}"),
+        }
+
+        // System-program-owned (vault). Body is irrelevant.
+        match classify_target(&target, &solana_sdk::system_program::ID, &[]).unwrap() {
+            TargetKind::Vault => {}
+            other => panic!("expected Vault, got {other:?}"),
+        }
+
+        // Unknown owner → Err.
+        let stranger = Pubkey::new_unique();
+        assert!(classify_target(&target, &stranger, &[]).is_err());
+    }
+
+    /// `validate_membership` returns Ok when the wallet is a member with
+    /// the required permission, NotAMember when not in the list, and
+    /// MissingPermission when in the list but lacking the action's
+    /// permission bit. v3-style ALL-permissions members always pass.
+    #[test]
+    fn validate_membership_paths() {
+        use super::error::{SquadsError, SquadsMembershipError};
+
+        let multisig_pk = Pubkey::new_unique();
+        let multisig = MultisigKey::from_pubkey(multisig_pk);
+        let alice = Pubkey::new_unique();
+        let bob = Pubkey::new_unique();
+        let stranger = Pubkey::new_unique();
+
+        let info = MultisigInfo {
+            address: multisig,
+            version: Version::V4,
+            threshold: 1,
+            transaction_index: 0,
+            resolved_from_vault: None,
+            members: vec![
+                MemberInfo {
+                    key: alice,
+                    permissions: MemberPermissions::ALL,
+                },
+                MemberInfo {
+                    key: bob,
+                    // Bob can vote but not initiate or execute.
+                    permissions: MemberPermissions {
+                        propose: false,
+                        vote: true,
+                        execute: false,
+                    },
+                },
+            ],
+        };
+
+        // Alice has all permissions — every action passes.
+        for action in [
+            MemberAction::Vote,
+            MemberAction::Execute,
+            MemberAction::Initiate,
+        ] {
+            assert!(
+                validate_membership(&info, &alice, action).is_ok(),
+                "alice should pass {action:?}",
+            );
+        }
+
+        // Bob can vote but not initiate or execute.
+        assert!(validate_membership(&info, &bob, MemberAction::Vote).is_ok());
+        match validate_membership(&info, &bob, MemberAction::Initiate).unwrap_err() {
+            Error::Squads(SquadsError::Membership(SquadsMembershipError::MissingPermission {
+                wallet,
+                multisig: m,
+                action,
+            })) => {
+                assert_eq!(wallet, bob);
+                assert_eq!(m, multisig_pk);
+                assert_eq!(action, "initiate");
+            }
+            other => panic!("expected MissingPermission, got {other:?}"),
+        }
+        match validate_membership(&info, &bob, MemberAction::Execute).unwrap_err() {
+            Error::Squads(SquadsError::Membership(SquadsMembershipError::MissingPermission {
+                action,
+                ..
+            })) => {
+                assert_eq!(action, "execute");
+            }
+            other => panic!("expected MissingPermission, got {other:?}"),
+        }
+
+        // Stranger isn't a member at all.
+        match validate_membership(&info, &stranger, MemberAction::Vote).unwrap_err() {
+            Error::Squads(SquadsError::Membership(SquadsMembershipError::NotAMember {
+                wallet,
+                multisig: m,
+            })) => {
+                assert_eq!(wallet, stranger);
+                assert_eq!(m, multisig_pk);
+            }
+            other => panic!("expected NotAMember, got {other:?}"),
+        }
+    }
+
+    /// `ProposalView` serializes with an internally-tagged `version`
+    /// field so consumers can route on `v3` / `v4` rather than sniffing
+    /// for shape-disjoint fields. Pins the on-the-wire JSON shape on
+    /// both arms so a future tag-removal regression is loud rather
+    /// than silent.
+    #[test]
+    fn proposal_view_serializes_with_version_tag() {
+        // v3 arm.
+        let summary = build_summary("0/1".to_string(), false, &[]);
+        let v3_view = ProposalView::V3(v3::ProposalInfo {
+            summary,
+            multisig: MultisigKey::from_pubkey(Pubkey::new_unique()),
+            transaction_index: 1,
+            transaction: Pubkey::new_unique(),
+            status: v3::ProposalStatusInfo::Active,
+            votes: ProposalVotes {
+                approved: 0,
+                rejected: 0,
+                cancelled: 0,
+            },
+            authority_index: 0,
+            authority: VaultKey::from_pubkey(Pubkey::new_unique()),
+            creator: Pubkey::new_unique(),
+            instructions: vec![],
+        });
+        let json = serde_json::to_value(&v3_view).unwrap();
+        assert_eq!(
+            json.get("version").and_then(|v| v.as_str()),
+            Some("v3"),
+            "v3 ProposalView must carry version=\"v3\"; got {json}",
+        );
+
+        // v4 arm — paired so a regression that drops the tag from
+        // only one variant gets caught here too. Use the simplest v4
+        // ProposalInfo variant (ConfigTransaction) so the test
+        // doesn't rely on lookup-table resolution machinery.
+        let v4_summary = build_summary("0/1".to_string(), false, &[]);
+        let v4_view = ProposalView::V4(v4::ProposalInfo::ConfigTransaction(
+            v4::ConfigTransactionInfo {
+                summary: v4_summary,
+                multisig: MultisigKey::from_pubkey(Pubkey::new_unique()),
+                transaction_index: 1,
+                proposal: Pubkey::new_unique(),
+                config_transaction: Pubkey::new_unique(),
+                status: v4::ProposalStatusInfo::Executing,
+                votes: ProposalVotes {
+                    approved: 0,
+                    rejected: 0,
+                    cancelled: 0,
+                },
+                creator: Pubkey::new_unique(),
+                actions: vec![],
+            },
+        ));
+        let json = serde_json::to_value(&v4_view).unwrap();
+        assert_eq!(
+            json.get("version").and_then(|v| v.as_str()),
+            Some("v4"),
+            "v4 ProposalView must carry version=\"v4\"; got {json}",
+        );
+    }
+}

--- a/helium-lib/src/squads/v3.rs
+++ b/helium-lib/src/squads/v3.rs
@@ -1,0 +1,721 @@
+//! Squads v3 (`SMPLecH…`). Account types come from the on-chain IDL via
+//! `declare_program!(squads_mpl)`. The `squads-mpl` crate is archived on a
+//! solana 1.x toolchain and unusable as a direct dep; the IDL path works
+//! because v3 has no parameterized types (unlike v4's `SmallVec<L,T>`).
+//!
+//! v3's transaction model is split across multiple accounts: an
+//! `MsTransaction` (status / metadata) plus one `MsInstruction` PDA per
+//! inner instruction. To inspect a proposal we fetch the transaction then
+//! enumerate its instruction PDAs in parallel.
+
+use super::{
+    error::SquadsError, InstructionAccountRef, InstructionInfo, MemberInfo, MemberPermissions,
+    MultisigInfo, MultisigKey, ProposalSummary, ProposalVotes, VaultKey, Version,
+};
+use crate::{
+    client::SolanaRpcClient,
+    error::{DecodeError, Error},
+    keypair::Pubkey,
+    programs::KnownProgram,
+};
+use anchor_lang::AccountDeserialize;
+use futures::stream::{self, StreamExt, TryStreamExt};
+use serde::Serialize;
+use solana_sdk::{bs58, pubkey};
+
+pub use crate::programs::squads_mpl;
+
+pub const PROGRAM_ID: Pubkey = pubkey!("SMPLecH534NA9acpos4G6x7uf3LWbCAwZQE9e8ZekMu");
+
+const SEED_PREFIX: &[u8] = b"squad";
+const SEED_TRANSACTION: &[u8] = b"transaction";
+const SEED_INSTRUCTION: &[u8] = b"instruction";
+const SEED_AUTHORITY: &[u8] = b"authority";
+
+/// First 8 bytes of `sha256("account:<TypeName>")` — Anchor's standard
+/// account discriminators. Used for cheap owner+discriminator checks
+/// during vault resolution; full deserialize is reserved for the
+/// fetch-and-decode paths.
+pub(super) const MS_DISCRIMINATOR: [u8; 8] = [70, 118, 9, 108, 254, 215, 31, 120];
+pub(super) const MS_TRANSACTION_DISCRIMINATOR: [u8; 8] = [182, 151, 104, 216, 255, 1, 19, 157];
+
+/// Derive the `MsTransaction` PDA for a given (multisig, transaction index)
+/// pair. v3 transaction indices are u32 (not u64 like v4).
+pub fn transaction_pda(multisig: &MultisigKey, transaction_index: u32) -> Pubkey {
+    Pubkey::find_program_address(
+        &[
+            SEED_PREFIX,
+            multisig.as_ref(),
+            &transaction_index.to_le_bytes(),
+            SEED_TRANSACTION,
+        ],
+        &PROGRAM_ID,
+    )
+    .0
+}
+
+/// Derive the `MsInstruction` PDA for a given (transaction, instruction
+/// index) pair. v3 instruction indices are 1-based u8.
+pub fn instruction_pda(transaction: &Pubkey, instruction_index: u8) -> Pubkey {
+    Pubkey::find_program_address(
+        &[
+            SEED_PREFIX,
+            transaction.as_ref(),
+            &instruction_index.to_le_bytes(),
+            SEED_INSTRUCTION,
+        ],
+        &PROGRAM_ID,
+    )
+    .0
+}
+
+/// Derive the authority (vault) PDA for a given (multisig, authority index)
+/// pair. v3 calls these "authorities"; functionally they're the same as
+/// v4's vaults — system-owned PDAs that hold funds and act as signers.
+pub fn authority_pda(multisig: &MultisigKey, authority_index: u32) -> VaultKey {
+    let pk = Pubkey::find_program_address(
+        &[
+            SEED_PREFIX,
+            multisig.as_ref(),
+            &authority_index.to_le_bytes(),
+            SEED_AUTHORITY,
+        ],
+        &PROGRAM_ID,
+    )
+    .0;
+    VaultKey::from_pubkey(pk)
+}
+
+/// Decoded view of a v3 transaction (proposal + the instructions it will
+/// execute). Mirrors `v4::ProposalInfo` where the concepts overlap;
+/// version-specific bits stay distinct (v3 has no per-status timestamps,
+/// no LUTs, no `stale_transaction_index` cross-check).
+#[derive(Debug, Clone, Serialize)]
+pub struct ProposalInfo {
+    pub summary: ProposalSummary,
+    pub multisig: MultisigKey,
+    pub transaction_index: u32,
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub transaction: Pubkey,
+    pub status: ProposalStatusInfo,
+    pub votes: ProposalVotes,
+    pub authority_index: u32,
+    /// The "vault" in v3 terms — the system-owned PDA that signs CPI calls
+    /// on behalf of the multisig.
+    pub authority: VaultKey,
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub creator: Pubkey,
+    pub instructions: Vec<InstructionInfo>,
+}
+
+/// v3 status enum. Unlike v4, v3 doesn't record a timestamp per status.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposalStatusInfo {
+    Draft,
+    Active,
+    /// Threshold met, ready for `execute_transaction`.
+    ExecuteReady,
+    Executed,
+    Rejected,
+    Cancelled,
+}
+
+/// List open proposals on a v3 multisig in one bulk fetch. Scans
+/// `1..=transaction_index` and filters to non-finalized statuses
+/// (Draft, Active, ExecuteReady). v3 has no `stale_transaction_index`
+/// equivalent, so even old proposals against a since-modified multisig
+/// can still appear; the on-chain `execute_transaction` path enforces
+/// the staleness check itself.
+pub async fn list_open_proposals<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig: &MultisigKey,
+) -> Result<Vec<super::ProposalListEntry>, Error> {
+    let rpc = client.as_ref();
+    let ms =
+        fetch_account::<squads_mpl::accounts::Ms>(rpc, multisig.as_pubkey(), "v3 Multisig").await?;
+    let last = ms.transaction_index;
+    if last == 0 {
+        return Ok(Vec::new());
+    }
+
+    let indices: Vec<u32> = (1..=last).collect();
+    let pdas: Vec<Pubkey> = indices
+        .iter()
+        .map(|i| transaction_pda(multisig, *i))
+        .collect();
+
+    let mut entries: Vec<super::ProposalListEntry> = Vec::new();
+    let rpc_url = rpc.url();
+    for (idx_chunk, pda_chunk) in indices
+        .chunks(super::MAX_GET_ACCOUNTS)
+        .zip(pdas.chunks(super::MAX_GET_ACCOUNTS))
+    {
+        let accounts = super::raw_get_multiple_accounts(&rpc_url, pda_chunk).await?;
+        for ((idx, pda), maybe_account) in idx_chunk.iter().zip(pda_chunk).zip(accounts) {
+            let Some(account) = maybe_account else {
+                continue;
+            };
+            // Owner mismatch / wrong discriminator means the PDA holds
+            // something other than an MsTransaction — skip silently
+            // (matches v4's filter behaviour). A discriminator-matched
+            // body that fails to decode is corruption worth surfacing.
+            if account.owner != PROGRAM_ID
+                || account.data.len() < 8
+                || account.data[..8] != MS_TRANSACTION_DISCRIMINATOR
+            {
+                continue;
+            }
+            let tx = squads_mpl::accounts::MsTransaction::try_deserialize(&mut &account.data[..])
+                .map_err(|e| DecodeError::deserialize(pda, "v3 MsTransaction", e))?;
+            let Some(status) = open_status_label(&tx.status) else {
+                continue;
+            };
+            entries.push(super::ProposalListEntry {
+                index: u64::from(*idx),
+                transaction: *pda,
+                status,
+                // v3's MsTransaction doesn't carry per-status
+                // timestamps. The Squads UI synthesizes them from
+                // signature history; we'd need a per-row
+                // `getSignaturesForAddress` to do the same, which
+                // isn't worth the latency for a list view.
+                status_timestamp: None,
+                votes: ProposalVotes {
+                    approved: tx.approved.len(),
+                    rejected: tx.rejected.len(),
+                    cancelled: tx.cancelled.len(),
+                },
+            });
+        }
+    }
+    // Newest first — matches the Squads UI's reverse-chronological
+    // ordering and v4's `list_open_proposals`.
+    entries.reverse();
+    Ok(entries)
+}
+
+fn open_status_label(status: &squads_mpl::types::MsTransactionStatus) -> Option<&'static str> {
+    use squads_mpl::types::MsTransactionStatus;
+    match status {
+        MsTransactionStatus::Draft => Some("draft"),
+        MsTransactionStatus::Active => Some("active"),
+        MsTransactionStatus::ExecuteReady => Some("execute_ready"),
+        MsTransactionStatus::Executed
+        | MsTransactionStatus::Rejected
+        | MsTransactionStatus::Cancelled => None,
+    }
+}
+
+/// Fetch a v3 transaction and all its instruction accounts and produce
+/// a reviewer-friendly summary. `multisig_or_vault` accepts whatever
+/// `super::resolve_to_multisig` accepts: a v3 Ms PDA, an authority
+/// (vault) PDA (resolved through the cache + scan path), or an
+/// MsTransaction PDA — multisig is read from the body.
+pub async fn get_proposal_info<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig_or_vault: &Pubkey,
+    transaction_index: u32,
+) -> Result<ProposalInfo, Error> {
+    let multisig_addr = super::resolve_to_multisig(client, multisig_or_vault).await?;
+    let transaction_addr = transaction_pda(&multisig_addr, transaction_index);
+
+    let rpc = client.as_ref();
+    let multisig =
+        fetch_account::<squads_mpl::accounts::Ms>(rpc, multisig_addr.as_pubkey(), "v3 Multisig")
+            .await?;
+    let transaction = fetch_account::<squads_mpl::accounts::MsTransaction>(
+        rpc,
+        &transaction_addr,
+        "v3 MsTransaction",
+    )
+    .await?;
+
+    // Instruction PDAs are 1-indexed and dense; a transaction with
+    // `instruction_index = N` has PDAs at seeds 1..=N. Fetch in parallel.
+    let instruction_addrs: Vec<Pubkey> = (1..=transaction.instruction_index)
+        .map(|i| instruction_pda(&transaction_addr, i))
+        .collect();
+    let instructions: Vec<InstructionInfo> = stream::iter(instruction_addrs)
+        .map(|addr| async move {
+            let ms_ix = fetch_account::<squads_mpl::accounts::MsInstruction>(
+                rpc,
+                &addr,
+                "v3 MsInstruction",
+            )
+            .await?;
+            Ok::<InstructionInfo, Error>(ms_instruction_to_info(&ms_ix))
+        })
+        .buffered(10)
+        .try_collect()
+        .await?;
+
+    let authority = authority_pda(&multisig_addr, transaction.authority_index);
+    let summary = build_summary(&transaction, multisig.threshold, &instructions);
+    let status = convert_status(&transaction.status);
+
+    Ok(ProposalInfo {
+        summary,
+        multisig: multisig_addr,
+        transaction_index: transaction.transaction_index,
+        transaction: transaction_addr,
+        status,
+        votes: ProposalVotes {
+            approved: transaction.approved.len(),
+            rejected: transaction.rejected.len(),
+            cancelled: transaction.cancelled.len(),
+        },
+        authority_index: transaction.authority_index,
+        authority,
+        creator: transaction.creator,
+        instructions,
+    })
+}
+
+pub(super) fn decode_multisig(
+    address: MultisigKey,
+    data: &[u8],
+    resolved_from_vault: Option<VaultKey>,
+) -> Result<MultisigInfo, Error> {
+    let ms = squads_mpl::accounts::Ms::try_deserialize(&mut &data[..])
+        .map_err(|e| DecodeError::deserialize(address.as_pubkey(), "v3 Multisig", e))?;
+    let members = ms
+        .keys
+        .iter()
+        .map(|k| MemberInfo {
+            key: *k,
+            permissions: MemberPermissions::ALL,
+        })
+        .collect();
+    Ok(MultisigInfo {
+        address,
+        version: Version::V3,
+        threshold: ms.threshold,
+        transaction_index: u64::from(ms.transaction_index),
+        members,
+        resolved_from_vault,
+    })
+}
+
+/// Cheap check for "this account is a v3 Multisig" used during vault
+/// resolution scans. Validates owner and discriminator without
+/// committing to a full deserialize.
+pub(super) fn is_multisig_account(owner: &Pubkey, data: &[u8]) -> bool {
+    *owner == PROGRAM_ID && data.len() >= 8 && data[..8] == MS_DISCRIMINATOR
+}
+
+/// Self-identify a v3 account that already passed the owner check. Returns
+/// `Ok(Some((ms, index)))` if the account is an `MsTransaction`; `Ok(None)`
+/// if it's an `Ms` (multisig — caller supplies the index); `Err` if the
+/// discriminator isn't recognized. v3 transaction indices are u32 on chain
+/// and widen to u64 for the unified API.
+pub(super) fn extract_target(
+    address: &Pubkey,
+    data: &[u8],
+) -> Result<Option<(Pubkey, u64)>, Error> {
+    let disc = super::read_discriminator(data)
+        .ok_or_else(|| DecodeError::wrong_discriminator(address, "v3 Ms or MsTransaction"))?;
+    match disc {
+        MS_DISCRIMINATOR => Ok(None),
+        MS_TRANSACTION_DISCRIMINATOR => {
+            let tx = squads_mpl::accounts::MsTransaction::try_deserialize(&mut &data[..])
+                .map_err(|e| DecodeError::deserialize(address, "v3 MsTransaction", e))?;
+            Ok(Some((tx.ms, u64::from(tx.transaction_index))))
+        }
+        _ => Err(DecodeError::wrong_discriminator(address, "v3 Ms or MsTransaction").into()),
+    }
+}
+
+/// Fetch and decode a v3 Anchor account. The 0.31 `AccountDeserialize`
+/// trait checks the 8-byte discriminator internally, so wrong-account-type
+/// failures surface here as a single deserialize error.
+async fn fetch_account<T: AccountDeserialize>(
+    rpc: &SolanaRpcClient,
+    address: &Pubkey,
+    type_name: &'static str,
+) -> Result<T, Error> {
+    let account = rpc.get_account(address).await?;
+    if account.owner != PROGRAM_ID {
+        return Err(DecodeError::wrong_owner(address, "Squads v3", &account.owner).into());
+    }
+    T::try_deserialize(&mut &account.data[..])
+        .map_err(|e| DecodeError::deserialize(address, type_name, e).into())
+}
+
+fn ms_instruction_to_info(ix: &squads_mpl::accounts::MsInstruction) -> InstructionInfo {
+    let accounts = ix
+        .keys
+        .iter()
+        .map(|meta| InstructionAccountRef {
+            pubkey: meta.pubkey,
+            writable: meta.is_writable,
+            signer: meta.is_signer,
+        })
+        .collect();
+    let program = KnownProgram::from_pubkey(&ix.program_id);
+    let disc_bytes = super::read_discriminator(&ix.data);
+    let body = ix.data.get(8..);
+    let method = program
+        .zip(disc_bytes.as_ref())
+        .and_then(|(p, d)| p.method_name_with_body(d, body.unwrap_or(&[])));
+    let args = program
+        .zip(disc_bytes.as_ref())
+        .zip(body)
+        .and_then(|((p, d), b)| p.decode_instruction_args(d, b));
+    let discriminator = disc_bytes.map(|d| bs58::encode(d).into_string());
+    InstructionInfo {
+        program_id: ix.program_id,
+        program,
+        method,
+        args,
+        accounts,
+        data_len: ix.data.len(),
+        discriminator,
+        data_b58: bs58::encode(&ix.data).into_string(),
+    }
+}
+
+fn convert_status(status: &squads_mpl::types::MsTransactionStatus) -> ProposalStatusInfo {
+    use squads_mpl::types::MsTransactionStatus;
+    match status {
+        MsTransactionStatus::Draft => ProposalStatusInfo::Draft,
+        MsTransactionStatus::Active => ProposalStatusInfo::Active,
+        MsTransactionStatus::ExecuteReady => ProposalStatusInfo::ExecuteReady,
+        MsTransactionStatus::Executed => ProposalStatusInfo::Executed,
+        MsTransactionStatus::Rejected => ProposalStatusInfo::Rejected,
+        MsTransactionStatus::Cancelled => ProposalStatusInfo::Cancelled,
+    }
+}
+
+fn build_summary(
+    transaction: &squads_mpl::accounts::MsTransaction,
+    threshold: u16,
+    instructions: &[InstructionInfo],
+) -> ProposalSummary {
+    let approved = transaction.approved.len();
+    let approvals = format!("{approved}/{threshold}");
+    // v3 has no per-transaction stale flag (it tracks `ms_change_index` on
+    // the multisig but doesn't record it on the transaction, so we can't
+    // tell from the transaction alone whether settings changed since it
+    // was created). Always reports `false`.
+    super::build_summary(approvals, false, instructions)
+}
+
+/// Build a v3 `approve_transaction` instruction. The wallet must hold
+/// the keypair for `member`, and the member must be in the multisig.
+pub fn approve_transaction_ix(
+    multisig: MultisigKey,
+    transaction_index: u32,
+    member: Pubkey,
+) -> solana_sdk::instruction::Instruction {
+    use anchor_lang::{InstructionData, ToAccountMetas};
+    let transaction = transaction_pda(&multisig, transaction_index);
+    solana_sdk::instruction::Instruction {
+        program_id: PROGRAM_ID,
+        accounts: squads_mpl::client::accounts::ApproveTransaction {
+            multisig: multisig.into_pubkey(),
+            transaction,
+            member,
+        }
+        .to_account_metas(None),
+        data: squads_mpl::client::args::ApproveTransaction {}.data(),
+    }
+}
+
+/// Build a v3 `reject_transaction` instruction.
+pub fn reject_transaction_ix(
+    multisig: MultisigKey,
+    transaction_index: u32,
+    member: Pubkey,
+) -> solana_sdk::instruction::Instruction {
+    use anchor_lang::{InstructionData, ToAccountMetas};
+    let transaction = transaction_pda(&multisig, transaction_index);
+    solana_sdk::instruction::Instruction {
+        program_id: PROGRAM_ID,
+        accounts: squads_mpl::client::accounts::RejectTransaction {
+            multisig: multisig.into_pubkey(),
+            transaction,
+            member,
+        }
+        .to_account_metas(None),
+        data: squads_mpl::client::args::RejectTransaction {}.data(),
+    }
+}
+
+/// Build a v3 `cancel_transaction` instruction. v3's cancel includes
+/// `system_program` in the accounts list (unlike approve/reject) because
+/// it may close the proposal account.
+pub fn cancel_transaction_ix(
+    multisig: MultisigKey,
+    transaction_index: u32,
+    member: Pubkey,
+) -> solana_sdk::instruction::Instruction {
+    use anchor_lang::{InstructionData, ToAccountMetas};
+    let transaction = transaction_pda(&multisig, transaction_index);
+    solana_sdk::instruction::Instruction {
+        program_id: PROGRAM_ID,
+        accounts: squads_mpl::client::accounts::CancelTransaction {
+            multisig: multisig.into_pubkey(),
+            transaction,
+            member,
+            system_program: solana_sdk::system_program::ID,
+        }
+        .to_account_metas(None),
+        data: squads_mpl::client::args::CancelTransaction {}.data(),
+    }
+}
+
+/// Build a v3 `execute_transaction` instruction. v3 execute differs from
+/// v4 by passing accounts via `account_list: Vec<u8>` — each byte is an
+/// index into `remaining_accounts`, and the program walks them in
+/// `[msix_pda, program_id, ix_account_1, ix_account_2, ...]` blocks per
+/// inner instruction.
+///
+/// Builds a deduplicated `remaining_accounts` list with the AccountMeta
+/// flags Squads expects (writable from `MsAccountMeta`, signer always
+/// false at the outer level — the v3 authority signs via invoke_signed
+/// inside the program), then emits the `account_list` indexes in the
+/// per-instruction order the program iterates.
+pub async fn execute_transaction_ix<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig: MultisigKey,
+    transaction_index: u32,
+    member: Pubkey,
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    use anchor_lang::{InstructionData, ToAccountMetas};
+
+    let transaction_addr = transaction_pda(&multisig, transaction_index);
+    let rpc = client.as_ref();
+    let transaction = fetch_account::<squads_mpl::accounts::MsTransaction>(
+        rpc,
+        &transaction_addr,
+        "v3 MsTransaction",
+    )
+    .await?;
+    let authority = authority_pda(&multisig, transaction.authority_index);
+
+    // Fetch every MsInstruction PDA (1..=instruction_index, 1-based).
+    let ix_addrs: Vec<Pubkey> = (1..=transaction.instruction_index)
+        .map(|i| instruction_pda(&transaction_addr, i))
+        .collect();
+    let ms_ixs: Vec<squads_mpl::accounts::MsInstruction> =
+        futures::stream::iter(ix_addrs.iter().copied())
+            .map(|addr| async move {
+                fetch_account::<squads_mpl::accounts::MsInstruction>(rpc, &addr, "v3 MsInstruction")
+                    .await
+            })
+            .buffered(10)
+            .try_collect()
+            .await?;
+
+    let (remaining, account_list) =
+        build_execute_accounts(authority.as_pubkey(), &ix_addrs, &ms_ixs)?;
+
+    let mut accounts = squads_mpl::client::accounts::ExecuteTransaction {
+        multisig: multisig.into_pubkey(),
+        transaction: transaction_addr,
+        member,
+    }
+    .to_account_metas(None);
+    accounts.extend(remaining);
+
+    Ok(solana_sdk::instruction::Instruction {
+        program_id: PROGRAM_ID,
+        accounts,
+        data: squads_mpl::client::args::ExecuteTransaction { account_list }.data(),
+    })
+}
+
+/// Pure builder used by `execute_transaction_ix`. Walks the per-
+/// instruction `[msix_pda, program_id, key1, key2, ...]` blocks the
+/// program iterates, deduplicates by pubkey, promotes writable when a
+/// later reference is writable, and strips the `is_signer` flag for
+/// the multisig authority (the program signs that PDA via
+/// `invoke_signed`). Returns the deduped `remaining_accounts` and the
+/// flat `account_list` of indexes the program walks.
+fn build_execute_accounts(
+    authority: &Pubkey,
+    ix_addrs: &[Pubkey],
+    ms_ixs: &[squads_mpl::accounts::MsInstruction],
+) -> Result<(Vec<solana_sdk::instruction::AccountMeta>, Vec<u8>), Error> {
+    use solana_sdk::instruction::AccountMeta;
+    use std::collections::HashMap;
+
+    let mut unique: Vec<AccountMeta> = Vec::new();
+    let mut index_of: HashMap<Pubkey, u8> = HashMap::new();
+    let mut account_list: Vec<u8> = Vec::new();
+
+    let mut push_account = |meta: AccountMeta| -> Result<(), Error> {
+        match index_of.get(&meta.pubkey) {
+            Some(&idx) => {
+                let entry = &mut unique[idx as usize];
+                entry.is_writable = entry.is_writable || meta.is_writable;
+                account_list.push(idx);
+            }
+            None => {
+                let idx_usize = unique.len();
+                let idx = u8::try_from(idx_usize)
+                    .map_err(|_| SquadsError::remaining_accounts_overflow(idx_usize))?;
+                index_of.insert(meta.pubkey, idx);
+                unique.push(meta);
+                account_list.push(idx);
+            }
+        }
+        Ok(())
+    };
+
+    for (i, ms_ix) in ms_ixs.iter().enumerate() {
+        push_account(AccountMeta::new_readonly(ix_addrs[i], false))?;
+        push_account(AccountMeta::new_readonly(ms_ix.program_id, false))?;
+        for key in &ms_ix.keys {
+            push_account(AccountMeta {
+                pubkey: key.pubkey,
+                is_writable: key.is_writable,
+                is_signer: key.is_signer && key.pubkey != *authority,
+            })?;
+        }
+    }
+
+    Ok((unique, account_list))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anchor_lang::Discriminator;
+
+    /// Each vote ix's data starts with the program's discriminator for
+    /// that method and the accounts come out in the documented order.
+    #[test]
+    fn approve_transaction_shape() {
+        let multisig = MultisigKey::from_pubkey(Pubkey::new_unique());
+        let member = Pubkey::new_unique();
+        let ix = approve_transaction_ix(multisig, 7, member);
+
+        assert_eq!(ix.program_id, PROGRAM_ID);
+        assert_eq!(
+            &ix.data[..8],
+            squads_mpl::client::args::ApproveTransaction::DISCRIMINATOR
+        );
+        assert_eq!(ix.accounts.len(), 3);
+        assert_eq!(ix.accounts[0].pubkey, multisig.into_pubkey());
+        assert!(!ix.accounts[0].is_signer);
+        assert_eq!(ix.accounts[1].pubkey, transaction_pda(&multisig, 7));
+        assert!(ix.accounts[1].is_writable);
+        assert_eq!(ix.accounts[2].pubkey, member);
+        assert!(ix.accounts[2].is_signer);
+    }
+
+    #[test]
+    fn cancel_includes_system_program() {
+        let ix = cancel_transaction_ix(
+            MultisigKey::from_pubkey(Pubkey::new_unique()),
+            1,
+            Pubkey::new_unique(),
+        );
+        assert_eq!(ix.accounts.len(), 4);
+        assert_eq!(ix.accounts[3].pubkey, solana_sdk::system_program::ID);
+    }
+
+    #[test]
+    fn vote_discriminators_distinct() {
+        let approve = squads_mpl::client::args::ApproveTransaction::DISCRIMINATOR;
+        let reject = squads_mpl::client::args::RejectTransaction::DISCRIMINATOR;
+        let cancel = squads_mpl::client::args::CancelTransaction::DISCRIMINATOR;
+        assert_ne!(approve, reject);
+        assert_ne!(approve, cancel);
+        assert_ne!(reject, cancel);
+    }
+
+    /// Cover the dedup + writable-promotion + signer-strip rules
+    /// `build_execute_accounts` enforces. Two synthetic instructions
+    /// share two accounts (the v3 authority + an arbitrary account)
+    /// and one shows up readonly first then writable second — the
+    /// builder must collapse to one entry, mark it writable, and
+    /// strip `is_signer` from the authority.
+    #[test]
+    fn execute_dedup_promote_strip() {
+        use squads_mpl::accounts::MsInstruction;
+        use squads_mpl::types::MsAccountMeta;
+
+        let multisig = MultisigKey::from_pubkey(Pubkey::new_unique());
+        let authority = authority_pda(&multisig, 1);
+        let authority_pk = authority.into_pubkey();
+        let program_a = Pubkey::new_unique();
+        let program_b = Pubkey::new_unique();
+        let shared = Pubkey::new_unique();
+
+        let ix_addrs = [
+            instruction_pda(&Pubkey::new_unique(), 1),
+            instruction_pda(&Pubkey::new_unique(), 2),
+        ];
+
+        let ms_ixs = vec![
+            MsInstruction {
+                program_id: program_a,
+                keys: vec![
+                    // Authority appears with is_signer=true; must be
+                    // stripped because the program signs via invoke_signed.
+                    MsAccountMeta {
+                        pubkey: authority_pk,
+                        is_signer: true,
+                        is_writable: true,
+                    },
+                    // First mention of `shared` is readonly.
+                    MsAccountMeta {
+                        pubkey: shared,
+                        is_signer: false,
+                        is_writable: false,
+                    },
+                ],
+                data: vec![],
+                instruction_index: 1,
+                bump: 0,
+                executed: false,
+            },
+            MsInstruction {
+                program_id: program_b,
+                keys: vec![
+                    // Second mention of `shared` is writable — must
+                    // promote the dedup'd entry to writable.
+                    MsAccountMeta {
+                        pubkey: shared,
+                        is_signer: false,
+                        is_writable: true,
+                    },
+                ],
+                data: vec![],
+                instruction_index: 2,
+                bump: 0,
+                executed: false,
+            },
+        ];
+
+        let (remaining, account_list) =
+            build_execute_accounts(&authority_pk, &ix_addrs, &ms_ixs).expect("build");
+
+        // 6 unique accounts: ix_pda_0, program_a, authority, shared,
+        // ix_pda_1, program_b. (`shared` collapses across the two ixs;
+        // `authority` is unique.)
+        assert_eq!(remaining.len(), 6);
+        let by_key: std::collections::HashMap<Pubkey, &solana_sdk::instruction::AccountMeta> =
+            remaining.iter().map(|m| (m.pubkey, m)).collect();
+
+        let auth_entry = by_key[&authority_pk];
+        assert!(
+            !auth_entry.is_signer,
+            "authority must lose is_signer at the outer level",
+        );
+        let shared_entry = by_key[&shared];
+        assert!(
+            shared_entry.is_writable,
+            "shared must be promoted to writable",
+        );
+
+        // account_list walks: [ix0_pda, program_a, authority, shared,
+        //                      ix1_pda, program_b, shared].
+        assert_eq!(account_list.len(), 7);
+        // Last entry refers to `shared` — same index as the earlier mention.
+        assert_eq!(account_list[3], account_list[6]);
+    }
+}

--- a/helium-lib/src/squads/v4.rs
+++ b/helium-lib/src/squads/v4.rs
@@ -1,0 +1,2765 @@
+//! Squads v4 (`SQDS4ep…`). Types come from the upstream
+//! `squads-multisig-program` crate.
+
+use super::{
+    error::{CompiledInstructionField, MessageField, SquadsError},
+    InstructionAccountRef, InstructionInfo, MemberInfo, MemberPermissions, MultisigInfo,
+    MultisigKey, ProposalSummary, ProposalVotes, VaultKey, Version,
+};
+use crate::{
+    client::SolanaRpcClient,
+    error::{DecodeError, EncodeError, Error},
+    keypair::Pubkey,
+    programs::KnownProgram,
+};
+use anchor_lang::prelude::AnchorDeserialize;
+use chrono::{DateTime, Utc};
+use futures::stream::{StreamExt, TryStreamExt};
+use serde::Serialize;
+use solana_sdk::{bs58, pubkey};
+
+pub const PROGRAM_ID: Pubkey = pubkey!("SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf");
+
+/// First 8 bytes of `sha256("account:<TypeName>")` — Anchor's standard
+/// account discriminators. Hardcoded because the upstream types are from a
+/// different anchor-lang version than helium-lib's, so we can't reuse the
+/// trait-generated constants directly.
+pub(super) const MULTISIG_DISCRIMINATOR: [u8; 8] = [224, 116, 121, 186, 68, 161, 79, 236];
+const PROPOSAL_DISCRIMINATOR: [u8; 8] = [26, 94, 189, 187, 116, 136, 53, 33];
+pub(super) const VAULT_TRANSACTION_DISCRIMINATOR: [u8; 8] = [168, 250, 162, 100, 81, 14, 162, 207];
+const CONFIG_TRANSACTION_DISCRIMINATOR: [u8; 8] = [94, 8, 4, 35, 113, 139, 139, 112];
+const BATCH_DISCRIMINATOR: [u8; 8] = [156, 194, 70, 44, 22, 88, 137, 44];
+const VAULT_BATCH_TRANSACTION_DISCRIMINATOR: [u8; 8] = [196, 121, 46, 36, 12, 19, 252, 7];
+
+/// Squads v4 PDA seed prefixes.
+const SEED_PREFIX: &[u8] = b"multisig";
+const SEED_TRANSACTION: &[u8] = b"transaction";
+const SEED_PROPOSAL: &[u8] = b"proposal";
+const SEED_VAULT: &[u8] = b"vault";
+const SEED_BATCH_TRANSACTION: &[u8] = b"batch_transaction";
+
+/// Derive the `VaultTransaction` PDA for a given (multisig, transaction
+/// index) pair.
+pub fn vault_transaction_pda(multisig: &MultisigKey, transaction_index: u64) -> Pubkey {
+    Pubkey::find_program_address(
+        &[
+            SEED_PREFIX,
+            multisig.as_ref(),
+            SEED_TRANSACTION,
+            &transaction_index.to_le_bytes(),
+        ],
+        &PROGRAM_ID,
+    )
+    .0
+}
+
+/// Derive the `Proposal` PDA for a given (multisig, transaction index) pair.
+pub fn proposal_pda(multisig: &MultisigKey, transaction_index: u64) -> Pubkey {
+    Pubkey::find_program_address(
+        &[
+            SEED_PREFIX,
+            multisig.as_ref(),
+            SEED_TRANSACTION,
+            &transaction_index.to_le_bytes(),
+            SEED_PROPOSAL,
+        ],
+        &PROGRAM_ID,
+    )
+    .0
+}
+
+/// Derive the `Vault` PDA for a given (multisig, vault index) pair.
+pub fn vault_pda(multisig: &MultisigKey, vault_index: u8) -> VaultKey {
+    let pk = Pubkey::find_program_address(
+        &[SEED_PREFIX, multisig.as_ref(), SEED_VAULT, &[vault_index]],
+        &PROGRAM_ID,
+    )
+    .0;
+    VaultKey::from_pubkey(pk)
+}
+
+/// Derive a sub-transaction PDA inside a Batch. `sub_index` is 1-based
+/// and dense — a Batch with `size = N` has VaultBatchTransaction PDAs at
+/// indexes `1..=N`. Note the index is u32 LE (matches Squads' on-chain
+/// `batch.size`) while the parent `batch_index` is u64 LE.
+pub fn batch_transaction_pda(multisig: &MultisigKey, batch_index: u64, sub_index: u32) -> Pubkey {
+    Pubkey::find_program_address(
+        &[
+            SEED_PREFIX,
+            multisig.as_ref(),
+            SEED_TRANSACTION,
+            &batch_index.to_le_bytes(),
+            SEED_BATCH_TRANSACTION,
+            &sub_index.to_le_bytes(),
+        ],
+        &PROGRAM_ID,
+    )
+    .0
+}
+
+/// Anchor instruction discriminators (`sha256("global:<fn>")[..8]`) for
+/// the vote/execute methods we build instructions for. Hardcoded for the
+/// same reason the account discriminators are: the upstream
+/// squads-multisig-program crate uses anchor-lang 0.32 while helium-lib
+/// uses 0.31, so we don't share the trait machinery that would expose
+/// these via codegen.
+const PROPOSAL_APPROVE_IX: [u8; 8] = [144, 37, 164, 136, 188, 216, 42, 248];
+const PROPOSAL_REJECT_IX: [u8; 8] = [243, 62, 134, 156, 230, 106, 246, 135];
+const PROPOSAL_CANCEL_IX: [u8; 8] = [27, 42, 127, 237, 38, 163, 84, 203];
+
+/// Build a `proposal_approve` instruction: vote yes on the proposal at
+/// `(multisig, transaction_index)` as `member`. The wallet running this
+/// must hold the keypair for `member`.
+pub fn proposal_approve_ix(
+    multisig: MultisigKey,
+    transaction_index: u64,
+    member: Pubkey,
+    memo: Option<String>,
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    proposal_vote_ix(
+        multisig,
+        transaction_index,
+        member,
+        memo,
+        &PROPOSAL_APPROVE_IX,
+    )
+}
+
+/// Build a `proposal_reject` instruction.
+pub fn proposal_reject_ix(
+    multisig: MultisigKey,
+    transaction_index: u64,
+    member: Pubkey,
+    memo: Option<String>,
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    proposal_vote_ix(
+        multisig,
+        transaction_index,
+        member,
+        memo,
+        &PROPOSAL_REJECT_IX,
+    )
+}
+
+/// Build a `proposal_cancel` instruction. Only valid against an
+/// already-Approved proposal (reverses an approval before execution).
+pub fn proposal_cancel_ix(
+    multisig: MultisigKey,
+    transaction_index: u64,
+    member: Pubkey,
+    memo: Option<String>,
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    proposal_vote_ix(
+        multisig,
+        transaction_index,
+        member,
+        memo,
+        &PROPOSAL_CANCEL_IX,
+    )
+}
+
+const VAULT_TRANSACTION_EXECUTE_IX: [u8; 8] = [194, 8, 161, 87, 153, 164, 25, 171];
+const VAULT_TRANSACTION_CREATE_IX: [u8; 8] = [48, 250, 78, 168, 208, 226, 218, 211];
+const CONFIG_TRANSACTION_CREATE_IX: [u8; 8] = [155, 236, 87, 228, 137, 75, 81, 39];
+const CONFIG_TRANSACTION_EXECUTE_IX: [u8; 8] = [114, 146, 244, 189, 252, 140, 36, 40];
+const PROPOSAL_CREATE_IX: [u8; 8] = [220, 60, 73, 224, 30, 108, 79, 159];
+
+/// Compile a list of `solana_sdk::Instruction` into the byte-string
+/// form Squads' `vault_transaction_create` expects in
+/// `VaultTransactionCreateArgs.transaction_message`. Thin wrapper
+/// around `compile_transaction_message_with_luts` with an empty LUT
+/// list — every account ends up inlined as a static key.
+///
+/// Fails with `SquadsError::MessageFieldOverflow` when the input
+/// exceeds Squads' wire-format limits (u8-counted account_keys /
+/// instructions / per-ix accounts / LUTs, u16-counted ix data).
+pub fn compile_transaction_message(
+    vault: &Pubkey,
+    instructions: &[solana_sdk::instruction::Instruction],
+) -> Result<Vec<u8>, Error> {
+    compile_transaction_message_with_luts(vault, instructions, &[])
+}
+
+/// LUT-aware compactor. `luts` is the list of address-lookup-table
+/// accounts available to the proposal — each holds the account_key (the
+/// table's address) and `addresses` (the resolved pubkeys). Accounts in
+/// the input instructions that match a LUT entry get encoded as a
+/// lookup reference rather than a static key, which compresses the
+/// proposal payload below the 1232-byte transaction-size limit when
+/// many accounts are involved.
+///
+/// Account classification:
+///   - Vault: forced to static, leads `writable_signers` at index 0.
+///   - Signer of any inner ix: must be static (LUTs can't carry
+///     signatures).
+///   - Program IDs of all inner ixs: kept static for parity with how
+///     Solana clients typically build messages and to keep
+///     `MultisigCompiledInstruction.program_id_index` resolution simple.
+///   - Everything else: LUT-resolvable when found in any provided LUT.
+///     The first LUT containing the account wins.
+pub fn compile_transaction_message_with_luts(
+    vault: &Pubkey,
+    instructions: &[solana_sdk::instruction::Instruction],
+    luts: &[solana_sdk::address_lookup_table::AddressLookupTableAccount],
+) -> Result<Vec<u8>, Error> {
+    use std::collections::HashMap;
+
+    #[derive(Clone, Copy, Default)]
+    struct Flags {
+        signer: bool,
+        writable: bool,
+    }
+
+    let mut flags: HashMap<Pubkey, Flags> = HashMap::new();
+    flags.insert(
+        *vault,
+        Flags {
+            signer: true,
+            writable: true,
+        },
+    );
+    let mut program_ids: std::collections::HashSet<Pubkey> = std::collections::HashSet::new();
+    for ix in instructions {
+        program_ids.insert(ix.program_id);
+        flags.entry(ix.program_id).or_default();
+        for meta in &ix.accounts {
+            let entry = flags.entry(meta.pubkey).or_default();
+            entry.signer |= meta.is_signer;
+            entry.writable |= meta.is_writable;
+        }
+    }
+
+    // For each account, decide static vs LUT-resolvable. LUT-resolvable
+    // tracks which LUT and which index inside it.
+    struct LutRef {
+        lut_idx: usize, // index into `luts`
+        addr_idx: u8,   // index into that LUT's addresses
+        writable: bool,
+    }
+    let mut lut_refs: HashMap<Pubkey, LutRef> = HashMap::new();
+    if !luts.is_empty() {
+        for (key, f) in flags.iter() {
+            // Anything that needs to sign (including the vault) must be
+            // static. Same for program IDs.
+            if *key == *vault || f.signer || program_ids.contains(key) {
+                continue;
+            }
+            for (lut_idx, lut) in luts.iter().enumerate() {
+                if let Some(addr_idx) = lut.addresses.iter().position(|a| a == key) {
+                    let addr_idx = match u8::try_from(addr_idx) {
+                        Ok(v) => v,
+                        Err(_) => continue, // LUT slot beyond u8 — skip
+                    };
+                    lut_refs.insert(
+                        *key,
+                        LutRef {
+                            lut_idx,
+                            addr_idx,
+                            writable: f.writable,
+                        },
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    // Static section: anything not in `lut_refs`. Vault leads the
+    // writable_signers section. Remaining keys are sorted by pubkey
+    // bytes within each (signer, writable) bucket so the same input
+    // always produces the same `transaction_message` payload — Squads
+    // doesn't care about ordering inside a bucket, but external tools
+    // that hash proposals do.
+    flags.remove(vault);
+    let mut writable_signers: Vec<Pubkey> = vec![*vault];
+    let mut readonly_signers: Vec<Pubkey> = Vec::new();
+    let mut writable_non_signers: Vec<Pubkey> = Vec::new();
+    let mut readonly_non_signers: Vec<Pubkey> = Vec::new();
+    let mut sorted: Vec<(Pubkey, Flags)> = flags
+        .into_iter()
+        .filter(|(key, _)| !lut_refs.contains_key(key))
+        .collect();
+    sorted.sort_by_key(|(key, _)| key.to_bytes());
+    for (key, f) in sorted {
+        match (f.signer, f.writable) {
+            (true, true) => writable_signers.push(key),
+            (true, false) => readonly_signers.push(key),
+            (false, true) => writable_non_signers.push(key),
+            (false, false) => readonly_non_signers.push(key),
+        }
+    }
+
+    let num_writable_signers = writable_signers.len();
+    let num_signers = num_writable_signers + readonly_signers.len();
+    let num_writable_non_signers = writable_non_signers.len();
+
+    let static_keys: Vec<Pubkey> = writable_signers
+        .into_iter()
+        .chain(readonly_signers)
+        .chain(writable_non_signers)
+        .chain(readonly_non_signers)
+        .collect();
+
+    // Reject before we even allocate index slots — both the static
+    // keys count itself and any later LUT-resolved index will need to
+    // fit in the same u8 namespace.
+    let _ = SquadsError::try_u8(static_keys.len(), MessageField::AccountKeys)?;
+    let mut key_to_index: HashMap<Pubkey, u8> = static_keys
+        .iter()
+        .enumerate()
+        .map(|(i, k)| (*k, i as u8))
+        .collect();
+
+    // Layout the LUT-resolved section per Squads' execute-validation
+    // order: per LUT in `luts` order, writable entries first then
+    // readonly. Build the index map alongside — accounts hit at
+    // static_keys.len() + offset in the resolved section.
+    struct UsedLut {
+        account_key: Pubkey,
+        writable_indexes: Vec<u8>,
+        readonly_indexes: Vec<u8>,
+    }
+    let mut used_luts: Vec<UsedLut> = Vec::new();
+    let mut next_idx = static_keys.len();
+    // Sort lut_refs once into a deterministic ordering keyed by pubkey
+    // bytes so the per-LUT writable/readonly entries land in the same
+    // sequence on every run.
+    let mut sorted_lut_refs: Vec<(Pubkey, &LutRef)> =
+        lut_refs.iter().map(|(k, r)| (*k, r)).collect();
+    sorted_lut_refs.sort_by_key(|(key, _)| key.to_bytes());
+    for (lut_idx, lut) in luts.iter().enumerate() {
+        let mut writable_indexes: Vec<u8> = Vec::new();
+        let mut readonly_indexes: Vec<u8> = Vec::new();
+        let mut writable_keys: Vec<Pubkey> = Vec::new();
+        let mut readonly_keys: Vec<Pubkey> = Vec::new();
+        for (key, lut_ref) in sorted_lut_refs.iter() {
+            if lut_ref.lut_idx != lut_idx {
+                continue;
+            }
+            if lut_ref.writable {
+                writable_indexes.push(lut_ref.addr_idx);
+                writable_keys.push(*key);
+            } else {
+                readonly_indexes.push(lut_ref.addr_idx);
+                readonly_keys.push(*key);
+            }
+        }
+        if writable_indexes.is_empty() && readonly_indexes.is_empty() {
+            continue;
+        }
+        for k in &writable_keys {
+            key_to_index.insert(
+                *k,
+                SquadsError::try_u8(next_idx, MessageField::LutResolvedIndex)?,
+            );
+            next_idx += 1;
+        }
+        for k in &readonly_keys {
+            key_to_index.insert(
+                *k,
+                SquadsError::try_u8(next_idx, MessageField::LutResolvedIndex)?,
+            );
+            next_idx += 1;
+        }
+        used_luts.push(UsedLut {
+            account_key: lut.key,
+            writable_indexes,
+            readonly_indexes,
+        });
+    }
+
+    let mut bytes: Vec<u8> = vec![
+        SquadsError::try_u8(num_signers, MessageField::NumSigners)?,
+        SquadsError::try_u8(num_writable_signers, MessageField::NumWritableSigners)?,
+        SquadsError::try_u8(
+            num_writable_non_signers,
+            MessageField::NumWritableNonSigners,
+        )?,
+    ];
+
+    // SmallVec<u8, Pubkey>: u8 length + N×32 bytes.
+    bytes.push(SquadsError::try_u8(
+        static_keys.len(),
+        MessageField::AccountKeys,
+    )?);
+    for k in &static_keys {
+        bytes.extend_from_slice(k.as_ref());
+    }
+
+    // SmallVec<u8, CompiledInstruction>.
+    bytes.push(SquadsError::try_u8(
+        instructions.len(),
+        MessageField::Instructions,
+    )?);
+    for ix in instructions {
+        bytes.push(
+            *key_to_index
+                .get(&ix.program_id)
+                .expect("program collected above"),
+        );
+        bytes.push(SquadsError::try_u8(
+            ix.accounts.len(),
+            MessageField::InstructionAccounts,
+        )?);
+        for meta in &ix.accounts {
+            bytes.push(
+                *key_to_index
+                    .get(&meta.pubkey)
+                    .expect("account collected above"),
+            );
+        }
+        bytes.extend_from_slice(
+            &SquadsError::try_u16(ix.data.len(), MessageField::InstructionDataLen)?.to_le_bytes(),
+        );
+        bytes.extend_from_slice(&ix.data);
+    }
+
+    // SmallVec<u8, MessageAddressTableLookup> = u8 length + per-LUT.
+    // Each lookup: account_key (Pubkey, 32 bytes), writable_indexes
+    // (SmallVec<u8, u8>), readonly_indexes (SmallVec<u8, u8>).
+    bytes.push(SquadsError::try_u8(
+        used_luts.len(),
+        MessageField::LutCount,
+    )?);
+    for lut in &used_luts {
+        bytes.extend_from_slice(lut.account_key.as_ref());
+        bytes.push(SquadsError::try_u8(
+            lut.writable_indexes.len(),
+            MessageField::LutWritableIndexes,
+        )?);
+        bytes.extend_from_slice(&lut.writable_indexes);
+        bytes.push(SquadsError::try_u8(
+            lut.readonly_indexes.len(),
+            MessageField::LutReadonlyIndexes,
+        )?);
+        bytes.extend_from_slice(&lut.readonly_indexes);
+    }
+
+    Ok(bytes)
+}
+
+/// Build a `vault_transaction_create` instruction. Allocates the
+/// VaultTransaction PDA at index `multisig.transaction_index + 1`. The
+/// caller is responsible for fetching the current `transaction_index`
+/// from the multisig and passing the *next* one in here.
+pub fn vault_transaction_create_ix(
+    multisig: MultisigKey,
+    next_transaction_index: u64,
+    creator: Pubkey,
+    vault_index: u8,
+    ephemeral_signers: u8,
+    transaction_message: Vec<u8>,
+    memo: Option<String>,
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    use anchor_lang::AnchorSerialize;
+    use solana_sdk::instruction::{AccountMeta, Instruction};
+
+    let args = squads_multisig_program::instructions::VaultTransactionCreateArgs {
+        vault_index,
+        ephemeral_signers,
+        transaction_message,
+        memo,
+    };
+    let mut data = VAULT_TRANSACTION_CREATE_IX.to_vec();
+    args.serialize(&mut data)
+        .map_err(|e| EncodeError::borsh("VaultTransactionCreateArgs", e))?;
+
+    let transaction = vault_transaction_pda(&multisig, next_transaction_index);
+    Ok(Instruction {
+        program_id: PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new(multisig.into_pubkey(), false),
+            AccountMeta::new(transaction, false),
+            AccountMeta::new_readonly(creator, true),
+            AccountMeta::new(creator, true), // rent_payer = creator
+            AccountMeta::new_readonly(solana_sdk::system_program::ID, false),
+        ],
+        data,
+    })
+}
+
+/// CLI-shaped view of the `ConfigAction` variants we expose. Maps
+/// 1:1 onto the upstream `state::ConfigAction` for the variants the
+/// wallet actually proposes (member changes, threshold changes,
+/// time-lock). Spending-limit and rent-collector actions aren't
+/// surfaced — they're rare and have parameter shapes the CLI would
+/// awkwardly need to express.
+///
+/// `AddMember.permissions` uses the typed `MemberPermissions` struct
+/// rather than a raw `u8` mask so the CLI side can't accidentally
+/// pass undefined bits — the bit encoding lives entirely in
+/// `MemberPermissions::to_mask`.
+#[derive(Debug, Clone)]
+pub enum ConfigActionInput {
+    AddMember {
+        new_member: Pubkey,
+        permissions: MemberPermissions,
+    },
+    RemoveMember {
+        old_member: Pubkey,
+    },
+    ChangeThreshold {
+        new_threshold: u16,
+    },
+    SetTimeLock {
+        new_time_lock: u32,
+    },
+}
+
+impl From<ConfigActionInput> for squads_multisig_program::state::ConfigAction {
+    fn from(value: ConfigActionInput) -> Self {
+        use squads_multisig_program::state::{ConfigAction, Member, Permissions};
+        match value {
+            ConfigActionInput::AddMember {
+                new_member,
+                permissions,
+            } => ConfigAction::AddMember {
+                new_member: Member {
+                    key: new_member,
+                    permissions: Permissions {
+                        mask: permissions.to_mask(),
+                    },
+                },
+            },
+            ConfigActionInput::RemoveMember { old_member } => {
+                ConfigAction::RemoveMember { old_member }
+            }
+            ConfigActionInput::ChangeThreshold { new_threshold } => {
+                ConfigAction::ChangeThreshold { new_threshold }
+            }
+            ConfigActionInput::SetTimeLock { new_time_lock } => {
+                ConfigAction::SetTimeLock { new_time_lock }
+            }
+        }
+    }
+}
+
+/// Build a `config_transaction_create` instruction. Allocates the
+/// ConfigTransaction PDA at the same `(multisig, "transaction",
+/// next_index)` seed as a vault transaction — the kind is determined
+/// by the discriminator at the head of the account, not the seed.
+/// Used to propose member changes, threshold changes, time-lock
+/// changes, and spending-limit/rent-collector edits.
+///
+/// When this proposal eventually executes, Squads' on-chain handler
+/// advances `multisig.stale_transaction_index` to the current
+/// `transaction_index`, invalidating any pending vault transactions
+/// created against the old member/threshold set. That's the protocol
+/// guarantee callers rely on for security; we just produce the ix.
+pub fn config_transaction_create_ix(
+    multisig: MultisigKey,
+    next_transaction_index: u64,
+    creator: Pubkey,
+    actions: Vec<squads_multisig_program::state::ConfigAction>,
+    memo: Option<String>,
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    use anchor_lang::AnchorSerialize;
+    use solana_sdk::instruction::{AccountMeta, Instruction};
+
+    let args = squads_multisig_program::instructions::ConfigTransactionCreateArgs { actions, memo };
+    let mut data = CONFIG_TRANSACTION_CREATE_IX.to_vec();
+    args.serialize(&mut data)
+        .map_err(|e| EncodeError::borsh("ConfigTransactionCreateArgs", e))?;
+
+    let transaction = vault_transaction_pda(&multisig, next_transaction_index);
+    Ok(Instruction {
+        program_id: PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new(multisig.into_pubkey(), false),
+            AccountMeta::new(transaction, false),
+            AccountMeta::new_readonly(creator, true),
+            AccountMeta::new(creator, true), // rent_payer = creator
+            AccountMeta::new_readonly(solana_sdk::system_program::ID, false),
+        ],
+        data,
+    })
+}
+
+/// Build a `proposal_create` instruction. Pairs with
+/// `vault_transaction_create_ix` to atomically create the proposal in
+/// `Active` status (or `Draft` when `draft=true`).
+pub fn proposal_create_ix(
+    multisig: MultisigKey,
+    transaction_index: u64,
+    creator: Pubkey,
+    draft: bool,
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    use anchor_lang::AnchorSerialize;
+    use solana_sdk::instruction::{AccountMeta, Instruction};
+
+    let args = squads_multisig_program::instructions::ProposalCreateArgs {
+        transaction_index,
+        draft,
+    };
+    let mut data = PROPOSAL_CREATE_IX.to_vec();
+    args.serialize(&mut data)
+        .map_err(|e| EncodeError::borsh("ProposalCreateArgs", e))?;
+
+    let proposal = proposal_pda(&multisig, transaction_index);
+    Ok(Instruction {
+        program_id: PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new_readonly(multisig.into_pubkey(), false),
+            AccountMeta::new(proposal, false),
+            AccountMeta::new_readonly(creator, true),
+            AccountMeta::new(creator, true), // rent_payer = creator
+            AccountMeta::new_readonly(solana_sdk::system_program::ID, false),
+        ],
+        data,
+    })
+}
+
+/// One-shot helper: fetch the multisig to learn the next index, compile
+/// the instructions, and return the
+/// `[vault_transaction_create, proposal_create]` pair the proposer signs
+/// to submit a new proposal in `Active` state.
+pub async fn propose_ixs<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig: MultisigKey,
+    vault_index: u8,
+    creator: Pubkey,
+    instructions: &[solana_sdk::instruction::Instruction],
+    memo: Option<String>,
+) -> Result<Vec<solana_sdk::instruction::Instruction>, Error> {
+    propose_ixs_with_luts(
+        client,
+        multisig,
+        vault_index,
+        creator,
+        instructions,
+        memo,
+        &[],
+    )
+    .await
+    .map(|(ixs, _index)| ixs)
+}
+
+/// LUT-aware variant of `propose_ixs`. `lut_addresses` is the list of
+/// address-lookup-table account keys to fetch and consult while
+/// compiling the message. Accounts in the input instructions that
+/// match a LUT entry get encoded as a lookup reference rather than a
+/// static key, keeping the proposal payload under the 1232-byte
+/// transaction-size limit when many accounts are involved.
+///
+/// Returns the proposer ix pair plus the proposal's `transaction_index`
+/// — the same value the on-chain Squads program will use for the
+/// VaultTransaction / Proposal PDAs. Callers that need to surface the
+/// post-submit handle (so reviewers can `squads inspect <vault>
+/// --index <n>`) take the index; callers that don't drop it.
+pub async fn propose_ixs_with_luts<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig: MultisigKey,
+    vault_index: u8,
+    creator: Pubkey,
+    instructions: &[solana_sdk::instruction::Instruction],
+    memo: Option<String>,
+    lut_addresses: &[Pubkey],
+) -> Result<(Vec<solana_sdk::instruction::Instruction>, u64), Error> {
+    let rpc = client.as_ref();
+    let multisig_state: squads_multisig_program::state::Multisig = fetch_account(
+        rpc,
+        multisig.as_pubkey(),
+        &MULTISIG_DISCRIMINATOR,
+        "v4 Multisig",
+    )
+    .await?;
+    let next_index = multisig_state
+        .transaction_index
+        .checked_add(1)
+        .ok_or_else(SquadsError::transaction_index_overflow)?;
+
+    let luts = if lut_addresses.is_empty() {
+        Vec::new()
+    } else {
+        crate::message::get_lut_accounts(client, lut_addresses).await?
+    };
+
+    let vault = vault_pda(&multisig, vault_index);
+    let message = compile_transaction_message_with_luts(vault.as_pubkey(), instructions, &luts)?;
+    let create =
+        vault_transaction_create_ix(multisig, next_index, creator, vault_index, 0, message, memo)?;
+    let proposal = proposal_create_ix(multisig, next_index, creator, false)?;
+    Ok((vec![create, proposal], next_index))
+}
+
+/// One-shot helper for member/threshold/config changes: fetch the
+/// multisig to learn the next index, build the
+/// `[config_transaction_create, proposal_create]` pair, and return
+/// it alongside the proposal's transaction index. Mirrors
+/// `propose_ixs_with_luts` for the config-change flow — config
+/// transactions don't have inner instructions to LUT-resolve, so
+/// this variant doesn't take an `lut_addresses` parameter.
+pub async fn propose_config_change_ixs<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig: MultisigKey,
+    creator: Pubkey,
+    actions: Vec<squads_multisig_program::state::ConfigAction>,
+    memo: Option<String>,
+) -> Result<(Vec<solana_sdk::instruction::Instruction>, u64), Error> {
+    let rpc = client.as_ref();
+    let multisig_state: squads_multisig_program::state::Multisig = fetch_account(
+        rpc,
+        multisig.as_pubkey(),
+        &MULTISIG_DISCRIMINATOR,
+        "v4 Multisig",
+    )
+    .await?;
+    let next_index = multisig_state
+        .transaction_index
+        .checked_add(1)
+        .ok_or_else(SquadsError::transaction_index_overflow)?;
+
+    let create = config_transaction_create_ix(multisig, next_index, creator, actions, memo)?;
+    let proposal = proposal_create_ix(multisig, next_index, creator, false)?;
+    Ok((vec![create, proposal], next_index))
+}
+
+/// Build a `vault_transaction_execute` instruction. Executes a v4
+/// proposal that has reached `Approved` status and (if applicable)
+/// passed its time lock. The wallet running this must hold the keypair
+/// for `member` and the member must have `Execute` permission on the
+/// multisig.
+///
+/// `remaining_accounts` are assembled in the exact order Squads
+/// validates against:
+///   1. LUT accounts in `message.address_table_lookups` order
+///   2. Static `message.account_keys` in their original message order
+///   3. For each LUT: that LUT's writable-resolved section, then its
+///      readonly-resolved section
+///
+/// Signer flags are propagated from the message except for the vault PDA
+/// and ephemeral signer PDAs (those sign via `invoke_signed` inside the
+/// program, not by the outer transaction).
+pub async fn vault_transaction_execute_ix<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig: MultisigKey,
+    transaction_index: u64,
+    member: Pubkey,
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    let vault_tx_addr = vault_transaction_pda(&multisig, transaction_index);
+
+    // Need the on-chain VaultTransaction to know the message + vault_index +
+    // ephemeral_signer_bumps for the remaining_accounts assembly.
+    let rpc = client.as_ref();
+    let vault_tx: squads_multisig_program::state::VaultTransaction = fetch_account(
+        rpc,
+        &vault_tx_addr,
+        &VAULT_TRANSACTION_DISCRIMINATOR,
+        "v4 VaultTransaction",
+    )
+    .await?;
+
+    // Resolve every LUT referenced by the message into
+    // `(writable_resolved, readonly_resolved)` pubkey slices, in the
+    // same order as `vault_tx.message.address_table_lookups`. Bails if
+    // any index falls outside the table — silently dropping would
+    // misalign downstream account positions.
+    let lut_addrs: Vec<Pubkey> = vault_tx
+        .message
+        .address_table_lookups
+        .iter()
+        .map(|a| a.account_key)
+        .collect();
+    let mut lut_resolutions: Vec<(Vec<Pubkey>, Vec<Pubkey>)> = Vec::new();
+    if !lut_addrs.is_empty() {
+        let luts = super::raw_get_multiple_accounts(&rpc.url(), &lut_addrs).await?;
+        for (lookup, account) in vault_tx.message.address_table_lookups.iter().zip(luts) {
+            let Some(raw) = account else {
+                return Err(Error::account_not_found());
+            };
+            let table =
+                solana_sdk::address_lookup_table::state::AddressLookupTable::deserialize(&raw.data)
+                    .map_err(|e| DecodeError::deserialize(&lookup.account_key, "LUT", e))?;
+            let writable =
+                resolve_lut_indexes(&table, &lookup.account_key, &lookup.writable_indexes)?;
+            let readonly =
+                resolve_lut_indexes(&table, &lookup.account_key, &lookup.readonly_indexes)?;
+            lut_resolutions.push((writable, readonly));
+        }
+    }
+
+    assemble_vault_execute_ix(
+        multisig,
+        transaction_index,
+        member,
+        &vault_tx,
+        &lut_resolutions,
+    )
+}
+
+/// Pure assembly of the `vault_transaction_execute` instruction given a
+/// fully-fetched `VaultTransaction` and pre-resolved LUT entries.
+/// Split from `vault_transaction_execute_ix` so the strict three-section
+/// account ordering (LUT account_keys → static keys → per-LUT
+/// writable-then-readonly), signer-strip for vault + ephemeral-signer
+/// PDAs, and ephemeral-signer PDA derivation can be unit-tested
+/// without RPC.
+///
+/// `lut_resolutions[i]` is the `(writable, readonly)` pubkey slice for
+/// `vault_tx.message.address_table_lookups[i]`, in the same order.
+fn assemble_vault_execute_ix(
+    multisig: MultisigKey,
+    transaction_index: u64,
+    member: Pubkey,
+    vault_tx: &squads_multisig_program::state::VaultTransaction,
+    lut_resolutions: &[(Vec<Pubkey>, Vec<Pubkey>)],
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    use solana_sdk::instruction::{AccountMeta, Instruction};
+
+    let proposal = proposal_pda(&multisig, transaction_index);
+    let vault_tx_addr = vault_transaction_pda(&multisig, transaction_index);
+    let msg = &vault_tx.message;
+    let vault_addr = vault_pda(&multisig, vault_tx.vault_index);
+
+    // Ephemeral signer PDAs are seeded `[SEED_PREFIX, vault_tx, "ephemeral_signer", index_le_u8]`.
+    // Squads' on-chain `vault_transaction_create` rejects >255 ephemeral
+    // signers via the same `as u8` cast, so any vault_tx we read back
+    // here will fit; surface a typed error if a forged account ever
+    // doesn't, instead of silently producing wrong PDAs.
+    let ephemeral_signers: Vec<Pubkey> = vault_tx
+        .ephemeral_signer_bumps
+        .iter()
+        .enumerate()
+        .map(|(i, _bump)| {
+            let idx = SquadsError::try_u8(i, MessageField::EphemeralSignerIndex)?;
+            Ok::<Pubkey, Error>(
+                Pubkey::find_program_address(
+                    &[
+                        SEED_PREFIX,
+                        vault_tx_addr.as_ref(),
+                        b"ephemeral_signer",
+                        &idx.to_le_bytes(),
+                    ],
+                    &PROGRAM_ID,
+                )
+                .0,
+            )
+        })
+        .collect::<Result<_, _>>()?;
+
+    let mut remaining: Vec<AccountMeta> =
+        Vec::with_capacity(msg.account_keys.len() + msg.address_table_lookups.len() * 2 + 4);
+
+    // 1. LUT accounts (read-only references to the tables themselves).
+    for lookup in msg.address_table_lookups.iter() {
+        remaining.push(AccountMeta::new_readonly(lookup.account_key, false));
+    }
+
+    // 2. Static account_keys with their writable/signer flags from the
+    //    message. Vault and ephemeral-signer PDAs sign via invoke_signed
+    //    inside the program, not the outer tx, so strip is_signer for them.
+    for (i, key) in msg.account_keys.iter().enumerate() {
+        let writable = msg.is_static_writable_index(i);
+        let signer = msg.is_signer_index(i)
+            && key != vault_addr.as_pubkey()
+            && !ephemeral_signers.contains(key);
+        remaining.push(AccountMeta {
+            pubkey: *key,
+            is_signer: signer,
+            is_writable: writable,
+        });
+    }
+
+    // 3. LUT-resolved entries per LUT: writable then readonly.
+    for (writable_keys, readonly_keys) in lut_resolutions {
+        for pk in writable_keys {
+            remaining.push(AccountMeta::new(*pk, false));
+        }
+        for pk in readonly_keys {
+            remaining.push(AccountMeta::new_readonly(*pk, false));
+        }
+    }
+
+    let mut accounts = vec![
+        AccountMeta::new_readonly(multisig.into_pubkey(), false),
+        AccountMeta::new(proposal, false),
+        AccountMeta::new_readonly(vault_tx_addr, false),
+        AccountMeta::new_readonly(member, true),
+    ];
+    accounts.extend(remaining);
+
+    Ok(Instruction {
+        program_id: PROGRAM_ID,
+        accounts,
+        data: VAULT_TRANSACTION_EXECUTE_IX.to_vec(),
+    })
+}
+
+/// Build the right v4 execute instruction for the proposal at
+/// `(multisig, transaction_index)` — VaultTransaction or
+/// ConfigTransaction. Reads the on-chain transaction account once to
+/// dispatch by 8-byte Anchor discriminator. Caller must hold the
+/// keypair for `member` and the member must have `Execute` permission.
+pub async fn execute_ix<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig: MultisigKey,
+    transaction_index: u64,
+    member: Pubkey,
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    let tx_addr = vault_transaction_pda(&multisig, transaction_index);
+    let account = client.as_ref().get_account(&tx_addr).await?;
+    if account.owner != PROGRAM_ID {
+        return Err(DecodeError::wrong_owner(&tx_addr, "Squads v4", &account.owner).into());
+    }
+    let disc = super::read_discriminator(&account.data)
+        .ok_or_else(|| DecodeError::wrong_discriminator(&tx_addr, "v4 transaction"))?;
+    match disc {
+        VAULT_TRANSACTION_DISCRIMINATOR => {
+            vault_transaction_execute_ix(client, multisig, transaction_index, member).await
+        }
+        CONFIG_TRANSACTION_DISCRIMINATOR => Ok(config_transaction_execute_ix(
+            multisig,
+            transaction_index,
+            member,
+        )),
+        _ => Err(DecodeError::wrong_discriminator(
+            &tx_addr,
+            "v4 VaultTransaction or ConfigTransaction",
+        )
+        .into()),
+    }
+}
+
+/// Build a `config_transaction_execute` instruction. Applies the
+/// pending member / threshold / time-lock / spending-limit changes to
+/// the multisig itself. The caller's `member` pubkey doubles as the
+/// `rent_payer` (Squads programs reallocate the multisig account when
+/// `members` grows or shrinks, and the rent payer covers the delta).
+fn config_transaction_execute_ix(
+    multisig: MultisigKey,
+    transaction_index: u64,
+    member: Pubkey,
+) -> solana_sdk::instruction::Instruction {
+    use solana_sdk::instruction::{AccountMeta, Instruction};
+
+    let proposal = proposal_pda(&multisig, transaction_index);
+    let transaction = vault_transaction_pda(&multisig, transaction_index);
+
+    let accounts = vec![
+        AccountMeta::new(multisig.into_pubkey(), false),
+        AccountMeta::new_readonly(member, true),
+        AccountMeta::new(proposal, false),
+        AccountMeta::new_readonly(transaction, false),
+        AccountMeta::new(member, true),
+        AccountMeta::new_readonly(solana_sdk::system_program::ID, false),
+    ];
+
+    Instruction {
+        program_id: PROGRAM_ID,
+        accounts,
+        data: CONFIG_TRANSACTION_EXECUTE_IX.to_vec(),
+    }
+}
+
+/// Fetch the multisig's `time_lock` setting (seconds between proposal
+/// approval and the earliest legal execute). Callers that want to bundle
+/// `proposal_approve + *_transaction_execute` into a single transaction
+/// need this to be `0` — the execute handler checks `now - approval_ts
+/// >= time_lock`, which never holds inside the same block.
+pub async fn get_time_lock<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig: &MultisigKey,
+) -> Result<u32, Error> {
+    let state: squads_multisig_program::state::Multisig = fetch_account(
+        client.as_ref(),
+        multisig.as_pubkey(),
+        &MULTISIG_DISCRIMINATOR,
+        "v4 Multisig",
+    )
+    .await?;
+    Ok(state.time_lock)
+}
+
+/// All three v4 vote instructions share the same accounts shape and
+/// `ProposalVoteArgs { memo: Option<String> }` body — only the
+/// discriminator differs. See upstream `proposal_vote.rs` for the
+/// definitions and the validation rules each one enforces on-chain.
+fn proposal_vote_ix(
+    multisig: MultisigKey,
+    transaction_index: u64,
+    member: Pubkey,
+    memo: Option<String>,
+    discriminator: &[u8; 8],
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    use anchor_lang::AnchorSerialize;
+    use solana_sdk::instruction::{AccountMeta, Instruction};
+
+    let args = squads_multisig_program::instructions::ProposalVoteArgs { memo };
+    let mut data = discriminator.to_vec();
+    args.serialize(&mut data)
+        .map_err(|e| EncodeError::borsh("ProposalVoteArgs", e))?;
+
+    let proposal = proposal_pda(&multisig, transaction_index);
+    Ok(Instruction {
+        program_id: PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new_readonly(multisig.into_pubkey(), false),
+            AccountMeta::new(member, true),
+            AccountMeta::new(proposal, false),
+        ],
+        data,
+    })
+}
+
+/// Decoded view of a v4 proposal. v4 supports three transaction kinds —
+/// `VaultTransaction` (the common one: arbitrary instructions executed
+/// by the vault), `ConfigTransaction` (changes to the multisig itself:
+/// members, threshold, time-lock, spending limits), and `Batch` (a
+/// serial sequence of vault transactions). The kind is dispatched from
+/// the transaction account's Anchor discriminator.
+///
+/// `summary` is rendered first so reviewers see the load-bearing facts
+/// (approvals vs threshold, staleness) before scrolling through detail.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ProposalInfo {
+    VaultTransaction(VaultTransactionInfo),
+    ConfigTransaction(ConfigTransactionInfo),
+    /// Serial execution of multiple vault transactions. Sub-transactions
+    /// are decoded with the same LUT-resolved account treatment as a
+    /// top-level VaultTransaction (see `BatchInfo.sub_transactions`).
+    Batch(BatchInfo),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VaultTransactionInfo {
+    pub summary: ProposalSummary,
+    pub multisig: MultisigKey,
+    pub transaction_index: u64,
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub proposal: Pubkey,
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub vault_transaction: Pubkey,
+    pub status: ProposalStatusInfo,
+    pub votes: ProposalVotes,
+    pub vault_index: u8,
+    pub vault: VaultKey,
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub creator: Pubkey,
+    pub ephemeral_signers: u8,
+    pub instructions: Vec<InstructionInfo>,
+    pub address_lookup_tables: Vec<AddressLookupInfo>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfigTransactionInfo {
+    pub summary: ProposalSummary,
+    pub multisig: MultisigKey,
+    pub transaction_index: u64,
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub proposal: Pubkey,
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub config_transaction: Pubkey,
+    pub status: ProposalStatusInfo,
+    pub votes: ProposalVotes,
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub creator: Pubkey,
+    /// Ordered list of multisig-config changes this proposal will apply
+    /// when executed. Each action is a single mutation — add member,
+    /// change threshold, etc.
+    pub actions: Vec<ConfigActionInfo>,
+}
+
+/// Reviewer-friendly rendering of a `ConfigAction`. Uses an internally
+/// tagged enum so each action's parameters live alongside the action's
+/// `type` in the JSON output.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ConfigActionInfo {
+    AddMember {
+        #[serde(with = "crate::keypair::serde_pubkey")]
+        new_member: Pubkey,
+        permissions: MemberPermissions,
+    },
+    RemoveMember {
+        #[serde(with = "crate::keypair::serde_pubkey")]
+        old_member: Pubkey,
+    },
+    ChangeThreshold {
+        new_threshold: u16,
+    },
+    SetTimeLock {
+        new_time_lock: u32,
+    },
+    AddSpendingLimit {
+        #[serde(with = "crate::keypair::serde_pubkey")]
+        create_key: Pubkey,
+        vault_index: u8,
+        #[serde(with = "crate::keypair::serde_pubkey")]
+        mint: Pubkey,
+        amount: u64,
+        period: ConfigSpendingPeriod,
+        members: Vec<String>,
+        destinations: Vec<String>,
+    },
+    RemoveSpendingLimit {
+        #[serde(with = "crate::keypair::serde_pubkey")]
+        spending_limit: Pubkey,
+    },
+    SetRentCollector {
+        #[serde(with = "crate::keypair::serde_opt_pubkey")]
+        new_rent_collector: Option<Pubkey>,
+    },
+    /// `ConfigAction` is `#[non_exhaustive]` upstream; future variants
+    /// land here until we update.
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchInfo {
+    pub summary: ProposalSummary,
+    pub multisig: MultisigKey,
+    pub transaction_index: u64,
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub proposal: Pubkey,
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub batch: Pubkey,
+    pub status: ProposalStatusInfo,
+    pub votes: ProposalVotes,
+    pub vault_index: u8,
+    pub vault: VaultKey,
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub creator: Pubkey,
+    /// Number of vault transactions in the batch.
+    pub size: u32,
+    /// How many sub-transactions have already been executed (0..=size).
+    pub executed_transactions: u32,
+    /// Decoded sub-transactions in execution order (1-based on chain;
+    /// 0-indexed in this `Vec`).
+    pub sub_transactions: Vec<BatchSubTransaction>,
+}
+
+/// One sub-transaction inside a Batch — same instruction shape as a
+/// VaultTransaction but stored as a separate `VaultBatchTransaction` PDA.
+/// The parent Batch already carries multisig/creator/vault_index, so each
+/// sub-transaction only repeats what's specific to it.
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchSubTransaction {
+    /// 1-based position within the batch.
+    pub batch_index: u32,
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub address: Pubkey,
+    pub ephemeral_signers: u8,
+    pub instructions: Vec<InstructionInfo>,
+    pub address_lookup_tables: Vec<AddressLookupInfo>,
+}
+
+/// v4 spending-limit reset period.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigSpendingPeriod {
+    OneTime,
+    Day,
+    Week,
+    Month,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum ProposalStatusInfo {
+    Draft {
+        timestamp: DateTime<Utc>,
+    },
+    Active {
+        timestamp: DateTime<Utc>,
+    },
+    Rejected {
+        timestamp: DateTime<Utc>,
+    },
+    Approved {
+        timestamp: DateTime<Utc>,
+    },
+    Executed {
+        timestamp: DateTime<Utc>,
+    },
+    Cancelled {
+        timestamp: DateTime<Utc>,
+    },
+    /// Two cases collapse here: (a) the deprecated transient status
+    /// preserved on old-format Squads accounts, and (b) any future
+    /// variant of upstream `ProposalStatus` we haven't taught the
+    /// converter about — `convert_proposal_status` falls through to
+    /// `Executing` so a forward-incompat decode renders as something
+    /// rather than failing the whole inspect.
+    Executing,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AddressLookupInfo {
+    #[serde(with = "crate::keypair::serde_pubkey")]
+    pub address: Pubkey,
+    pub writable_indexes: Vec<u8>,
+    pub readonly_indexes: Vec<u8>,
+}
+
+/// List open proposals on a v4 multisig in one bulk fetch. Scans
+/// `(stale_transaction_index + 1)..=transaction_index` — the only range
+/// where votes/executes can still affect state — and filters to
+/// non-finalized proposal statuses. The multisig address must already
+/// be resolved (no vault → multisig translation here; the dispatch
+/// happens at `super::list_open_proposals`).
+pub async fn list_open_proposals<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig: &MultisigKey,
+) -> Result<Vec<super::ProposalListEntry>, Error> {
+    use squads_multisig_program::state::Proposal;
+
+    let rpc = client.as_ref();
+    let multisig_state: squads_multisig_program::state::Multisig = fetch_account(
+        rpc,
+        multisig.as_pubkey(),
+        &MULTISIG_DISCRIMINATOR,
+        "v4 Multisig",
+    )
+    .await?;
+
+    let stale = multisig_state.stale_transaction_index;
+    let last = multisig_state.transaction_index;
+    if last <= stale {
+        return Ok(Vec::new());
+    }
+
+    let indices: Vec<u64> = (stale + 1..=last).collect();
+    let pdas: Vec<Pubkey> = indices.iter().map(|i| proposal_pda(multisig, *i)).collect();
+
+    let mut entries: Vec<super::ProposalListEntry> = Vec::new();
+    let rpc_url = rpc.url();
+    for (idx_chunk, pda_chunk) in indices
+        .chunks(super::MAX_GET_ACCOUNTS)
+        .zip(pdas.chunks(super::MAX_GET_ACCOUNTS))
+    {
+        let accounts = super::raw_get_multiple_accounts(&rpc_url, pda_chunk).await?;
+        for ((idx, pda), maybe_account) in idx_chunk.iter().zip(pda_chunk).zip(accounts) {
+            // Proposal PDAs aren't always allocated at every index — a
+            // proposer can split `vault_transaction_create` and
+            // `proposal_create` across separate transactions, leaving
+            // gaps. Skip absent / mismatched accounts.
+            let Some(account) = maybe_account else {
+                continue;
+            };
+            if account.owner != PROGRAM_ID
+                || account.data.len() < 8
+                || account.data[..8] != PROPOSAL_DISCRIMINATOR
+            {
+                continue;
+            }
+            let proposal = Proposal::deserialize(&mut &account.data[8..])
+                .map_err(|e| DecodeError::deserialize(pda, "v4 Proposal", e))?;
+            let Some(status) = open_status_label(&proposal.status) else {
+                continue;
+            };
+            entries.push(super::ProposalListEntry {
+                index: *idx,
+                transaction: vault_transaction_pda(multisig, *idx),
+                status,
+                status_timestamp: status_timestamp(&proposal.status),
+                votes: votes_from(&proposal),
+            });
+        }
+    }
+
+    // Newest first — matches the Squads UI's reverse-chronological
+    // ordering. Reviewers triage from the most-recent activity, so
+    // putting old drafts at the bottom keeps the head of the list
+    // useful.
+    entries.reverse();
+    Ok(entries)
+}
+
+/// Lift the timestamp out of any `ProposalStatus` variant. Returns
+/// `None` only for the deprecated transient `Executing` (no
+/// timestamp on chain) or if the on-chain seconds-since-epoch falls
+/// outside chrono's range. Used to surface proposal age in
+/// `list_open_proposals` without re-fetching the proposal account.
+fn status_timestamp(
+    status: &squads_multisig_program::state::ProposalStatus,
+) -> Option<DateTime<Utc>> {
+    use squads_multisig_program::state::ProposalStatus;
+    let ts = match status {
+        ProposalStatus::Draft { timestamp } => *timestamp,
+        ProposalStatus::Active { timestamp } => *timestamp,
+        ProposalStatus::Approved { timestamp } => *timestamp,
+        ProposalStatus::Rejected { timestamp } => *timestamp,
+        ProposalStatus::Executed { timestamp } => *timestamp,
+        ProposalStatus::Cancelled { timestamp } => *timestamp,
+        _ => return None,
+    };
+    DateTime::<Utc>::from_timestamp(ts, 0)
+}
+
+fn open_status_label(
+    status: &squads_multisig_program::state::ProposalStatus,
+) -> Option<&'static str> {
+    use squads_multisig_program::state::ProposalStatus;
+    match status {
+        ProposalStatus::Draft { .. } => Some("draft"),
+        ProposalStatus::Active { .. } => Some("active"),
+        ProposalStatus::Approved { .. } => Some("approved"),
+        // `Executing` is deprecated upstream and Executed/Rejected/
+        // Cancelled are finalized — none are open.
+        _ => None,
+    }
+}
+
+/// Fetch a v4 proposal and its associated vault transaction, decode the
+/// transaction message, and return a structured summary suitable for
+/// signers reviewing what a proposal will do before approving it.
+///
+/// `multisig_or_vault` accepts whatever `super::resolve_to_multisig`
+/// accepts: a v4 Multisig PDA, a vault PDA (resolved through the cache
+/// and fallback scan), or any v4 transaction-bearing account
+/// (Proposal / VaultTransaction / ConfigTransaction / Batch — multisig
+/// is read from the body).
+pub async fn get_proposal_info<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig_or_vault: &Pubkey,
+    transaction_index: u64,
+) -> Result<ProposalInfo, Error> {
+    use squads_multisig_program::state::{Multisig, Proposal};
+
+    let multisig_addr = super::resolve_to_multisig(client, multisig_or_vault).await?;
+    let proposal_addr = proposal_pda(&multisig_addr, transaction_index);
+    let transaction_addr = vault_transaction_pda(&multisig_addr, transaction_index);
+
+    let rpc = client.as_ref();
+    // The multisig is needed for threshold + stale_transaction_index.
+    let multisig: Multisig = fetch_account(
+        rpc,
+        multisig_addr.as_pubkey(),
+        &MULTISIG_DISCRIMINATOR,
+        "v4 Multisig",
+    )
+    .await?;
+    let proposal: Proposal =
+        fetch_account(rpc, &proposal_addr, &PROPOSAL_DISCRIMINATOR, "v4 Proposal").await?;
+
+    // Transaction PDAs are shared across kinds (VaultTransaction,
+    // ConfigTransaction, Batch all use the same `["multisig", ms,
+    // "transaction", index]` seeds). Fetch the account once and dispatch
+    // on its 8-byte discriminator.
+    let tx_account = rpc.get_account(&transaction_addr).await?;
+    if tx_account.owner != PROGRAM_ID {
+        return Err(
+            DecodeError::wrong_owner(&transaction_addr, "Squads v4", &tx_account.owner).into(),
+        );
+    }
+    let disc = super::read_discriminator(&tx_account.data)
+        .ok_or_else(|| DecodeError::wrong_discriminator(&transaction_addr, "v4 transaction"))?;
+    let body = &tx_account.data[8..];
+
+    let ctx = DecodeCtx {
+        multisig,
+        multisig_addr,
+        transaction_index,
+        proposal,
+        proposal_addr,
+        transaction_addr,
+        body,
+    };
+    match disc {
+        VAULT_TRANSACTION_DISCRIMINATOR => decode_vault_transaction(client, ctx).await,
+        CONFIG_TRANSACTION_DISCRIMINATOR => decode_config_transaction(ctx),
+        BATCH_DISCRIMINATOR => decode_batch(client, ctx).await,
+        _ => Err(DecodeError::wrong_discriminator(
+            &transaction_addr,
+            "v4 VaultTransaction / ConfigTransaction / Batch",
+        )
+        .into()),
+    }
+}
+
+/// Shared context for the per-kind decoders: everything fetched/computed
+/// before we know which transaction type we're looking at.
+struct DecodeCtx<'a> {
+    multisig: squads_multisig_program::state::Multisig,
+    multisig_addr: MultisigKey,
+    transaction_index: u64,
+    proposal: squads_multisig_program::state::Proposal,
+    proposal_addr: Pubkey,
+    transaction_addr: Pubkey,
+    body: &'a [u8],
+}
+
+async fn decode_vault_transaction<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    ctx: DecodeCtx<'_>,
+) -> Result<ProposalInfo, Error> {
+    let DecodeCtx {
+        multisig,
+        multisig_addr,
+        transaction_index,
+        proposal,
+        proposal_addr,
+        transaction_addr: vault_tx_addr,
+        body,
+    } = ctx;
+    let vault_tx = squads_multisig_program::state::VaultTransaction::deserialize(&mut &body[..])
+        .map_err(|e| DecodeError::deserialize(&vault_tx_addr, "v4 VaultTransaction", e))?;
+
+    let vault = vault_pda(&multisig_addr, vault_tx.vault_index);
+    let resolved_keys = resolve_account_keys(client, &vault_tx.message).await?;
+    let instructions: Vec<InstructionInfo> = vault_tx
+        .message
+        .instructions
+        .iter()
+        .map(|ix| compile_instruction_info(ix, &resolved_keys))
+        .collect::<Result<_, _>>()?;
+    let address_lookup_tables =
+        extract_lookup_tables(vault_tx.message.address_table_lookups.iter());
+    let summary = build_summary(&multisig, transaction_index, &proposal, &instructions);
+
+    Ok(ProposalInfo::VaultTransaction(VaultTransactionInfo {
+        summary,
+        multisig: multisig_addr,
+        transaction_index,
+        proposal: proposal_addr,
+        vault_transaction: vault_tx_addr,
+        status: convert_proposal_status(&proposal.status)?,
+        votes: votes_from(&proposal),
+        vault_index: vault_tx.vault_index,
+        vault,
+        creator: vault_tx.creator,
+        ephemeral_signers: SquadsError::try_u8(
+            vault_tx.ephemeral_signer_bumps.len(),
+            MessageField::EphemeralSignerIndex,
+        )?,
+        instructions,
+        address_lookup_tables,
+    }))
+}
+
+fn decode_config_transaction(ctx: DecodeCtx<'_>) -> Result<ProposalInfo, Error> {
+    let DecodeCtx {
+        multisig,
+        multisig_addr,
+        transaction_index,
+        proposal,
+        proposal_addr,
+        transaction_addr: config_tx_addr,
+        body,
+    } = ctx;
+    let config_tx = squads_multisig_program::state::ConfigTransaction::deserialize(&mut &body[..])
+        .map_err(|e| DecodeError::deserialize(&config_tx_addr, "v4 ConfigTransaction", e))?;
+
+    let actions: Vec<ConfigActionInfo> = config_tx
+        .actions
+        .iter()
+        .map(convert_config_action)
+        .collect();
+    let summary = build_summary(&multisig, transaction_index, &proposal, &[]);
+
+    Ok(ProposalInfo::ConfigTransaction(ConfigTransactionInfo {
+        summary,
+        multisig: multisig_addr,
+        transaction_index,
+        proposal: proposal_addr,
+        config_transaction: config_tx_addr,
+        status: convert_proposal_status(&proposal.status)?,
+        votes: votes_from(&proposal),
+        creator: config_tx.creator,
+        actions,
+    }))
+}
+
+async fn decode_batch<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    ctx: DecodeCtx<'_>,
+) -> Result<ProposalInfo, Error> {
+    let DecodeCtx {
+        multisig,
+        multisig_addr,
+        transaction_index,
+        proposal,
+        proposal_addr,
+        transaction_addr: batch_addr,
+        body,
+    } = ctx;
+    let batch = squads_multisig_program::state::Batch::deserialize(&mut &body[..])
+        .map_err(|e| DecodeError::deserialize(&batch_addr, "v4 Batch", e))?;
+
+    let vault = vault_pda(&multisig_addr, batch.vault_index);
+    let sub_transactions =
+        fetch_batch_sub_transactions(client, &multisig_addr, transaction_index, batch.size).await?;
+    let all_instructions: Vec<InstructionInfo> = sub_transactions
+        .iter()
+        .flat_map(|s| s.instructions.iter().cloned())
+        .collect();
+
+    let summary = build_summary(&multisig, transaction_index, &proposal, &all_instructions);
+
+    Ok(ProposalInfo::Batch(BatchInfo {
+        summary,
+        multisig: multisig_addr,
+        transaction_index,
+        proposal: proposal_addr,
+        batch: batch_addr,
+        status: convert_proposal_status(&proposal.status)?,
+        votes: votes_from(&proposal),
+        vault_index: batch.vault_index,
+        vault,
+        creator: batch.creator,
+        size: batch.size,
+        executed_transactions: batch.executed_transaction_index,
+        sub_transactions,
+    }))
+}
+
+/// Fetch and decode all sub-transactions for a Batch in parallel. Each
+/// sub-tx's instructions get the same LUT-resolved account treatment as
+/// a top-level VaultTransaction.
+async fn fetch_batch_sub_transactions<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    multisig_addr: &MultisigKey,
+    batch_index: u64,
+    size: u32,
+) -> Result<Vec<BatchSubTransaction>, Error> {
+    if size == 0 {
+        return Ok(Vec::new());
+    }
+    let rpc = client.as_ref();
+    let entries: Vec<(u32, Pubkey)> = (1..=size)
+        .map(|i| (i, batch_transaction_pda(multisig_addr, batch_index, i)))
+        .collect();
+
+    futures::stream::iter(entries)
+        .map(|(idx, addr)| async move {
+            let account = rpc.get_account(&addr).await?;
+            if account.owner != PROGRAM_ID
+                || account.data.len() < 8
+                || account.data[..8] != VAULT_BATCH_TRANSACTION_DISCRIMINATOR
+            {
+                return Err(
+                    DecodeError::wrong_discriminator(&addr, "v4 VaultBatchTransaction").into(),
+                );
+            }
+            let sub = squads_multisig_program::state::VaultBatchTransaction::deserialize(
+                &mut &account.data[8..],
+            )
+            .map_err(|e| DecodeError::deserialize(&addr, "v4 VaultBatchTransaction", e))?;
+            let resolved_keys = resolve_account_keys(client, &sub.message).await?;
+            let instructions: Vec<InstructionInfo> = sub
+                .message
+                .instructions
+                .iter()
+                .map(|ix| compile_instruction_info(ix, &resolved_keys))
+                .collect::<Result<_, _>>()?;
+            let address_lookup_tables =
+                extract_lookup_tables(sub.message.address_table_lookups.iter());
+            Ok::<BatchSubTransaction, Error>(BatchSubTransaction {
+                batch_index: idx,
+                address: addr,
+                ephemeral_signers: SquadsError::try_u8(
+                    sub.ephemeral_signer_bumps.len(),
+                    MessageField::EphemeralSignerIndex,
+                )?,
+                instructions,
+                address_lookup_tables,
+            })
+        })
+        .buffered(5)
+        .try_collect()
+        .await
+}
+
+fn convert_config_action(
+    action: &squads_multisig_program::state::ConfigAction,
+) -> ConfigActionInfo {
+    use squads_multisig_program::state::{ConfigAction, Period};
+    let period = |p: Period| match p {
+        Period::OneTime => ConfigSpendingPeriod::OneTime,
+        Period::Day => ConfigSpendingPeriod::Day,
+        Period::Week => ConfigSpendingPeriod::Week,
+        Period::Month => ConfigSpendingPeriod::Month,
+    };
+    match action {
+        ConfigAction::AddMember { new_member } => ConfigActionInfo::AddMember {
+            new_member: new_member.key,
+            permissions: MemberPermissions::from_mask(new_member.permissions.mask),
+        },
+        ConfigAction::RemoveMember { old_member } => ConfigActionInfo::RemoveMember {
+            old_member: *old_member,
+        },
+        ConfigAction::ChangeThreshold { new_threshold } => ConfigActionInfo::ChangeThreshold {
+            new_threshold: *new_threshold,
+        },
+        ConfigAction::SetTimeLock { new_time_lock } => ConfigActionInfo::SetTimeLock {
+            new_time_lock: *new_time_lock,
+        },
+        ConfigAction::AddSpendingLimit {
+            create_key,
+            vault_index,
+            mint,
+            amount,
+            period: p,
+            members,
+            destinations,
+        } => ConfigActionInfo::AddSpendingLimit {
+            create_key: *create_key,
+            vault_index: *vault_index,
+            mint: *mint,
+            amount: *amount,
+            period: period(*p),
+            members: members.iter().map(ToString::to_string).collect(),
+            destinations: destinations.iter().map(ToString::to_string).collect(),
+        },
+        ConfigAction::RemoveSpendingLimit { spending_limit } => {
+            ConfigActionInfo::RemoveSpendingLimit {
+                spending_limit: *spending_limit,
+            }
+        }
+        ConfigAction::SetRentCollector { new_rent_collector } => {
+            ConfigActionInfo::SetRentCollector {
+                new_rent_collector: *new_rent_collector,
+            }
+        }
+        // upstream is `#[non_exhaustive]`
+        _ => ConfigActionInfo::Unknown,
+    }
+}
+
+/// Fetch a v4 account, verify its owner and 8-byte discriminator, and Borsh-
+/// decode the body. The upstream Anchor types (Multisig / Proposal /
+/// VaultTransaction) are decorated with `#[account]` against anchor-lang
+/// 0.32 — a different trait surface than helium-lib's 0.31 fork — so we
+/// validate manually rather than going through `AccountDeserialize`.
+async fn fetch_account<T: AnchorDeserialize>(
+    rpc: &SolanaRpcClient,
+    address: &Pubkey,
+    expected_disc: &[u8; 8],
+    type_name: &'static str,
+) -> Result<T, Error> {
+    let account = rpc.get_account(address).await?;
+    decode_account(
+        address,
+        &account.owner,
+        &account.data,
+        expected_disc,
+        type_name,
+    )
+}
+
+/// Validate-and-decode helper used by both fetch paths and the unified
+/// `decode_multisig` entry. Exists so error sites have a single
+/// authoritative source instead of repeating wrong-owner / wrong-disc /
+/// borsh-failure strings at every call.
+fn decode_account<T: AnchorDeserialize>(
+    address: &Pubkey,
+    owner: &Pubkey,
+    data: &[u8],
+    expected_disc: &[u8; 8],
+    type_name: &'static str,
+) -> Result<T, Error> {
+    if *owner != PROGRAM_ID {
+        return Err(DecodeError::wrong_owner(address, "Squads v4", owner).into());
+    }
+    if data.len() < 8 || &data[..8] != expected_disc {
+        return Err(DecodeError::wrong_discriminator(address, type_name).into());
+    }
+    T::deserialize(&mut &data[8..])
+        .map_err(|e| DecodeError::deserialize(address, type_name, e).into())
+}
+
+/// Vote tally lifted off the on-chain `Proposal`. Used by every decode
+/// path that surfaces a `ProposalVotes` so the field set stays
+/// consistent.
+fn votes_from(proposal: &squads_multisig_program::state::Proposal) -> ProposalVotes {
+    ProposalVotes {
+        approved: proposal.approved.len(),
+        rejected: proposal.rejected.len(),
+        cancelled: proposal.cancelled.len(),
+    }
+}
+
+/// Convert Squads' on-chain `MessageAddressTableLookup` entries into
+/// our reviewer-facing `AddressLookupInfo` rows. Used by both the
+/// top-level VaultTransaction decoder and the Batch sub-transaction
+/// decoder so the surfaced shape stays in sync.
+fn extract_lookup_tables<'a, I>(lookups: I) -> Vec<AddressLookupInfo>
+where
+    I: IntoIterator<Item = &'a squads_multisig_program::state::MultisigMessageAddressTableLookup>,
+{
+    lookups
+        .into_iter()
+        .map(|lut| AddressLookupInfo {
+            address: lut.account_key,
+            writable_indexes: lut.writable_indexes.clone(),
+            readonly_indexes: lut.readonly_indexes.clone(),
+        })
+        .collect()
+}
+
+/// Compute the at-a-glance signals from already-fetched data — no extra
+/// RPC calls. Order matters for `programs`: we keep the order of first
+/// appearance so the summary mirrors the instruction list.
+fn build_summary(
+    multisig: &squads_multisig_program::state::Multisig,
+    transaction_index: u64,
+    proposal: &squads_multisig_program::state::Proposal,
+    instructions: &[InstructionInfo],
+) -> ProposalSummary {
+    let approved = proposal.approved.len();
+    let threshold = multisig.threshold;
+    let approvals = format!("{approved}/{threshold}");
+    let stale = transaction_index <= multisig.stale_transaction_index;
+    super::build_summary(approvals, stale, instructions)
+}
+
+pub(super) fn decode_multisig(
+    address: MultisigKey,
+    data: &[u8],
+    resolved_from_vault: Option<VaultKey>,
+) -> Result<MultisigInfo, Error> {
+    let multisig = decode_account::<squads_multisig_program::state::Multisig>(
+        address.as_pubkey(),
+        &PROGRAM_ID, // already validated by the caller, but recheck for safety
+        data,
+        &MULTISIG_DISCRIMINATOR,
+        "v4 Multisig",
+    )?;
+    let members = multisig
+        .members
+        .iter()
+        .map(|m| MemberInfo {
+            key: m.key,
+            permissions: MemberPermissions::from_mask(m.permissions.mask),
+        })
+        .collect();
+    Ok(MultisigInfo {
+        address,
+        version: Version::V4,
+        threshold: multisig.threshold,
+        transaction_index: multisig.transaction_index,
+        members,
+        resolved_from_vault,
+    })
+}
+
+/// Cheap check for "this account is a v4 Multisig" used during vault
+/// resolution scans.
+pub(super) fn is_multisig_account(owner: &Pubkey, data: &[u8]) -> bool {
+    *owner == PROGRAM_ID && data.len() >= 8 && data[..8] == MULTISIG_DISCRIMINATOR
+}
+
+/// Self-identify a v4 account that already passed the owner check. Returns
+/// `Ok(Some((multisig, index)))` for any of the four transaction-bearing
+/// kinds (Proposal / VaultTransaction / ConfigTransaction / Batch);
+/// `Ok(None)` if the account is a Multisig (caller must supply the
+/// index); `Err` if the discriminator isn't one we recognize.
+pub(super) fn extract_target(
+    address: &Pubkey,
+    data: &[u8],
+) -> Result<Option<(Pubkey, u64)>, Error> {
+    use squads_multisig_program::state::{Batch, ConfigTransaction, Proposal, VaultTransaction};
+    let disc = super::read_discriminator(data)
+        .ok_or_else(|| DecodeError::wrong_discriminator(address, "v4 account"))?;
+    let body = &data[8..];
+    Ok(Some(match disc {
+        MULTISIG_DISCRIMINATOR => return Ok(None),
+        PROPOSAL_DISCRIMINATOR => {
+            let p = Proposal::deserialize(&mut &body[..])
+                .map_err(|e| DecodeError::deserialize(address, "v4 Proposal", e))?;
+            (p.multisig, p.transaction_index)
+        }
+        VAULT_TRANSACTION_DISCRIMINATOR => {
+            let v = VaultTransaction::deserialize(&mut &body[..])
+                .map_err(|e| DecodeError::deserialize(address, "v4 VaultTransaction", e))?;
+            (v.multisig, v.index)
+        }
+        CONFIG_TRANSACTION_DISCRIMINATOR => {
+            let c = ConfigTransaction::deserialize(&mut &body[..])
+                .map_err(|e| DecodeError::deserialize(address, "v4 ConfigTransaction", e))?;
+            (c.multisig, c.index)
+        }
+        BATCH_DISCRIMINATOR => {
+            let b = Batch::deserialize(&mut &body[..])
+                .map_err(|e| DecodeError::deserialize(address, "v4 Batch", e))?;
+            (b.multisig, b.index)
+        }
+        _ => {
+            return Err(DecodeError::wrong_discriminator(address, "v4 account").into());
+        }
+    }))
+}
+
+fn convert_proposal_status(
+    status: &squads_multisig_program::state::ProposalStatus,
+) -> Result<ProposalStatusInfo, Error> {
+    use squads_multisig_program::state::ProposalStatus;
+    // Squads timestamps are seconds since epoch; `from_timestamp`
+    // returns `None` only for values outside chrono's representable
+    // range (year ±262_144), which a healthy proposal never produces.
+    // Surface the bad value rather than silently rendering 1970 — a
+    // reviewer who sees a malformed timestamp wants to know the
+    // proposal account is corrupt.
+    let to_dt = |ts: i64| {
+        DateTime::<Utc>::from_timestamp(ts, 0).ok_or(SquadsError::invalid_status_timestamp(ts))
+    };
+    #[allow(deprecated)]
+    Ok(match status {
+        ProposalStatus::Draft { timestamp } => ProposalStatusInfo::Draft {
+            timestamp: to_dt(*timestamp)?,
+        },
+        ProposalStatus::Active { timestamp } => ProposalStatusInfo::Active {
+            timestamp: to_dt(*timestamp)?,
+        },
+        ProposalStatus::Rejected { timestamp } => ProposalStatusInfo::Rejected {
+            timestamp: to_dt(*timestamp)?,
+        },
+        ProposalStatus::Approved { timestamp } => ProposalStatusInfo::Approved {
+            timestamp: to_dt(*timestamp)?,
+        },
+        ProposalStatus::Executed { timestamp } => ProposalStatusInfo::Executed {
+            timestamp: to_dt(*timestamp)?,
+        },
+        ProposalStatus::Cancelled { timestamp } => ProposalStatusInfo::Cancelled {
+            timestamp: to_dt(*timestamp)?,
+        },
+        ProposalStatus::Executing => ProposalStatusInfo::Executing,
+        // Upstream `ProposalStatus` is `#[non_exhaustive]`; future variants
+        // render as the deprecated transient `Executing` until we update.
+        _ => ProposalStatusInfo::Executing,
+    })
+}
+
+/// One entry in the resolved account list — tracks pubkey plus its
+/// writable/signer status so we can render instruction account refs
+/// uniformly whether they came from static keys or were materialized
+/// out of an address lookup table.
+struct ResolvedKey {
+    pubkey: Pubkey,
+    writable: bool,
+    signer: bool,
+}
+
+/// Build the full account list a v4 instruction can address: static keys
+/// in their original positions, then for each LUT in
+/// `address_table_lookups` order, that LUT's writable-resolved section
+/// followed by its readonly-resolved section. Matches the layout
+/// `vault_transaction_execute` validates against in
+/// `ExecutableTransactionMessage::new_validated` (per-LUT
+/// writable/readonly), which is what `MultisigCompiledInstruction.
+/// account_indexes` reference.
+async fn resolve_account_keys<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    msg: &squads_multisig_program::state::VaultTransactionMessage,
+) -> Result<Vec<ResolvedKey>, Error> {
+    let mut keys: Vec<ResolvedKey> = msg
+        .account_keys
+        .iter()
+        .enumerate()
+        .map(|(i, key)| ResolvedKey {
+            pubkey: *key,
+            writable: msg.is_static_writable_index(i),
+            signer: msg.is_signer_index(i),
+        })
+        .collect();
+
+    if msg.address_table_lookups.is_empty() {
+        return Ok(keys);
+    }
+
+    // Bulk-fetch the LUT accounts via the same raw JSON-RPC path used by
+    // vault resolution — solana-client's `get_multiple_accounts` trips
+    // on the rent_epoch=u64::MAX sentinel.
+    let lut_addrs: Vec<Pubkey> = msg
+        .address_table_lookups
+        .iter()
+        .map(|lut| lut.account_key)
+        .collect();
+    let rpc_url = client.as_ref().url();
+    let lut_accounts = super::raw_get_multiple_accounts(&rpc_url, &lut_addrs).await?;
+
+    for (lut, account) in msg.address_table_lookups.iter().zip(lut_accounts) {
+        // Inspect can't render a faithful proposal view if a referenced
+        // LUT is missing — the on-chain resolution would still produce
+        // accounts, but our local resolution would silently drop them
+        // and `compile_instruction_info` would render an instruction
+        // with fewer accounts than it actually has. Match the execute
+        // path's `account_not_found` bail.
+        let Some(raw) = account else {
+            return Err(Error::account_not_found());
+        };
+        let table =
+            solana_sdk::address_lookup_table::state::AddressLookupTable::deserialize(&raw.data)
+                .map_err(|e| DecodeError::deserialize(&lut.account_key, "LUT", e))?;
+        // Same out-of-range bail as the execute path — silent skip
+        // would shift later indices and break alignment with
+        // compile_instruction_info.
+        for key in resolve_lut_indexes(&table, &lut.account_key, &lut.writable_indexes)? {
+            keys.push(ResolvedKey {
+                pubkey: key,
+                writable: true,
+                signer: false,
+            });
+        }
+        for key in resolve_lut_indexes(&table, &lut.account_key, &lut.readonly_indexes)? {
+            keys.push(ResolvedKey {
+                pubkey: key,
+                writable: false,
+                signer: false,
+            });
+        }
+    }
+    Ok(keys)
+}
+
+/// Resolve a slice of LUT indexes against the resolved table, bailing
+/// loudly on any out-of-range index instead of silently dropping the
+/// entry. Squads' on-chain handler reads the same LUT and won't tolerate
+/// a missing slot — silently skipping would produce a misaligned account
+/// list and ship a tx the validator either rejects or mis-applies.
+fn resolve_lut_indexes(
+    table: &solana_sdk::address_lookup_table::state::AddressLookupTable<'_>,
+    table_addr: &Pubkey,
+    indexes: &[u8],
+) -> Result<Vec<Pubkey>, Error> {
+    indexes
+        .iter()
+        .map(|&idx| {
+            table
+                .addresses
+                .get(usize::from(idx))
+                .copied()
+                .ok_or_else(|| {
+                    SquadsError::lut_index_out_of_range(*table_addr, idx, table.addresses.len())
+                        .into()
+                })
+        })
+        .collect()
+}
+
+fn compile_instruction_info(
+    ix: &squads_multisig_program::state::MultisigCompiledInstruction,
+    keys: &[ResolvedKey],
+) -> Result<InstructionInfo, Error> {
+    let program_idx = usize::from(ix.program_id_index);
+    let program_id = keys.get(program_idx).map(|k| k.pubkey).ok_or_else(|| {
+        SquadsError::instruction_index_out_of_range(
+            CompiledInstructionField::ProgramIdIndex,
+            program_idx,
+            keys.len(),
+        )
+    })?;
+    let accounts: Vec<InstructionAccountRef> = ix
+        .account_indexes
+        .iter()
+        .map(|idx| {
+            let i = usize::from(*idx);
+            let key = keys.get(i).ok_or_else(|| {
+                SquadsError::instruction_index_out_of_range(
+                    CompiledInstructionField::AccountIndex,
+                    i,
+                    keys.len(),
+                )
+            })?;
+            Ok::<_, Error>(InstructionAccountRef {
+                pubkey: key.pubkey,
+                writable: key.writable,
+                signer: key.signer,
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    let program = KnownProgram::from_pubkey(&program_id);
+    let disc_bytes = super::read_discriminator(&ix.data);
+    let body = ix.data.get(8..);
+    let method = program
+        .zip(disc_bytes.as_ref())
+        .and_then(|(p, d)| p.method_name_with_body(d, body.unwrap_or(&[])));
+    let args = program
+        .zip(disc_bytes.as_ref())
+        .zip(body)
+        .and_then(|((p, d), b)| p.decode_instruction_args(d, b));
+    let discriminator = disc_bytes.map(|d| bs58::encode(d).into_string());
+    Ok(InstructionInfo {
+        program_id,
+        program,
+        method,
+        args,
+        accounts,
+        data_len: ix.data.len(),
+        discriminator,
+        data_b58: bs58::encode(&ix.data).into_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip: an approve instruction's first 8 data bytes are the
+    /// approve discriminator, the rest deserializes into a
+    /// `ProposalVoteArgs` carrying the original memo. Catches mismatches
+    /// between the hardcoded discriminators and the upstream args type.
+    #[test]
+    fn proposal_approve_roundtrip() {
+        let multisig = MultisigKey::from_pubkey(Pubkey::new_unique());
+        let member = Pubkey::new_unique();
+        let memo = Some("ship it".to_string());
+        let ix = proposal_approve_ix(multisig, 42, member, memo.clone()).expect("build");
+
+        assert_eq!(ix.program_id, PROGRAM_ID);
+        assert_eq!(&ix.data[..8], &PROPOSAL_APPROVE_IX);
+        let args = squads_multisig_program::instructions::ProposalVoteArgs::deserialize(
+            &mut &ix.data[8..],
+        )
+        .expect("decode args");
+        assert_eq!(args.memo, memo);
+
+        // Account ordering: multisig (ro), member (signer mut), proposal (mut)
+        assert_eq!(ix.accounts.len(), 3);
+        assert_eq!(ix.accounts[0].pubkey, multisig.into_pubkey());
+        assert!(!ix.accounts[0].is_signer);
+        assert!(!ix.accounts[0].is_writable);
+        assert_eq!(ix.accounts[1].pubkey, member);
+        assert!(ix.accounts[1].is_signer);
+        assert!(ix.accounts[1].is_writable);
+        assert_eq!(ix.accounts[2].pubkey, proposal_pda(&multisig, 42));
+        assert!(!ix.accounts[2].is_signer);
+        assert!(ix.accounts[2].is_writable);
+    }
+
+    /// Reject and cancel share the same accounts shape; only the
+    /// discriminator differs.
+    #[test]
+    fn vote_discriminators_distinct() {
+        assert_ne!(PROPOSAL_APPROVE_IX, PROPOSAL_REJECT_IX);
+        assert_ne!(PROPOSAL_APPROVE_IX, PROPOSAL_CANCEL_IX);
+        assert_ne!(PROPOSAL_REJECT_IX, PROPOSAL_CANCEL_IX);
+    }
+
+    /// Compile a tiny synthetic instruction message and confirm the
+    /// header counts, key ordering, and payload framing match Squads'
+    /// expected layout. Catches regressions in the SmallVec encoding.
+    #[test]
+    fn compile_message_layout() {
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+        let vault = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = Instruction {
+            program_id: program,
+            accounts: vec![
+                AccountMeta::new(vault, true),
+                AccountMeta::new(recipient, false),
+            ],
+            data: vec![1, 2, 3, 4],
+        };
+        let bytes = compile_transaction_message(&vault, &[ix]).expect("compact");
+
+        // Header: 1 signer total, 1 writable signer, 1 writable non-signer
+        // (recipient), and program_id is readonly non-signer.
+        assert_eq!(bytes[0], 1, "num_signers");
+        assert_eq!(bytes[1], 1, "num_writable_signers");
+        assert_eq!(bytes[2], 1, "num_writable_non_signers");
+
+        // account_keys: u8 length = 3 (vault, recipient, program), then
+        // 3 × 32 bytes. Vault must be at index 0 (writable signer slot).
+        assert_eq!(bytes[3], 3, "account_keys count");
+        let key0 = &bytes[4..36];
+        assert_eq!(key0, vault.as_ref(), "vault first");
+
+        // Instruction count = 1 immediately after the keys section.
+        let ix_count_offset = 4 + 3 * 32;
+        assert_eq!(bytes[ix_count_offset], 1, "instruction count");
+
+        // CompiledInstruction: program_id_index (u8), account_indexes
+        // SmallVec<u8, u8> = u8 len + N bytes, data SmallVec<u16, u8> =
+        // u16 LE len + N bytes.
+        let p = ix_count_offset + 1;
+        // program_id_index points to the program in account_keys.
+        assert_eq!(bytes[p], 2, "program_id at index 2");
+        assert_eq!(bytes[p + 1], 2, "account_indexes len = 2");
+        // account_indexes[0] = vault (0), [1] = recipient (1)
+        assert_eq!(bytes[p + 2], 0);
+        assert_eq!(bytes[p + 3], 1);
+        // data length is u16 LE = 4
+        assert_eq!(&bytes[p + 4..p + 6], &4u16.to_le_bytes());
+        assert_eq!(&bytes[p + 6..p + 10], &[1, 2, 3, 4]);
+
+        // Trailing empty address_table_lookups (SmallVec<u8, _> length = 0).
+        assert_eq!(*bytes.last().unwrap(), 0, "no LUTs");
+    }
+
+    #[test]
+    fn create_discriminators_distinct() {
+        assert_ne!(VAULT_TRANSACTION_CREATE_IX, PROPOSAL_CREATE_IX);
+        assert_ne!(VAULT_TRANSACTION_CREATE_IX, VAULT_TRANSACTION_EXECUTE_IX);
+        assert_ne!(VAULT_TRANSACTION_CREATE_IX, CONFIG_TRANSACTION_CREATE_IX);
+        assert_ne!(CONFIG_TRANSACTION_CREATE_IX, PROPOSAL_CREATE_IX);
+    }
+
+    /// Round-trip: a config_transaction_create instruction's data
+    /// starts with the discriminator and decodes into
+    /// `ConfigTransactionCreateArgs` carrying the actions and memo
+    /// passed in. Catches discriminator typos and args-shape drift.
+    #[test]
+    fn config_transaction_create_roundtrip() {
+        use squads_multisig_program::state::{ConfigAction, Member, Permissions};
+        let multisig = MultisigKey::from_pubkey(Pubkey::new_unique());
+        let creator = Pubkey::new_unique();
+        let new_member = Pubkey::new_unique();
+        let actions = vec![
+            ConfigAction::AddMember {
+                new_member: Member {
+                    key: new_member,
+                    permissions: Permissions { mask: 0b111 },
+                },
+            },
+            ConfigAction::ChangeThreshold { new_threshold: 2 },
+        ];
+        let memo = Some("add member".to_string());
+        let ix = config_transaction_create_ix(multisig, 5, creator, actions, memo.clone())
+            .expect("build");
+
+        assert_eq!(ix.program_id, PROGRAM_ID);
+        assert_eq!(&ix.data[..8], &CONFIG_TRANSACTION_CREATE_IX);
+        let args = squads_multisig_program::instructions::ConfigTransactionCreateArgs::deserialize(
+            &mut &ix.data[8..],
+        )
+        .expect("decode args");
+        assert_eq!(args.actions.len(), 2);
+        assert_eq!(args.memo, memo);
+
+        // Account ordering: multisig (mut), transaction (mut), creator
+        // (signer), rent_payer (signer mut, same as creator), system_program.
+        assert_eq!(ix.accounts.len(), 5);
+        assert_eq!(ix.accounts[0].pubkey, multisig.into_pubkey());
+        assert!(ix.accounts[0].is_writable);
+        assert_eq!(ix.accounts[1].pubkey, vault_transaction_pda(&multisig, 5));
+        assert!(ix.accounts[1].is_writable);
+        assert_eq!(ix.accounts[2].pubkey, creator);
+        assert!(ix.accounts[2].is_signer);
+        assert_eq!(ix.accounts[3].pubkey, creator); // rent_payer = creator
+        assert!(ix.accounts[3].is_signer);
+        assert!(ix.accounts[3].is_writable);
+        assert_eq!(ix.accounts[4].pubkey, solana_sdk::system_program::ID);
+    }
+
+    /// `ConfigActionInput::AddMember` round-trips into the upstream
+    /// `state::ConfigAction::AddMember` with the right Member +
+    /// Permissions shape, and `MemberPermissions::to_mask` produces
+    /// the bit positions Squads' on-chain `Permission` enum expects.
+    #[test]
+    fn config_action_input_add_member_lowering() {
+        use squads_multisig_program::state::ConfigAction;
+        let new_member = Pubkey::new_unique();
+        let action: ConfigAction = ConfigActionInput::AddMember {
+            new_member,
+            // Initiate + Execute, not Vote.
+            permissions: MemberPermissions {
+                propose: true,
+                vote: false,
+                execute: true,
+            },
+        }
+        .into();
+        match action {
+            ConfigAction::AddMember { new_member: m } => {
+                assert_eq!(m.key, new_member);
+                assert_eq!(m.permissions.mask, 0b101);
+            }
+            _ => panic!("expected AddMember"),
+        }
+    }
+
+    /// `MemberPermissions::to_mask` ↔ `from_mask` round-trip pins the
+    /// bit-position contract with Squads' upstream `Permission` enum
+    /// (`Initiate=1<<0`, `Vote=1<<1`, `Execute=1<<2`). A regression in
+    /// either direction surfaces here.
+    #[test]
+    fn member_permissions_mask_round_trip() {
+        for propose in [false, true] {
+            for vote in [false, true] {
+                for execute in [false, true] {
+                    let p = MemberPermissions {
+                        propose,
+                        vote,
+                        execute,
+                    };
+                    assert_eq!(MemberPermissions::from_mask(p.to_mask()), p);
+                }
+            }
+        }
+        // Spot-check known bit positions.
+        assert_eq!(MemberPermissions::ALL.to_mask(), 0b111);
+        assert_eq!(MemberPermissions::default().to_mask(), 0);
+    }
+
+    /// An account in a LUT is pulled out of the static keys, encoded as
+    /// a lookup reference (account_key + index inside the LUT), and
+    /// referenced by the compiled instruction at
+    /// `static_keys.len() + offset` in the resolved section.
+    #[test]
+    fn compile_message_with_luts_layout() {
+        use solana_sdk::address_lookup_table::AddressLookupTableAccount;
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+
+        let vault = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let lut_account = Pubkey::new_unique();
+        let lut = AddressLookupTableAccount {
+            key: Pubkey::new_unique(),
+            // Pad with a few unrelated entries so addr_idx isn't 0.
+            addresses: vec![
+                Pubkey::new_unique(),
+                Pubkey::new_unique(),
+                lut_account,
+                Pubkey::new_unique(),
+            ],
+        };
+        let lut_addr_idx: u8 = 2;
+
+        let ix = Instruction {
+            program_id: program,
+            accounts: vec![
+                AccountMeta::new(vault, true),
+                AccountMeta::new(recipient, false),
+                AccountMeta::new_readonly(lut_account, false),
+            ],
+            data: vec![9, 9, 9],
+        };
+        let bytes =
+            compile_transaction_message_with_luts(&vault, &[ix], &[lut.clone()]).expect("compact");
+
+        // Header.
+        assert_eq!(bytes[0], 1, "num_signers");
+        assert_eq!(bytes[1], 1, "num_writable_signers");
+        assert_eq!(bytes[2], 1, "num_writable_non_signers");
+
+        // Static keys: only vault, recipient, program — lut_account is
+        // resolved through the LUT, not inlined.
+        assert_eq!(bytes[3], 3, "static account_keys count");
+        let key0 = &bytes[4..36];
+        assert_eq!(key0, vault.as_ref(), "vault first");
+
+        // Instruction section.
+        let ix_count_offset = 4 + 3 * 32;
+        assert_eq!(bytes[ix_count_offset], 1);
+        let p = ix_count_offset + 1;
+        // program_id sits in static_keys at index 2 (readonly non-signer).
+        assert_eq!(bytes[p], 2, "program_id_index = 2");
+        assert_eq!(bytes[p + 1], 3, "account_indexes len = 3");
+        assert_eq!(bytes[p + 2], 0, "vault at static index 0");
+        assert_eq!(bytes[p + 3], 1, "recipient at static index 1");
+        // lut_account resolves at static_keys.len() + 0 = 3 (first
+        // entry in the LUT's resolved section, readonly).
+        assert_eq!(bytes[p + 4], 3, "lut_account at index 3");
+        assert_eq!(&bytes[p + 5..p + 7], &3u16.to_le_bytes(), "data len");
+        assert_eq!(&bytes[p + 7..p + 10], &[9, 9, 9]);
+
+        // address_table_lookups: 1 entry, account_key, no writable, one
+        // readonly index pointing into the LUT.
+        let lut_offset = p + 10;
+        assert_eq!(bytes[lut_offset], 1, "1 LUT lookup");
+        assert_eq!(&bytes[lut_offset + 1..lut_offset + 33], lut.key.as_ref());
+        assert_eq!(bytes[lut_offset + 33], 0, "writable_indexes empty");
+        assert_eq!(bytes[lut_offset + 34], 1, "readonly_indexes len = 1");
+        assert_eq!(bytes[lut_offset + 35], lut_addr_idx);
+        assert_eq!(bytes.len(), lut_offset + 36, "no trailing bytes");
+    }
+
+    /// Counts that don't fit Squads' u8/u16 wire-format limits should
+    /// surface a clean `MessageFieldOverflow` error rather than silently
+    /// truncate via `as u8` and produce a corrupted message that
+    /// on-chain validation would reject with an unrelated parse error.
+    #[test]
+    fn compile_message_rejects_oversized_data() {
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+        let vault = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = Instruction {
+            program_id: program,
+            accounts: vec![AccountMeta::new(vault, true)],
+            // Just over u16::MAX bytes of data.
+            data: vec![0u8; usize::from(u16::MAX) + 1],
+        };
+        let err =
+            compile_transaction_message(&vault, &[ix]).expect_err("must reject oversized data");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("instruction_data_len"),
+            "error should name the offending field, got: {msg}",
+        );
+    }
+
+    /// Same input must produce the same byte output across runs — both
+    /// the static-key buckets and the per-LUT entries pull from
+    /// HashMaps internally, so ordering needs an explicit sort. A
+    /// proposal payload that hashes differently between runs would
+    /// break any external tooling that pins proposals by content hash.
+    #[test]
+    fn compile_message_is_deterministic() {
+        use solana_sdk::address_lookup_table::AddressLookupTableAccount;
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+
+        let vault = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        // Eight distinct accounts spread across all four buckets so
+        // HashMap ordering would visibly affect output.
+        let writable_signer = Pubkey::new_unique();
+        let readonly_signer = Pubkey::new_unique();
+        let writable_a = Pubkey::new_unique();
+        let writable_b = Pubkey::new_unique();
+        let readonly_a = Pubkey::new_unique();
+        let readonly_b = Pubkey::new_unique();
+        let lut_a = Pubkey::new_unique();
+        let lut_b = Pubkey::new_unique();
+        let lut = AddressLookupTableAccount {
+            key: Pubkey::new_unique(),
+            addresses: vec![lut_a, lut_b],
+        };
+        let ix = Instruction {
+            program_id: program,
+            accounts: vec![
+                AccountMeta::new(vault, true),
+                AccountMeta::new(writable_signer, true),
+                AccountMeta::new_readonly(readonly_signer, true),
+                AccountMeta::new(writable_a, false),
+                AccountMeta::new(writable_b, false),
+                AccountMeta::new_readonly(readonly_a, false),
+                AccountMeta::new_readonly(readonly_b, false),
+                AccountMeta::new(lut_a, false),
+                AccountMeta::new_readonly(lut_b, false),
+            ],
+            data: vec![7; 16],
+        };
+        let first = compile_transaction_message_with_luts(&vault, &[ix.clone()], &[lut.clone()])
+            .expect("compact");
+        for _ in 0..16 {
+            assert_eq!(
+                first,
+                compile_transaction_message_with_luts(&vault, &[ix.clone()], &[lut.clone()])
+                    .expect("compact"),
+                "compactor output must be deterministic"
+            );
+        }
+    }
+
+    /// Empty `luts` is a no-op: output equals the non-LUT compactor.
+    #[test]
+    fn compile_message_with_empty_luts_matches_static() {
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+        let vault = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = Instruction {
+            program_id: program,
+            accounts: vec![
+                AccountMeta::new(vault, true),
+                AccountMeta::new(recipient, false),
+            ],
+            data: vec![1, 2, 3, 4],
+        };
+        let static_only = compile_transaction_message(&vault, &[ix.clone()]).expect("compact");
+        let with_empty_luts =
+            compile_transaction_message_with_luts(&vault, &[ix], &[]).expect("compact");
+        assert_eq!(static_only, with_empty_luts);
+    }
+
+    /// A signer in an inner instruction must remain in the static keys
+    /// even if it appears in a LUT — LUTs can't carry signatures.
+    #[test]
+    fn compile_message_signer_forced_static_despite_lut() {
+        use solana_sdk::address_lookup_table::AddressLookupTableAccount;
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+
+        let vault = Pubkey::new_unique();
+        let extra_signer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let lut = AddressLookupTableAccount {
+            key: Pubkey::new_unique(),
+            addresses: vec![extra_signer],
+        };
+        let ix = Instruction {
+            program_id: program,
+            accounts: vec![
+                AccountMeta::new(vault, true),
+                AccountMeta::new_readonly(extra_signer, true),
+            ],
+            data: vec![],
+        };
+        let bytes = compile_transaction_message_with_luts(&vault, &[ix], &[lut]).expect("compact");
+
+        // Both signers stay static: 2 signers, 1 writable signer.
+        assert_eq!(bytes[0], 2, "num_signers");
+        assert_eq!(bytes[1], 1, "num_writable_signers");
+        assert_eq!(bytes[3], 3, "static account_keys count");
+        // No LUT entries should be emitted (the signer was the only
+        // candidate, and signers are forced static).
+        let last = *bytes.last().unwrap();
+        assert_eq!(last, 0, "no LUT lookups emitted");
+    }
+
+    /// When an account appears in two LUTs the compactor must pick the
+    /// first — the inner `position` + `break` combination at the LUT
+    /// classification site enforces this. A future refactor that
+    /// scanned all LUTs (or picked the last) would silently switch
+    /// which LUT a proposal references; the on-chain `address_table_lookups`
+    /// section then points at a different table than the proposer
+    /// intended. Test pins the contract.
+    #[test]
+    fn compile_message_lut_first_wins() {
+        use solana_sdk::address_lookup_table::AddressLookupTableAccount;
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+
+        let vault = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let shared = Pubkey::new_unique();
+        let lut_a = AddressLookupTableAccount {
+            key: Pubkey::new_unique(),
+            addresses: vec![shared],
+        };
+        let lut_b = AddressLookupTableAccount {
+            key: Pubkey::new_unique(),
+            addresses: vec![shared],
+        };
+        let ix = Instruction {
+            program_id: program,
+            accounts: vec![
+                AccountMeta::new(vault, true),
+                AccountMeta::new_readonly(shared, false),
+            ],
+            data: vec![],
+        };
+        let bytes = compile_transaction_message_with_luts(&vault, &[ix], &[lut_a.clone(), lut_b])
+            .expect("compact");
+
+        // Static count = 2 (vault + program); shared is LUT-resolved.
+        assert_eq!(bytes[3], 2, "static account_keys count");
+        // Walk to the address_table_lookups section: header(3) + static
+        // keys (1 + 2*32) + ix section (1 + 1 + 1 + 2 + 2 + 0).
+        let static_end = 4 + 2 * 32;
+        // Instruction section: count(1) + program_id_index(1) +
+        // accounts_len(1) + 2 account indexes + data_len(2) + 0 bytes.
+        let ix_count_offset = static_end;
+        assert_eq!(bytes[ix_count_offset], 1);
+        let lut_section_offset = ix_count_offset + 1 + 1 + 1 + 2 + 2;
+        assert_eq!(bytes[lut_section_offset], 1, "exactly one LUT used");
+        // First 32 bytes of the LUT entry must be lut_a's key — first wins.
+        assert_eq!(
+            &bytes[lut_section_offset + 1..lut_section_offset + 33],
+            lut_a.key.as_ref(),
+            "first LUT in the slice must win",
+        );
+    }
+
+    /// Per-LUT writable entries must precede readonly entries in the
+    /// resolved index space — Squads' `ExecutableTransactionMessage::
+    /// new_validated` walks the section in that order. Test feeds one
+    /// LUT containing both a writable and a readonly account and
+    /// asserts the writable account's index comes first in the
+    /// compiled instruction's `account_indexes`.
+    #[test]
+    fn compile_message_lut_writable_before_readonly() {
+        use solana_sdk::address_lookup_table::AddressLookupTableAccount;
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+
+        let vault = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        // Pick fixed bytes so deterministic-sort doesn't reshuffle them.
+        let writable_key = Pubkey::from([1u8; 32]);
+        let readonly_key = Pubkey::from([2u8; 32]);
+        let lut = AddressLookupTableAccount {
+            key: Pubkey::new_unique(),
+            addresses: vec![readonly_key, writable_key], // intentionally not in order
+        };
+        let ix = Instruction {
+            program_id: program,
+            accounts: vec![
+                AccountMeta::new(vault, true),
+                AccountMeta::new(writable_key, false),
+                AccountMeta::new_readonly(readonly_key, false),
+            ],
+            data: vec![],
+        };
+        let bytes =
+            compile_transaction_message_with_luts(&vault, &[ix], &[lut.clone()]).expect("compact");
+
+        // Static count = 2 (vault + program); both LUT keys are resolved.
+        let static_count = bytes[3] as usize;
+        assert_eq!(static_count, 2, "static account_keys count");
+
+        // Walk to the LUT section.
+        let ix_count_offset = 4 + static_count * 32;
+        assert_eq!(bytes[ix_count_offset], 1);
+        let p = ix_count_offset + 1;
+        // Instruction account_indexes layout: vault(0), writable_key, readonly_key.
+        assert_eq!(bytes[p + 1], 3, "account_indexes len = 3");
+        assert_eq!(bytes[p + 2], 0, "vault at static index 0");
+        // Writable goes first in the LUT-resolved section.
+        let writable_resolved_idx = static_count as u8;
+        let readonly_resolved_idx = static_count as u8 + 1;
+        assert_eq!(
+            bytes[p + 3],
+            writable_resolved_idx,
+            "writable_key at static_count+0",
+        );
+        assert_eq!(
+            bytes[p + 4],
+            readonly_resolved_idx,
+            "readonly_key at static_count+1",
+        );
+
+        // Verify the address_table_lookups layout: writable_indexes
+        // section comes before readonly_indexes. Layout after `p`:
+        // program_id_index(1) + accounts_len(1) + 3 indexes + data_len(2)
+        // + 0 data bytes = p + 7.
+        let lut_section_offset = p + 7;
+        assert_eq!(bytes[lut_section_offset], 1, "1 LUT");
+        let lut_offset = lut_section_offset + 1;
+        // 32 bytes of LUT account_key, then writable_indexes len + 1 byte,
+        // then readonly_indexes len + 1 byte.
+        assert_eq!(bytes[lut_offset + 32], 1, "writable_indexes len = 1");
+        assert_eq!(
+            bytes[lut_offset + 33],
+            1, // index 1 in the LUT (writable_key)
+            "writable_indexes[0] points at writable_key in LUT addresses",
+        );
+        assert_eq!(bytes[lut_offset + 34], 1, "readonly_indexes len = 1");
+        assert_eq!(
+            bytes[lut_offset + 35],
+            0, // index 0 in the LUT (readonly_key)
+            "readonly_indexes[0] points at readonly_key in LUT addresses",
+        );
+    }
+
+    /// `vault_transaction_execute` mirror of the compactor's
+    /// LUT-aware layout: outer instruction's `remaining_accounts` must
+    /// be assembled in the strict three-section order Squads' on-chain
+    /// validator expects:
+    ///   1. LUT account_keys (read-only references to the tables)
+    ///   2. Static `message.account_keys` in their original order, with
+    ///      the writable/signer flags from the message — except vault
+    ///      and ephemeral-signer PDAs lose `is_signer` because they
+    ///      sign via `invoke_signed` inside the program.
+    ///   3. For each LUT in `address_table_lookups` order: the LUT's
+    ///      writable-resolved keys (mutable, non-signer) followed by
+    ///      its readonly-resolved keys (immutable, non-signer).
+    ///
+    /// A regression in any of these — section ordering, signer-strip,
+    /// per-LUT writable-then-readonly ordering — would produce a
+    /// misaligned account list that the on-chain Squads program would
+    /// reject (or, worse, silently mis-apply). Pin all three sections
+    /// here using a synthetic VaultTransaction with one ephemeral
+    /// signer and one LUT, no RPC.
+    #[test]
+    fn assemble_vault_execute_ix_three_section_layout() {
+        use solana_sdk::instruction::AccountMeta;
+        use squads_multisig_program::state::{
+            MultisigCompiledInstruction, MultisigMessageAddressTableLookup, VaultTransaction,
+            VaultTransactionMessage,
+        };
+
+        let multisig = MultisigKey::from_pubkey(Pubkey::new_unique());
+        let transaction_index: u64 = 42;
+        let member = Pubkey::new_unique();
+        let vault_tx_addr = vault_transaction_pda(&multisig, transaction_index);
+        let vault_index: u8 = 0;
+        let vault_addr = vault_pda(&multisig, vault_index);
+
+        // One ephemeral signer at index 0; its PDA must lose
+        // `is_signer` even though the message marks it a signer.
+        let ephemeral_signer = Pubkey::find_program_address(
+            &[
+                SEED_PREFIX,
+                vault_tx_addr.as_ref(),
+                b"ephemeral_signer",
+                &0u8.to_le_bytes(),
+            ],
+            &PROGRAM_ID,
+        )
+        .0;
+
+        // Static keys layout: vault (writable signer at 0), eph_signer
+        // (readonly signer), program (readonly non-signer), recipient
+        // (writable non-signer). The compactor orders the message
+        // header counts as (num_signers=2, num_writable_signers=1,
+        // num_writable_non_signers=1).
+        let program = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let static_keys = vec![
+            vault_addr.into_pubkey(),
+            ephemeral_signer,
+            program,
+            recipient,
+        ];
+        // One LUT with two writable + one readonly resolved entry.
+        let lut_addr = Pubkey::new_unique();
+        let writable_resolved = vec![Pubkey::new_unique(), Pubkey::new_unique()];
+        let readonly_resolved = vec![Pubkey::new_unique()];
+
+        let vault_tx = VaultTransaction {
+            multisig: multisig.into_pubkey(),
+            creator: Pubkey::new_unique(),
+            index: transaction_index,
+            bump: 0,
+            vault_index,
+            vault_bump: 0,
+            ephemeral_signer_bumps: vec![0u8],
+            message: VaultTransactionMessage {
+                num_signers: 2,
+                num_writable_signers: 1,
+                num_writable_non_signers: 1,
+                account_keys: static_keys.clone(),
+                instructions: vec![MultisigCompiledInstruction {
+                    program_id_index: 2, // program
+                    account_indexes: vec![0, 3].try_into().unwrap(),
+                    data: vec![].try_into().unwrap(),
+                }],
+                address_table_lookups: vec![MultisigMessageAddressTableLookup {
+                    account_key: lut_addr,
+                    writable_indexes: vec![0u8, 1u8].try_into().unwrap(),
+                    readonly_indexes: vec![2u8].try_into().unwrap(),
+                }],
+            },
+        };
+
+        let lut_resolutions = vec![(writable_resolved.clone(), readonly_resolved.clone())];
+        let ix = assemble_vault_execute_ix(
+            multisig,
+            transaction_index,
+            member,
+            &vault_tx,
+            &lut_resolutions,
+        )
+        .expect("assemble");
+
+        assert_eq!(ix.program_id, PROGRAM_ID);
+        assert_eq!(&ix.data[..], &VAULT_TRANSACTION_EXECUTE_IX);
+
+        // Outer fixed prefix: multisig (ro), proposal (mut), vault_tx (ro), member (signer ro).
+        let proposal = proposal_pda(&multisig, transaction_index);
+        assert_eq!(
+            ix.accounts[0],
+            AccountMeta::new_readonly(multisig.into_pubkey(), false),
+        );
+        assert_eq!(ix.accounts[1], AccountMeta::new(proposal, false));
+        assert_eq!(
+            ix.accounts[2],
+            AccountMeta::new_readonly(vault_tx_addr, false),
+        );
+        assert_eq!(ix.accounts[3], AccountMeta::new_readonly(member, true));
+
+        // Section 1: LUT accounts (read-only references). One LUT.
+        let mut cursor = 4;
+        assert_eq!(
+            ix.accounts[cursor],
+            AccountMeta::new_readonly(lut_addr, false),
+            "section 1: LUT account_keys come first",
+        );
+        cursor += 1;
+
+        // Section 2: static account_keys in their message order, with
+        // signer-strip applied to vault and ephemeral signers. Vault
+        // is writable per num_writable_signers=1, but loses is_signer.
+        // Ephemeral signer is readonly per the layout (signer count 2,
+        // writable signers 1) and loses is_signer too.
+        assert_eq!(
+            ix.accounts[cursor].pubkey,
+            vault_addr.into_pubkey(),
+            "section 2[0] is vault",
+        );
+        assert!(ix.accounts[cursor].is_writable, "vault stays writable");
+        assert!(
+            !ix.accounts[cursor].is_signer,
+            "vault loses is_signer at outer level (signed via invoke_signed)",
+        );
+        cursor += 1;
+
+        assert_eq!(
+            ix.accounts[cursor].pubkey, ephemeral_signer,
+            "section 2[1] is ephemeral signer",
+        );
+        assert!(
+            !ix.accounts[cursor].is_signer,
+            "ephemeral signer loses is_signer at outer level",
+        );
+        cursor += 1;
+
+        // Program and recipient are non-signers; flags carry through.
+        assert_eq!(ix.accounts[cursor].pubkey, program);
+        assert!(!ix.accounts[cursor].is_signer);
+        cursor += 1;
+        assert_eq!(ix.accounts[cursor].pubkey, recipient);
+        cursor += 1;
+
+        // Section 3: per-LUT writable resolved (mutable non-signers),
+        // then readonly resolved (immutable non-signers). Order
+        // matters strictly.
+        for pk in &writable_resolved {
+            assert_eq!(
+                ix.accounts[cursor],
+                AccountMeta::new(*pk, false),
+                "section 3 writable-resolved must precede readonly-resolved",
+            );
+            cursor += 1;
+        }
+        for pk in &readonly_resolved {
+            assert_eq!(
+                ix.accounts[cursor],
+                AccountMeta::new_readonly(*pk, false),
+                "section 3 readonly-resolved follows writable",
+            );
+            cursor += 1;
+        }
+
+        // No accounts past section 3.
+        assert_eq!(
+            cursor,
+            ix.accounts.len(),
+            "no trailing accounts past section 3",
+        );
+    }
+
+    /// `resolve_lut_indexes` is the load-bearing helper for the
+    /// critical LUT-out-of-range bug fix: a silently-dropped index
+    /// would shift later resolved entries up by one slot and produce
+    /// a misaligned `remaining_accounts` list. Pin both arms — every
+    /// in-range index resolves to its address, and any out-of-range
+    /// index bails with a typed `LutIndexOutOfRange`.
+    #[test]
+    fn resolve_lut_indexes_in_range_and_overflow() {
+        use crate::squads::error::SquadsEncodingError;
+        use solana_sdk::address_lookup_table::state::{AddressLookupTable, LookupTableMeta};
+        use std::borrow::Cow;
+
+        let addrs = [
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+        ];
+        let table = AddressLookupTable {
+            meta: LookupTableMeta::default(),
+            addresses: Cow::Borrowed(&addrs),
+        };
+        let table_addr = Pubkey::new_unique();
+
+        // In-range indexes resolve in order.
+        let resolved =
+            resolve_lut_indexes(&table, &table_addr, &[2u8, 0u8]).expect("in-range resolves");
+        assert_eq!(resolved, vec![addrs[2], addrs[0]]);
+
+        // Empty input is a clean empty result.
+        assert_eq!(
+            resolve_lut_indexes(&table, &table_addr, &[]).expect("empty"),
+            Vec::<Pubkey>::new(),
+        );
+
+        // Any out-of-range index bails — pin the typed error so a
+        // future regression to silent-skip surfaces here.
+        let err = resolve_lut_indexes(&table, &table_addr, &[0u8, 5u8]).unwrap_err();
+        match err {
+            Error::Squads(SquadsError::Encoding(SquadsEncodingError::LutIndexOutOfRange {
+                table,
+                index,
+                size,
+            })) => {
+                assert_eq!(table, table_addr);
+                assert_eq!(index, 5);
+                assert_eq!(size, addrs.len());
+            }
+            other => panic!("expected LutIndexOutOfRange, got {other:?}"),
+        }
+    }
+}

--- a/helium-lib/src/token.rs
+++ b/helium-lib/src/token.rs
@@ -63,20 +63,19 @@ const SPL_TRANSFER_CHECKED_CU: u32 = 7000;
 /// (Estimated value based on similar operations)
 const SPL_CLOSE_ACCOUNT_CU: u32 = 3000;
 
-/// Builds a versioned message that burns a token amount from the payer's account.
-pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
-    client: &C,
-    token_amount: &TokenAmount,
+/// Build the bare burn instruction (no compute-budget framing) for a
+/// given owner. Native SOL burn is not supported.
+pub fn burn_instruction(
     payer: &Pubkey,
-    opts: &TransactionOpts,
-) -> Result<(message::VersionedMessage, u64), Error> {
-    let ix = match token_amount.token.mint() {
+    token_amount: &TokenAmount,
+) -> Result<solana_sdk::instruction::Instruction, Error> {
+    match token_amount.token.mint() {
         spl_mint if spl_mint == Token::Sol.mint() => {
-            return Err(DecodeError::other("native token burn not supported").into());
+            Err(DecodeError::other("native token burn not supported").into())
         }
         spl_mint => {
             let token_account = token_amount.token.associated_token_address(payer);
-            anchor_spl::token::spl_token::instruction::burn_checked(
+            Ok(anchor_spl::token::spl_token::instruction::burn_checked(
                 &anchor_spl::token::spl_token::id(),
                 &token_account,
                 spl_mint,
@@ -84,10 +83,18 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
                 &[payer],
                 token_amount.amount,
                 token_amount.token.decimals(),
-            )?
+            )?)
         }
-    };
+    }
+}
 
+pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    token_amount: &TokenAmount,
+    payer: &Pubkey,
+    opts: &TransactionOpts,
+) -> Result<(message::VersionedMessage, u64), Error> {
+    let ix = burn_instruction(payer, token_amount)?;
     message::mk_message(client, &[ix], &opts.lut_addresses, payer).await
 }
 
@@ -103,42 +110,37 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
     Ok((txn, block_height))
 }
 
-/// Builds a versioned message that transfers tokens to one or more recipients.
-pub async fn transfer_message<C: AsRef<SolanaRpcClient>>(
-    client: &C,
-    transfers: &[(Pubkey, TokenAmount)],
+/// Build the bare transfer instructions (no compute-budget framing) for
+/// one or more recipients, with `payer` as the source authority. Used
+/// directly by callers that don't want the compute-budget envelope —
+/// e.g. wrapping the instructions into a Squads proposal where the
+/// outer (proposer) transaction supplies its own compute budget.
+pub fn transfer_instructions(
     payer: &Pubkey,
-    opts: &TransactionOpts,
-) -> Result<(message::VersionedMessage, u64), Error> {
-    let mut ixs = vec![];
-    let mut ixs_accounts = vec![];
-    let mut cu_budget: u32 = SYS_PROGRAM_SETUP_CU;
+    transfers: &[(Pubkey, TokenAmount)],
+) -> Result<Vec<solana_sdk::instruction::Instruction>, Error> {
+    let mut ixs = Vec::new();
     for (payee, token_amount) in transfers {
         match token_amount.token.mint() {
             spl_mint if spl_mint == Token::Sol.mint() => {
-                let ix = solana_system_interface::instruction::transfer(
+                ixs.push(solana_system_interface::instruction::transfer(
                     payer,
                     payee,
                     token_amount.amount,
-                );
-                ixs_accounts.extend_from_slice(&ix.accounts);
-                ixs.push(ix);
-                cu_budget += SYS_PROGRAM_TRANSFER_CU;
+                ));
             }
             spl_mint => {
                 let source_pubkey = token_amount.token.associated_token_address(payer);
                 let destination_pubkey = token_amount.token.associated_token_address(payee);
-                let ix = spl_associated_token_account::instruction::create_associated_token_account_idempotent(
-                    payer,
-                    payee,
-                    spl_mint,
-                    &anchor_spl::token::spl_token::id(),
+                ixs.push(
+                    spl_associated_token_account::instruction::create_associated_token_account_idempotent(
+                        payer,
+                        payee,
+                        spl_mint,
+                        &anchor_spl::token::spl_token::id(),
+                    ),
                 );
-                ixs_accounts.extend_from_slice(&ix.accounts);
-                ixs.push(ix);
-                cu_budget += SPL_CREATE_IDEMPOTENT_CU;
-
-                let ix = anchor_spl::token::spl_token::instruction::transfer_checked(
+                ixs.push(anchor_spl::token::spl_token::instruction::transfer_checked(
                     &anchor_spl::token::spl_token::id(),
                     &source_pubkey,
                     token_amount.token.mint(),
@@ -147,13 +149,33 @@ pub async fn transfer_message<C: AsRef<SolanaRpcClient>>(
                     &[],
                     token_amount.amount,
                     token_amount.token.decimals(),
-                )?;
-                ixs_accounts.extend_from_slice(&ix.accounts);
-                ixs.push(ix);
-                cu_budget += SPL_TRANSFER_CHECKED_CU;
+                )?);
             }
         }
     }
+    Ok(ixs)
+}
+
+/// Builds a versioned message that transfers tokens to one or more recipients.
+pub async fn transfer_message<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    transfers: &[(Pubkey, TokenAmount)],
+    payer: &Pubkey,
+    opts: &TransactionOpts,
+) -> Result<(message::VersionedMessage, u64), Error> {
+    let ixs = transfer_instructions(payer, transfers)?;
+    let cu_budget: u32 = SYS_PROGRAM_SETUP_CU
+        + transfers
+            .iter()
+            .map(|(_, ta)| {
+                if ta.token.mint() == Token::Sol.mint() {
+                    SYS_PROGRAM_TRANSFER_CU
+                } else {
+                    SPL_CREATE_IDEMPOTENT_CU + SPL_TRANSFER_CHECKED_CU
+                }
+            })
+            .sum::<u32>();
+    let ixs_accounts: Vec<_> = ixs.iter().flat_map(|i| i.accounts.clone()).collect();
     let final_ixs = &[
         &[
             priority_fee::compute_budget_instruction(cu_budget),

--- a/helium-wallet/src/cmd/assets/burn.rs
+++ b/helium-wallet/src/cmd/assets/burn.rs
@@ -1,5 +1,5 @@
-use crate::cmd::*;
-use helium_lib::{asset, dao, entity_key};
+use crate::cmd::{squads as cmd_squads, *};
+use helium_lib::{asset, dao, entity_key, keypair::Pubkey};
 
 #[derive(Clone, Debug, clap::Args)]
 /// Burn a given asset (NFT)
@@ -9,6 +9,13 @@ pub struct Cmd {
     /// Entity key of asset to burn
     #[clap(flatten)]
     entity_key: entity_key::EncodedEntityKey,
+    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    /// The asset's current owner must be the resolved vault.
+    #[arg(long)]
+    squads: Option<Pubkey>,
+    /// Memo recorded on the v4 proposal (`--squads` only).
+    #[arg(long)]
+    memo: Option<String>,
     /// Commit the transaction
     #[command(flatten)]
     commit: CommitOpts,
@@ -19,14 +26,30 @@ impl Cmd {
         let client = opts.client()?;
         let password = get_wallet_password(false)?;
         let keypair = opts.load_keypair(password.as_bytes())?;
+        let transaction_opts = self.commit.transaction_opts(&client);
         let asset = asset::for_entity_key(&client, &self.entity_key.as_entity_key()?).await?;
-        let (tx, _) = asset::burn(
-            &client,
-            &asset.id,
-            &keypair,
-            &self.commit.transaction_opts(&client),
-        )
-        .await?;
+
+        if let Some(squads_target) = self.squads {
+            let client_ref = &client;
+            let asset_id = asset.id;
+            return cmd_squads::submit_proposal_with(
+                client_ref,
+                squads_target,
+                self.memo.clone(),
+                &keypair,
+                &self.commit,
+                &transaction_opts,
+                |vault| async move {
+                    Ok(vec![
+                        asset::fetch_burn_instruction(client_ref, &asset_id, vault.as_pubkey())
+                            .await?,
+                    ])
+                },
+            )
+            .await;
+        }
+
+        let (tx, _) = asset::burn(&client, &asset.id, &keypair, &transaction_opts).await?;
 
         print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }

--- a/helium-wallet/src/cmd/assets/transfer.rs
+++ b/helium-wallet/src/cmd/assets/transfer.rs
@@ -1,4 +1,4 @@
-use crate::cmd::*;
+use crate::cmd::{squads as cmd_squads, *};
 use helium_lib::{
     asset, entity_key,
     keypair::{Pubkey, Signer},
@@ -13,6 +13,13 @@ pub struct Cmd {
 
     /// Solana address of Recipient of Hotspot
     recipient: Pubkey,
+    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    /// The asset's current owner must be the resolved vault.
+    #[arg(long)]
+    squads: Option<Pubkey>,
+    /// Memo recorded on the v4 proposal (`--squads` only).
+    #[arg(long)]
+    memo: Option<String>,
     /// Commit the transfer
     #[command(flatten)]
     commit: CommitOpts,
@@ -22,12 +29,42 @@ impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let password = get_wallet_password(false)?;
         let keypair = opts.load_keypair(password.as_bytes())?;
-        if keypair.pubkey() == self.recipient {
-            bail!("recipient already owner of hotspot");
-        }
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
         let kta = kta::for_entity_key(&self.entity_key.as_entity_key()?).await?;
+
+        if let Some(squads_target) = self.squads {
+            let client_ref = &client;
+            let recipient = self.recipient;
+            let asset_id = kta.asset;
+            return cmd_squads::submit_proposal_with(
+                client_ref,
+                squads_target,
+                self.memo.clone(),
+                &keypair,
+                &self.commit,
+                &transaction_opts,
+                |vault| async move {
+                    if vault.as_pubkey() == &recipient {
+                        bail!("recipient already owner of asset");
+                    }
+                    Ok(vec![
+                        asset::fetch_transfer_instruction(
+                            client_ref,
+                            &asset_id,
+                            &recipient,
+                            vault.as_pubkey(),
+                        )
+                        .await?,
+                    ])
+                },
+            )
+            .await;
+        }
+
+        if keypair.pubkey() == self.recipient {
+            bail!("recipient already owner of hotspot");
+        }
         let (tx, _) = asset::transfer(
             &client,
             &kta.asset,

--- a/helium-wallet/src/cmd/burn.rs
+++ b/helium-wallet/src/cmd/burn.rs
@@ -1,5 +1,5 @@
-use crate::cmd::*;
-use helium_lib::{dao::SubDao, token};
+use crate::cmd::{squads as cmd_squads, *};
+use helium_lib::{dao::SubDao, keypair::Pubkey, token};
 
 #[derive(Debug, Clone, clap::Args)]
 /// Burn tokens
@@ -8,6 +8,12 @@ pub struct Cmd {
     subdao: SubDao,
     /// Amount to burn
     amount: f64,
+    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    #[arg(long)]
+    squads: Option<Pubkey>,
+    /// Memo recorded on the v4 proposal (`--squads` only).
+    #[arg(long)]
+    memo: Option<String>,
     /// Commit the burn
     #[command(flatten)]
     commit: CommitOpts,
@@ -21,6 +27,25 @@ impl Cmd {
         let txn_opts = self.commit.transaction_opts(&client);
 
         let token_amount = token::TokenAmount::from_f64(self.subdao.token(), self.amount);
+
+        if let Some(squads_target) = self.squads {
+            return cmd_squads::submit_proposal_with(
+                &client,
+                squads_target,
+                self.memo.clone(),
+                &keypair,
+                &self.commit,
+                &txn_opts,
+                |vault| async move {
+                    Ok(vec![token::burn_instruction(
+                        vault.as_pubkey(),
+                        &token_amount,
+                    )?])
+                },
+            )
+            .await;
+        }
+
         let (tx, _) = token::burn(&client, &token_amount, &keypair, &txn_opts).await?;
         print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }

--- a/helium-wallet/src/cmd/dc/burn.rs
+++ b/helium-wallet/src/cmd/dc/burn.rs
@@ -1,5 +1,5 @@
-use crate::cmd::*;
-use helium_lib::{dao, dc};
+use crate::cmd::{squads as cmd_squads, *};
+use helium_lib::{dao, dc, keypair::Pubkey};
 
 #[derive(Debug, Clone, clap::Args)]
 /// Burn Data Credits (DC) from this wallet or delegated for the given router into oblivion.
@@ -13,6 +13,14 @@ pub struct Cmd {
     /// Note that the wallet keypair must be the burn authority for the router key
     /// for the burn to succeed
     router: Option<String>,
+    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    /// Only supported for the non-delegated (no router) burn path; the
+    /// DC is sourced from the resolved vault's DC ATA.
+    #[arg(long)]
+    squads: Option<Pubkey>,
+    /// Memo recorded on the v4 proposal (`--squads` only).
+    #[arg(long)]
+    memo: Option<String>,
     /// Commit the burn
     #[command(flatten)]
     commit: CommitOpts,
@@ -24,6 +32,22 @@ impl Cmd {
         let keypair = opts.load_keypair(password.as_bytes())?;
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
+
+        if let Some(squads_target) = self.squads {
+            if self.router.is_some() || self.subdao.is_some() {
+                bail!("--squads only supports the non-delegated burn path");
+            }
+            return cmd_squads::submit_proposal_with(
+                &client,
+                squads_target,
+                self.memo.clone(),
+                &keypair,
+                &self.commit,
+                &transaction_opts,
+                |vault| async move { Ok(vec![dc::burn_instruction(self.dc, vault.as_pubkey())]) },
+            )
+            .await;
+        }
 
         let (tx, _) = match (&self.router, self.subdao) {
             (Some(router_key), Some(subdao)) => {

--- a/helium-wallet/src/cmd/dc/delegate.rs
+++ b/helium-wallet/src/cmd/dc/delegate.rs
@@ -1,5 +1,5 @@
-use crate::cmd::*;
-use helium_lib::{dao::SubDao, dc};
+use crate::cmd::{squads as cmd_squads, *};
+use helium_lib::{dao::SubDao, dc, keypair::Pubkey};
 
 #[derive(Debug, Clone, clap::Args)]
 /// Delegate DC from this wallet to a given router
@@ -13,6 +13,14 @@ pub struct Cmd {
     /// Amount of DC to delegate
     dc: u64,
 
+    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    /// The DC is sourced from the resolved vault's DC ATA.
+    #[arg(long)]
+    squads: Option<Pubkey>,
+    /// Memo recorded on the v4 proposal (`--squads` only).
+    #[arg(long)]
+    memo: Option<String>,
+
     /// Commit the delegation
     #[command(flatten)]
     commit: CommitOpts,
@@ -25,6 +33,27 @@ impl Cmd {
 
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
+
+        if let Some(squads_target) = self.squads {
+            return cmd_squads::submit_proposal_with(
+                &client,
+                squads_target,
+                self.memo.clone(),
+                &keypair,
+                &self.commit,
+                &transaction_opts,
+                |vault| async move {
+                    Ok(vec![dc::delegate_instruction(
+                        self.subdao,
+                        &self.payer,
+                        self.dc,
+                        vault.as_pubkey(),
+                    )])
+                },
+            )
+            .await;
+        }
+
         let (tx, _) = dc::delegate(
             &client,
             self.subdao,

--- a/helium-wallet/src/cmd/dc/mint.rs
+++ b/helium-wallet/src/cmd/dc/mint.rs
@@ -1,4 +1,4 @@
-use crate::cmd::*;
+use crate::cmd::{squads as cmd_squads, *};
 use helium_lib::{
     dc,
     keypair::{Pubkey, Signer},
@@ -24,6 +24,15 @@ pub struct Cmd {
     #[arg(long, conflicts_with = "hnt")]
     dc: Option<u64>,
 
+    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    /// HNT is sourced from the resolved vault; the wallet only signs as
+    /// proposer.
+    #[arg(long)]
+    squads: Option<Pubkey>,
+    /// Memo recorded on the v4 proposal (`--squads` only).
+    #[arg(long)]
+    memo: Option<String>,
+
     /// Commit the burn
     #[command(flatten)]
     commit: CommitOpts,
@@ -35,7 +44,6 @@ impl Cmd {
         let keypair = opts.load_keypair(password.as_bytes())?;
 
         let client = opts.client()?;
-        let payee = self.payee.unwrap_or(keypair.pubkey());
         let amount = match (self.hnt, self.dc) {
             (Some(hnt), None) => TokenAmount::from_f64(Token::Hnt, hnt),
             (None, Some(dc)) => TokenAmount::from_u64(Token::Dc, dc),
@@ -43,6 +51,30 @@ impl Cmd {
         };
         let transaction_opts = self.commit.transaction_opts(&client);
 
+        if let Some(squads_target) = self.squads {
+            let client_ref = &client;
+            let payee_override = self.payee;
+            return cmd_squads::submit_proposal_with(
+                client_ref,
+                squads_target,
+                self.memo.clone(),
+                &keypair,
+                &self.commit,
+                &transaction_opts,
+                |vault| async move {
+                    // Default payee is the vault when --squads is set;
+                    // the resulting DC lands in the vault's DC ATA
+                    // unless --payee overrides.
+                    let payee = payee_override.unwrap_or_else(|| vault.into_pubkey());
+                    Ok(vec![
+                        dc::mint_instruction(client_ref, amount, &payee, vault.as_pubkey()).await?,
+                    ])
+                },
+            )
+            .await;
+        }
+
+        let payee = self.payee.unwrap_or(keypair.pubkey());
         let (tx, _) = dc::mint(&client, amount, &payee, &keypair, &transaction_opts).await?;
         print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }

--- a/helium-wallet/src/cmd/hotspots/burn.rs
+++ b/helium-wallet/src/cmd/hotspots/burn.rs
@@ -1,5 +1,5 @@
-use crate::cmd::*;
-use helium_lib::{dao, hotspot};
+use crate::cmd::{squads as cmd_squads, *};
+use helium_lib::{dao, hotspot, keypair::Pubkey};
 
 #[derive(Clone, Debug, clap::Args)]
 /// Burn a given Hotspot NFT
@@ -8,6 +8,13 @@ pub struct Cmd {
     subdao: dao::SubDao,
     /// Key for the Hotspot NFT to burn
     address: helium_crypto::PublicKey,
+    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    /// The hotspot's current owner must be the resolved vault.
+    #[arg(long)]
+    squads: Option<Pubkey>,
+    /// Memo recorded on the v4 proposal (`--squads` only).
+    #[arg(long)]
+    memo: Option<String>,
     /// Commit the transaction
     #[command(flatten)]
     commit: CommitOpts,
@@ -18,13 +25,29 @@ impl Cmd {
         let client = opts.client()?;
         let password = get_wallet_password(false)?;
         let keypair = opts.load_keypair(password.as_bytes())?;
-        let (tx, _) = hotspot::burn(
-            &client,
-            &self.address,
-            &keypair,
-            &self.commit.transaction_opts(&client),
-        )
-        .await?;
+        let transaction_opts = self.commit.transaction_opts(&client);
+
+        if let Some(squads_target) = self.squads {
+            let client_ref = &client;
+            let address = self.address.clone();
+            return cmd_squads::submit_proposal_with(
+                client_ref,
+                squads_target,
+                self.memo.clone(),
+                &keypair,
+                &self.commit,
+                &transaction_opts,
+                |vault| async move {
+                    Ok(vec![
+                        hotspot::fetch_burn_instruction(client_ref, &address, vault.as_pubkey())
+                            .await?,
+                    ])
+                },
+            )
+            .await;
+        }
+
+        let (tx, _) = hotspot::burn(&client, &self.address, &keypair, &transaction_opts).await?;
 
         print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }

--- a/helium-wallet/src/cmd/hotspots/transfer.rs
+++ b/helium-wallet/src/cmd/hotspots/transfer.rs
@@ -1,4 +1,4 @@
-use crate::cmd::*;
+use crate::cmd::{squads as cmd_squads, *};
 use helium_lib::{
     hotspot,
     keypair::{Pubkey, Signer},
@@ -11,6 +11,13 @@ pub struct Cmd {
     address: helium_crypto::PublicKey,
     /// Solana address of Recipient of Hotspot
     recipient: Pubkey,
+    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    /// The hotspot's current owner must be the resolved vault.
+    #[arg(long)]
+    squads: Option<Pubkey>,
+    /// Memo recorded on the v4 proposal (`--squads` only).
+    #[arg(long)]
+    memo: Option<String>,
     /// Commit the transfer
     #[command(flatten)]
     commit: CommitOpts,
@@ -20,11 +27,41 @@ impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let password = get_wallet_password(false)?;
         let keypair = opts.load_keypair(password.as_bytes())?;
+        let client = opts.client()?;
+        let transaction_opts = self.commit.transaction_opts(&client);
+
+        if let Some(squads_target) = self.squads {
+            let client_ref = &client;
+            let address = self.address.clone();
+            let recipient = self.recipient;
+            return cmd_squads::submit_proposal_with(
+                client_ref,
+                squads_target,
+                self.memo.clone(),
+                &keypair,
+                &self.commit,
+                &transaction_opts,
+                |vault| async move {
+                    if vault.as_pubkey() == &recipient {
+                        bail!("recipient already owner of hotspot");
+                    }
+                    Ok(vec![
+                        hotspot::fetch_transfer_instruction(
+                            client_ref,
+                            &address,
+                            &recipient,
+                            vault.as_pubkey(),
+                        )
+                        .await?,
+                    ])
+                },
+            )
+            .await;
+        }
+
         if keypair.pubkey() == self.recipient {
             bail!("recipient already owner of hotspot");
         }
-        let client = opts.client()?;
-        let transaction_opts = self.commit.transaction_opts(&client);
         let (tx, _) = hotspot::transfer(
             &client,
             &self.address,

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -34,6 +34,7 @@ pub mod memo;
 pub mod price;
 pub mod router;
 pub mod sign;
+pub mod squads;
 pub mod swap;
 pub mod transfer;
 pub mod upgrade;

--- a/helium-wallet/src/cmd/squads/execute.rs
+++ b/helium-wallet/src/cmd/squads/execute.rs
@@ -1,0 +1,63 @@
+use crate::cmd::*;
+use helium_lib::{
+    keypair::{Pubkey, Signer},
+    message,
+    squads::{self, MemberAction, SquadsError, Version},
+    transaction::mk_transaction,
+};
+
+/// Execute an approved Squads proposal. The wallet must hold a member
+/// keypair with `Execute` permission (v4) or be a member of the
+/// multisig (v3).
+#[derive(Debug, Clone, clap::Args)]
+pub struct Cmd {
+    /// Multisig PDA, vault PDA, or transaction/proposal PDA.
+    target: Pubkey,
+    /// Transaction index. Required if `target` is a multisig or vault.
+    #[arg(long)]
+    index: Option<u64>,
+    #[command(flatten)]
+    commit: CommitOpts,
+}
+
+impl Cmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        let password = get_wallet_password(false)?;
+        let keypair = opts.load_keypair(password.as_bytes())?;
+        let client = opts.client()?;
+        let txn_opts = self.commit.transaction_opts(&client);
+        let member = keypair.pubkey();
+
+        let resolved = squads::resolve_proposal_target(&client, &self.target, self.index).await?;
+        // Pre-flight: v4 requires the Execute permission; v3 has no
+        // per-member permissions but still requires membership. Catches
+        // "wrong wallet" before the on-chain program rejects.
+        squads::check_member_permission(
+            &client,
+            &resolved.multisig,
+            &member,
+            MemberAction::Execute,
+        )
+        .await?;
+        let ix = match resolved.version {
+            Version::V4 => {
+                // Dispatcher: routes to vault_transaction_execute or
+                // config_transaction_execute based on the on-chain
+                // transaction account's discriminator.
+                squads::v4::execute_ix(&client, resolved.multisig, resolved.index, member).await?
+            }
+            Version::V3 => {
+                let index = resolved.index;
+                let idx =
+                    u32::try_from(index).map_err(|_| SquadsError::v3_index_out_of_range(index))?;
+                squads::v3::execute_transaction_ix(&client, resolved.multisig, idx, member).await?
+            }
+        };
+
+        let ixs = &[ix];
+        let (msg, _block_height) =
+            message::mk_message(&client, ixs, &txn_opts.lut_addresses, &member).await?;
+        let tx = mk_transaction(msg, &[&*keypair])?;
+        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
+    }
+}

--- a/helium-wallet/src/cmd/squads/inspect.rs
+++ b/helium-wallet/src/cmd/squads/inspect.rs
@@ -1,0 +1,29 @@
+use crate::cmd::*;
+use helium_lib::{keypair::Pubkey, squads};
+
+/// Decode a Squads proposal (v3 or v4): status, votes, and the inner
+/// instructions it will execute when approved. Use this before signing to
+/// verify the proposal does what it claims.
+///
+/// Accepts either:
+///   - a multisig or vault PDA plus an explicit `--index`, or
+///   - a transaction or proposal PDA on its own (it self-identifies).
+#[derive(Debug, Clone, clap::Args)]
+pub struct Cmd {
+    /// Multisig PDA, vault PDA, transaction PDA, or proposal PDA.
+    target: Pubkey,
+
+    /// Transaction index. Required when `target` is a multisig or vault;
+    /// inferred from the account body when `target` is a transaction or
+    /// proposal PDA.
+    #[arg(long)]
+    index: Option<u64>,
+}
+
+impl Cmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        let client = opts.client()?;
+        let info = squads::inspect_target(&client, &self.target, self.index).await?;
+        print_json(&info)
+    }
+}

--- a/helium-wallet/src/cmd/squads/list.rs
+++ b/helium-wallet/src/cmd/squads/list.rs
@@ -1,0 +1,51 @@
+use crate::cmd::*;
+use chrono::{Duration, Utc};
+use helium_lib::{keypair::Pubkey, squads};
+
+/// List actionable proposals on a Squads multisig — Active and
+/// Approved (v4) / ExecuteReady (v3) statuses, ordered newest first.
+/// Drafts are hidden by default since they're pre-activation parking
+/// and an old draft is almost always abandoned context; pass
+/// `--include-drafts` to surface them. Defaults to the last 7 days
+/// of activity — old still-open proposals are usually abandoned
+/// context regardless of status; widen the window with `--days <N>`
+/// or pass `--days 0` to disable the age filter entirely.
+/// Finalized proposals (Executed, Rejected, Cancelled) and v4
+/// stale-by-config proposals are never shown — those can't be acted on.
+#[derive(Debug, Clone, clap::Args)]
+pub struct Cmd {
+    /// Multisig, vault, or any transaction/proposal PDA in the multisig.
+    target: Pubkey,
+
+    /// Also include Draft proposals. Drafts are pre-activation
+    /// parking — useful when triaging your own pending work, noise
+    /// when triaging votes or executions someone else needs to drive.
+    #[arg(long)]
+    include_drafts: bool,
+
+    /// Look back this many days; older proposals are filtered out.
+    /// `0` disables the filter and shows every still-open proposal
+    /// regardless of age. v3 multisigs don't carry per-status
+    /// timestamps — those entries pass through unconditionally.
+    #[arg(long, default_value_t = 7)]
+    days: u32,
+}
+
+impl Cmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        let client = opts.client()?;
+        let entries = squads::list_open_proposals(&client, &self.target).await?;
+        let cutoff = (self.days > 0).then(|| Utc::now() - Duration::days(i64::from(self.days)));
+        let filtered: Vec<_> = entries
+            .into_iter()
+            .filter(|e| self.include_drafts || e.status != "draft")
+            .filter(|e| match (cutoff, e.status_timestamp) {
+                // No filter requested or v3 entry without a timestamp:
+                // pass through.
+                (None, _) | (_, None) => true,
+                (Some(cutoff), Some(ts)) => ts >= cutoff,
+            })
+            .collect();
+        print_json(&filtered)
+    }
+}

--- a/helium-wallet/src/cmd/squads/members.rs
+++ b/helium-wallet/src/cmd/squads/members.rs
@@ -1,0 +1,177 @@
+use crate::cmd::{squads as cmd_squads, *};
+use helium_lib::{
+    keypair::Pubkey,
+    squads::{self, v4::ConfigActionInput, MemberPermissions},
+};
+
+/// Manage the member roster of a Squads multisig.
+#[derive(Debug, Clone, clap::Args)]
+pub struct Cmd {
+    #[command(subcommand)]
+    cmd: SubCmd,
+}
+
+impl Cmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        match &self.cmd {
+            SubCmd::List(c) => c.run(opts).await,
+            SubCmd::Add(c) => c.run(opts).await,
+            SubCmd::Remove(c) => c.run(opts).await,
+        }
+    }
+}
+
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum SubCmd {
+    List(ListCmd),
+    Add(AddCmd),
+    Remove(RemoveCmd),
+}
+
+/// Print the members, threshold, and version of a Squads multisig.
+/// `target` accepts a multisig PDA, a vault PDA, or any
+/// transaction/proposal PDA in the multisig — vault and
+/// transaction-bearing addresses resolve back to the multisig
+/// automatically (vaults via cache + recent-signature scan,
+/// transaction PDAs by reading the multisig from their body).
+#[derive(Debug, Clone, clap::Args)]
+pub struct ListCmd {
+    /// Multisig, vault, or any transaction/proposal PDA in the multisig.
+    target: Pubkey,
+}
+
+impl ListCmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        let client = opts.client()?;
+        let info = squads::get_multisig_info(&client, &self.target).await?;
+        print_json(&info)
+    }
+}
+
+/// Propose adding a member to a Squads multisig (v4 only). Creates a
+/// ConfigTransaction proposal — once approved + executed by threshold
+/// of existing members, the new member is added to `multisig.members`
+/// with the requested permissions, and `multisig.stale_transaction_index`
+/// advances to invalidate any pending vault transactions created
+/// against the old member set.
+#[derive(Debug, Clone, clap::Args)]
+pub struct AddCmd {
+    /// Multisig, vault, or any transaction/proposal PDA in the multisig.
+    target: Pubkey,
+
+    /// Pubkey of the new member.
+    new_member: Pubkey,
+
+    /// Permissions the new member receives. Defaults to all three
+    /// (initiate + vote + execute), the typical "trusted member"
+    /// shape Helium multisigs use. Use repeated flags or a
+    /// comma-separated list to narrow: e.g. `--perm vote --perm
+    /// execute` for a member who can vote and execute but not
+    /// initiate proposals.
+    #[arg(long = "perm", value_enum, num_args = 0.., value_delimiter = ',')]
+    perm: Vec<PermissionFlag>,
+
+    /// Memo recorded on the proposal.
+    #[arg(long)]
+    memo: Option<String>,
+
+    #[command(flatten)]
+    commit: CommitOpts,
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub enum PermissionFlag {
+    Initiate,
+    Vote,
+    Execute,
+}
+
+impl PermissionFlag {
+    /// Set the matching field on `perms` to true.
+    fn apply(self, perms: &mut MemberPermissions) {
+        match self {
+            Self::Initiate => perms.propose = true,
+            Self::Vote => perms.vote = true,
+            Self::Execute => perms.execute = true,
+        }
+    }
+}
+
+impl AddCmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        let password = get_wallet_password(false)?;
+        let keypair = opts.load_keypair(password.as_bytes())?;
+        let client = opts.client()?;
+        let txn_opts = self.commit.transaction_opts(&client);
+
+        let permissions = if self.perm.is_empty() {
+            MemberPermissions::ALL
+        } else {
+            let mut perms = MemberPermissions::default();
+            for flag in &self.perm {
+                flag.apply(&mut perms);
+            }
+            perms
+        };
+        let action = ConfigActionInput::AddMember {
+            new_member: self.new_member,
+            permissions,
+        };
+        cmd_squads::submit_config_proposal(
+            &client,
+            self.target,
+            vec![action],
+            self.memo.clone(),
+            &keypair,
+            &self.commit,
+            &txn_opts,
+        )
+        .await
+    }
+}
+
+/// Propose removing a member from a Squads multisig (v4 only). Once
+/// the proposal lands and is executed, the member is dropped from
+/// `multisig.members` and `stale_transaction_index` advances.
+/// Removing a member can require dropping the threshold first if the
+/// remaining member count would fall below threshold — Squads'
+/// on-chain handler will reject the execute in that case.
+#[derive(Debug, Clone, clap::Args)]
+pub struct RemoveCmd {
+    /// Multisig, vault, or any transaction/proposal PDA in the multisig.
+    target: Pubkey,
+
+    /// Pubkey of the member to remove.
+    old_member: Pubkey,
+
+    /// Memo recorded on the proposal.
+    #[arg(long)]
+    memo: Option<String>,
+
+    #[command(flatten)]
+    commit: CommitOpts,
+}
+
+impl RemoveCmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        let password = get_wallet_password(false)?;
+        let keypair = opts.load_keypair(password.as_bytes())?;
+        let client = opts.client()?;
+        let txn_opts = self.commit.transaction_opts(&client);
+
+        let action = ConfigActionInput::RemoveMember {
+            old_member: self.old_member,
+        };
+        cmd_squads::submit_config_proposal(
+            &client,
+            self.target,
+            vec![action],
+            self.memo.clone(),
+            &keypair,
+            &self.commit,
+            &txn_opts,
+        )
+        .await
+    }
+}

--- a/helium-wallet/src/cmd/squads/mod.rs
+++ b/helium-wallet/src/cmd/squads/mod.rs
@@ -1,0 +1,208 @@
+use crate::cmd::*;
+use helium_lib::{
+    keypair::{Keypair, Pubkey, Signer},
+    message, solana_sdk,
+    squads::{self as lib_squads, MemberAction, MultisigKey, VaultKey},
+    transaction::mk_transaction,
+    TransactionOpts,
+};
+use solana_sdk::{instruction::Instruction, transaction::VersionedTransaction};
+use std::sync::Arc;
+
+mod execute;
+mod inspect;
+mod list;
+mod members;
+mod threshold;
+mod vote;
+
+/// Resolve a `--squads <addr>` value into the (multisig, vault PDA,
+/// vault_index) triple every proposer-side wallet command needs.
+/// Helium multisigs use vault index 0; non-zero vaults aren't surfaced
+/// at the wallet CLI level.
+pub(crate) async fn squads_vault<C: AsRef<helium_lib::client::SolanaRpcClient>>(
+    client: &C,
+    squads_target: Pubkey,
+) -> Result<(MultisigKey, VaultKey, u8)> {
+    let multisig = lib_squads::resolve_to_multisig(client, &squads_target).await?;
+    let vault_index: u8 = 0;
+    let vault = lib_squads::v4::vault_pda(&multisig, vault_index);
+    Ok((multisig, vault, vault_index))
+}
+
+/// End-to-end Squads proposal submission for `--squads`-aware wallet
+/// commands. Resolves the vault, runs `build_ixs(vault)` to produce
+/// the inner instruction list, wraps the result as a v4 proposal, and
+/// commits / prints the response. The closure is async so callers can
+/// fetch on-chain state (assets, oracles) while building their ixs.
+///
+/// The printed JSON is augmented with `multisig`, `vault`,
+/// `vault_index`, and `transaction_index` so reviewers can immediately
+/// `helium-wallet squads inspect <vault> --index <n>` to verify what
+/// they just signed lands as the on-chain proposal expects.
+pub(crate) async fn submit_proposal_with<C, F, Fut>(
+    client: &C,
+    squads_target: Pubkey,
+    memo: Option<String>,
+    keypair: &Arc<Keypair>,
+    commit: &CommitOpts,
+    txn_opts: &TransactionOpts,
+    build_ixs: F,
+) -> Result
+where
+    C: AsRef<helium_lib::client::SolanaRpcClient>,
+    F: FnOnce(VaultKey) -> Fut,
+    Fut: std::future::Future<Output = Result<Vec<Instruction>>>,
+{
+    let (multisig, vault, vault_index) = squads_vault(client, squads_target).await?;
+    // Pre-flight: the proposer (this wallet) must be a v4 member with
+    // Initiate permission. v3 has no permission bits but still
+    // requires membership. Cheaper to surface here than after the
+    // user pays for the inner-ix build (asset fetches, etc.).
+    let proposer = keypair.pubkey();
+    lib_squads::check_member_permission(client, &multisig, &proposer, MemberAction::Initiate)
+        .await?;
+    let inner_ixs = build_ixs(vault).await?;
+    let (tx, transaction_index) = wrap_as_proposal(
+        client,
+        multisig,
+        vault_index,
+        &inner_ixs,
+        memo,
+        keypair,
+        txn_opts,
+    )
+    .await?;
+    let response = commit.maybe_commit(tx, client).await?;
+    let mut json = response.to_json();
+    if let serde_json::Value::Object(map) = &mut json {
+        map.insert("multisig".to_string(), multisig.to_string().into());
+        map.insert("vault".to_string(), vault.to_string().into());
+        map.insert("vault_index".to_string(), vault_index.into());
+        map.insert("transaction_index".to_string(), transaction_index.into());
+    }
+    print_json(&json)
+}
+
+/// Sibling of `submit_proposal_with` for ConfigTransaction proposals
+/// (member changes, threshold changes, time-lock, etc). Builds the
+/// `[config_transaction_create, proposal_create]` pair, signs as
+/// proposer, and surfaces the same `multisig` + `transaction_index`
+/// JSON augment so reviewers can immediately `squads inspect <tx>`
+/// post-submit. No vault index — config proposals act on the
+/// multisig itself, not a vault.
+pub(crate) async fn submit_config_proposal<C>(
+    client: &C,
+    target: Pubkey,
+    actions: Vec<helium_lib::squads::v4::ConfigActionInput>,
+    memo: Option<String>,
+    keypair: &Arc<Keypair>,
+    commit: &CommitOpts,
+    txn_opts: &TransactionOpts,
+) -> Result
+where
+    C: AsRef<helium_lib::client::SolanaRpcClient>,
+{
+    let multisig = lib_squads::resolve_to_multisig(client, &target).await?;
+    let proposer = keypair.pubkey();
+    // Same Initiate-permission gate the vault-tx proposer side uses.
+    lib_squads::check_member_permission(client, &multisig, &proposer, MemberAction::Initiate)
+        .await?;
+    let on_chain_actions: Vec<_> = actions.into_iter().map(Into::into).collect();
+    let (proposal_ixs, transaction_index) = lib_squads::v4::propose_config_change_ixs(
+        client,
+        multisig,
+        proposer,
+        on_chain_actions,
+        memo,
+    )
+    .await?;
+    let (msg, _block_height) =
+        message::mk_message(client, &proposal_ixs, &txn_opts.lut_addresses, &proposer).await?;
+    let tx = mk_transaction(msg, &[&**keypair])?;
+    let response = commit.maybe_commit(tx, client).await?;
+    let mut json = response.to_json();
+    if let serde_json::Value::Object(map) = &mut json {
+        map.insert("multisig".to_string(), multisig.to_string().into());
+        map.insert("transaction_index".to_string(), transaction_index.into());
+    }
+    print_json(&json)
+}
+
+/// Wrap a list of inner instructions (built with `vault` as the
+/// authority/payer) into a v4 Squads proposal: a `vault_transaction_create`
+/// followed by `proposal_create`. Returns the outer transaction signed
+/// by the proposer keypair (ready for `CommitOpts::maybe_commit`)
+/// alongside the proposal's `transaction_index`, which the caller
+/// needs to surface so reviewers can `squads inspect` post-submit.
+///
+/// `txn_opts.lut_addresses` is passed through on both sides — the inner
+/// (proposal payload) compactor consults the LUTs to keep the encoded
+/// `transaction_message` under the 1232-byte limit, and the outer
+/// transaction message uses them for its own compression. The default
+/// is Helium's `COMMON_LUT` (devnet variant on devnet).
+pub(crate) async fn wrap_as_proposal<C: AsRef<helium_lib::client::SolanaRpcClient>>(
+    client: &C,
+    multisig: MultisigKey,
+    vault_index: u8,
+    inner_ixs: &[Instruction],
+    memo: Option<String>,
+    keypair: &Arc<Keypair>,
+    txn_opts: &TransactionOpts,
+) -> Result<(VersionedTransaction, u64)> {
+    let proposer = keypair.pubkey();
+    let (proposal_ixs, transaction_index) = lib_squads::v4::propose_ixs_with_luts(
+        client,
+        multisig,
+        vault_index,
+        proposer,
+        inner_ixs,
+        memo,
+        &txn_opts.lut_addresses,
+    )
+    .await?;
+    let (msg, _block_height) =
+        message::mk_message(client, &proposal_ixs, &txn_opts.lut_addresses, &proposer).await?;
+    let tx = mk_transaction(msg, &[&**keypair])?;
+    Ok((tx, transaction_index))
+}
+
+#[derive(Debug, clap::Args)]
+pub struct Cmd {
+    #[command(subcommand)]
+    cmd: SquadsCommand,
+}
+
+impl Cmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        self.cmd.run(opts).await
+    }
+}
+
+/// Commands for Squads multisig wallets (v3 and v4)
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum SquadsCommand {
+    Members(members::Cmd),
+    List(list::Cmd),
+    Inspect(inspect::Cmd),
+    Approve(vote::Approve),
+    Reject(vote::Reject),
+    Cancel(vote::Cancel),
+    Execute(execute::Cmd),
+    Threshold(threshold::Cmd),
+}
+
+impl SquadsCommand {
+    pub async fn run(&self, opts: Opts) -> Result {
+        match self {
+            Self::Members(cmd) => cmd.run(opts).await,
+            Self::List(cmd) => cmd.run(opts).await,
+            Self::Inspect(cmd) => cmd.run(opts).await,
+            Self::Approve(cmd) => cmd.run(opts).await,
+            Self::Reject(cmd) => cmd.run(opts).await,
+            Self::Cancel(cmd) => cmd.run(opts).await,
+            Self::Execute(cmd) => cmd.run(opts).await,
+            Self::Threshold(cmd) => cmd.run(opts).await,
+        }
+    }
+}

--- a/helium-wallet/src/cmd/squads/threshold.rs
+++ b/helium-wallet/src/cmd/squads/threshold.rs
@@ -1,0 +1,45 @@
+use crate::cmd::{squads as cmd_squads, *};
+use helium_lib::{keypair::Pubkey, squads::v4::ConfigActionInput};
+
+/// Propose a new approval threshold for the multisig (v4 only). Once
+/// the proposal lands and is executed, future proposals require the
+/// new threshold to pass. Squads' on-chain handler enforces a
+/// `[1, members.len()]` range at execute time.
+#[derive(Debug, Clone, clap::Args)]
+pub struct Cmd {
+    /// Multisig, vault, or any transaction/proposal PDA in the multisig.
+    target: Pubkey,
+
+    /// New approval threshold.
+    new_threshold: u16,
+
+    /// Memo recorded on the proposal.
+    #[arg(long)]
+    memo: Option<String>,
+
+    #[command(flatten)]
+    commit: CommitOpts,
+}
+
+impl Cmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        let password = get_wallet_password(false)?;
+        let keypair = opts.load_keypair(password.as_bytes())?;
+        let client = opts.client()?;
+        let txn_opts = self.commit.transaction_opts(&client);
+
+        let action = ConfigActionInput::ChangeThreshold {
+            new_threshold: self.new_threshold,
+        };
+        cmd_squads::submit_config_proposal(
+            &client,
+            self.target,
+            vec![action],
+            self.memo.clone(),
+            &keypair,
+            &self.commit,
+            &txn_opts,
+        )
+        .await
+    }
+}

--- a/helium-wallet/src/cmd/squads/vote.rs
+++ b/helium-wallet/src/cmd/squads/vote.rs
@@ -1,0 +1,194 @@
+use crate::cmd::*;
+use helium_lib::{
+    keypair::{Pubkey, Signer},
+    message, solana_sdk,
+    squads::{self, MemberAction, ProposalTarget, SquadsError, Version},
+    transaction::mk_transaction,
+};
+
+/// Approve a Squads proposal. Without `--commit`, simulates only.
+#[derive(Debug, Clone, clap::Args)]
+pub struct Approve {
+    #[command(flatten)]
+    target: VoteTarget,
+    /// Bundle the matching `*_transaction_execute` instruction into the
+    /// same transaction as the approve, so the proposal is approved AND
+    /// executed atomically with a single signature. Convenient for
+    /// single-threshold multisigs and "I'm the last vote" scenarios.
+    /// Errors out if the multisig has a non-zero `time_lock` (the
+    /// execute handler enforces `now - approval_ts >= time_lock`, which
+    /// can't hold inside the same block).
+    #[arg(long)]
+    execute: bool,
+}
+
+impl Approve {
+    pub async fn run(&self, opts: Opts) -> Result {
+        if !self.execute {
+            return self.target.run(opts, VoteKind::Approve).await;
+        }
+        self.run_with_execute(opts).await
+    }
+
+    async fn run_with_execute(&self, opts: Opts) -> Result {
+        let password = get_wallet_password(false)?;
+        let keypair = opts.load_keypair(password.as_bytes())?;
+        let client = opts.client()?;
+        let txn_opts = self.target.commit.transaction_opts(&client);
+        let member = keypair.pubkey();
+
+        let resolved =
+            squads::resolve_proposal_target(&client, &self.target.target, self.target.index)
+                .await?;
+        if !matches!(resolved.version, Version::V4) {
+            bail!("--execute on `squads approve` is only supported for v4 multisigs");
+        }
+
+        // Caller needs both Vote and Execute permissions for the combined tx
+        // to land. Check up front so the user gets a clean local error
+        // instead of paying simulation fees on a doomed submission.
+        squads::check_member_permission(&client, &resolved.multisig, &member, MemberAction::Vote)
+            .await?;
+        squads::check_member_permission(
+            &client,
+            &resolved.multisig,
+            &member,
+            MemberAction::Execute,
+        )
+        .await?;
+
+        let time_lock = squads::v4::get_time_lock(&client, &resolved.multisig).await?;
+        if time_lock != 0 {
+            bail!(
+                "multisig has a {time_lock}s time lock; --execute can't ride along with \
+                 approve in the same transaction. Run `squads execute` separately after \
+                 the time lock releases."
+            );
+        }
+
+        let approve_ix = build_vote_ix(&resolved, member, &self.target.memo, VoteKind::Approve)?;
+        let execute_ix =
+            squads::v4::execute_ix(&client, resolved.multisig, resolved.index, member).await?;
+
+        let ixs = &[approve_ix, execute_ix];
+        let (msg, _block_height) =
+            message::mk_message(&client, ixs, &txn_opts.lut_addresses, &member).await?;
+        let tx = mk_transaction(msg, &[&*keypair])?;
+        print_json(
+            &self
+                .target
+                .commit
+                .maybe_commit(tx, &client)
+                .await?
+                .to_json(),
+        )
+    }
+}
+
+/// Reject a Squads proposal.
+#[derive(Debug, Clone, clap::Args)]
+pub struct Reject {
+    #[command(flatten)]
+    target: VoteTarget,
+}
+
+impl Reject {
+    pub async fn run(&self, opts: Opts) -> Result {
+        self.target.run(opts, VoteKind::Reject).await
+    }
+}
+
+/// Cancel a previously-approved Squads proposal (only valid against an
+/// `Approved` proposal that hasn't been executed yet).
+#[derive(Debug, Clone, clap::Args)]
+pub struct Cancel {
+    #[command(flatten)]
+    target: VoteTarget,
+}
+
+impl Cancel {
+    pub async fn run(&self, opts: Opts) -> Result {
+        self.target.run(opts, VoteKind::Cancel).await
+    }
+}
+
+/// Common argument shape for all three vote actions.
+#[derive(Debug, Clone, clap::Args)]
+pub struct VoteTarget {
+    /// Multisig PDA, vault PDA, or transaction/proposal PDA. Same shapes
+    /// `squads inspect` accepts.
+    target: Pubkey,
+    /// Transaction index. Required if `target` is a multisig or vault;
+    /// inferred from the body otherwise.
+    #[arg(long)]
+    index: Option<u64>,
+    /// Optional v4 memo string attached to the vote (ignored on v3).
+    #[arg(long)]
+    memo: Option<String>,
+    #[command(flatten)]
+    commit: CommitOpts,
+}
+
+#[derive(Clone, Copy)]
+enum VoteKind {
+    Approve,
+    Reject,
+    Cancel,
+}
+
+impl VoteTarget {
+    async fn run(&self, opts: Opts, kind: VoteKind) -> Result {
+        let password = get_wallet_password(false)?;
+        let keypair = opts.load_keypair(password.as_bytes())?;
+        let client = opts.client()?;
+        let txn_opts = self.commit.transaction_opts(&client);
+
+        let resolved = squads::resolve_proposal_target(&client, &self.target, self.index).await?;
+        let member = keypair.pubkey();
+        // Pre-flight: the on-chain program rejects votes from non-members
+        // or members lacking the Vote permission. Surface a clear local
+        // error instead of letting the user pay simulation fees on a
+        // submission Squads will reject.
+        squads::check_member_permission(&client, &resolved.multisig, &member, MemberAction::Vote)
+            .await?;
+        let vote_ix = build_vote_ix(&resolved, member, &self.memo, kind)?;
+
+        let ixs = &[vote_ix];
+        let (msg, _block_height) =
+            message::mk_message(&client, ixs, &txn_opts.lut_addresses, &member).await?;
+        let tx = mk_transaction(msg, &[&*keypair])?;
+        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
+    }
+}
+
+fn build_vote_ix(
+    resolved: &ProposalTarget,
+    member: Pubkey,
+    memo: &Option<String>,
+    kind: VoteKind,
+) -> Result<solana_sdk::instruction::Instruction> {
+    let multisig = resolved.multisig;
+    Ok(match resolved.version {
+        Version::V4 => {
+            let idx = resolved.index;
+            let memo = memo.clone();
+            match kind {
+                VoteKind::Approve => squads::v4::proposal_approve_ix(multisig, idx, member, memo)?,
+                VoteKind::Reject => squads::v4::proposal_reject_ix(multisig, idx, member, memo)?,
+                VoteKind::Cancel => squads::v4::proposal_cancel_ix(multisig, idx, member, memo)?,
+            }
+        }
+        Version::V3 => {
+            let idx = v3_index(resolved.index)?;
+            match kind {
+                VoteKind::Approve => squads::v3::approve_transaction_ix(multisig, idx, member),
+                VoteKind::Reject => squads::v3::reject_transaction_ix(multisig, idx, member),
+                VoteKind::Cancel => squads::v3::cancel_transaction_ix(multisig, idx, member),
+            }
+        }
+    })
+}
+
+fn v3_index(index: u64) -> Result<u32> {
+    u32::try_from(index).map_err(|_| SquadsError::v3_index_out_of_range(index).into())
+}

--- a/helium-wallet/src/cmd/transfer.rs
+++ b/helium-wallet/src/cmd/transfer.rs
@@ -1,4 +1,7 @@
-use crate::cmd::*;
+use crate::{
+    cmd::{squads as cmd_squads, *},
+    result::Result,
+};
 use helium_lib::{
     keypair::{serde_pubkey, Pubkey},
     token::{self, Token, TokenAmount},
@@ -36,6 +39,16 @@ pub enum PayCmd {
 pub struct One {
     #[command(flatten)]
     payee: Payee,
+    /// Submit as a Squads v4 proposal instead of executing directly.
+    /// Accepts a multisig PDA or a vault PDA — when a vault is given the
+    /// multisig is resolved through the local cache. The transfer's
+    /// source becomes the vault's ATA (not the wallet's), and the wallet
+    /// just signs as proposer.
+    #[arg(long)]
+    squads: Option<Pubkey>,
+    /// Memo recorded on the v4 proposal (`--squads` only).
+    #[arg(long)]
+    memo: Option<String>,
     /// Commit the payment to the API
     #[command(flatten)]
     commit: CommitOpts,
@@ -76,6 +89,12 @@ pub struct One {
 pub struct Multi {
     /// File to read multiple payments from.
     path: PathBuf,
+    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    #[arg(long)]
+    squads: Option<Pubkey>,
+    /// Memo recorded on the v4 proposal (`--squads` only).
+    #[arg(long)]
+    memo: Option<String>,
     /// Commit the payments
     #[command(flatten)]
     commit: CommitOpts,
@@ -89,9 +108,38 @@ impl PayCmd {
         let client = opts.client()?;
         let txn_opts = self.commit().transaction_opts(&client);
 
+        if let Some(squads_target) = self.squads_target() {
+            return cmd_squads::submit_proposal_with(
+                &client,
+                squads_target,
+                self.squads_memo().cloned(),
+                &keypair,
+                self.commit(),
+                &txn_opts,
+                |vault| async move {
+                    Ok(token::transfer_instructions(vault.as_pubkey(), &payments)?)
+                },
+            )
+            .await;
+        }
+
         let (tx, _) = token::transfer(&client, &payments, &keypair, &txn_opts).await?;
 
         print_json(&self.commit().maybe_commit(tx, &client).await?.to_json())
+    }
+
+    fn squads_target(&self) -> Option<Pubkey> {
+        match &self {
+            Self::One(one) => one.squads,
+            Self::Multi(multi) => multi.squads,
+        }
+    }
+
+    fn squads_memo(&self) -> Option<&String> {
+        match &self {
+            Self::One(one) => one.memo.as_ref(),
+            Self::Multi(multi) => multi.memo.as_ref(),
+        }
     }
 
     fn collect_payments(&self) -> Result<Vec<(Pubkey, TokenAmount)>> {

--- a/helium-wallet/src/main.rs
+++ b/helium-wallet/src/main.rs
@@ -4,8 +4,8 @@
 use clap::Parser;
 use helium_wallet::{
     cmd::{
-        assets, balance, burn, create, dc, export, hotspots, info, memo, price, router, sign, swap,
-        transfer, upgrade, Opts,
+        assets, balance, burn, create, dc, export, hotspots, info, memo, price, router, sign,
+        squads, swap, transfer, upgrade, Opts,
     },
     result::Result,
 };
@@ -42,6 +42,7 @@ pub enum Cmd {
     Swap(swap::Cmd),
     Export(export::Cmd),
     Sign(sign::Cmd),
+    Squads(squads::Cmd),
     Memo(memo::Cmd),
     Assets(assets::Cmd),
 }
@@ -72,6 +73,7 @@ impl Cli {
             Cmd::Swap(cmd) => cmd.run(self.opts).await,
             Cmd::Export(cmd) => cmd.run(self.opts).await,
             Cmd::Sign(cmd) => cmd.run(self.opts).await,
+            Cmd::Squads(cmd) => cmd.run(self.opts).await,
             Cmd::Memo(cmd) => cmd.run(self.opts).await,
             Cmd::Assets(cmd) => cmd.run(self.opts).await,
         }


### PR DESCRIPTION
## Summary

Native Squads multisig integration in `helium-wallet`. Both v3 (`SMPLecH…`) and v4 (`SQDS4ep…`) are supported across read, vote, execute, and propose paths. Treasury-style wallet ops (`transfer`, `burn`, `dc mint/burn/delegate`, `assets transfer/burn`, `hotspots transfer/burn`) gain optional `--squads <multisig|vault>` and `--memo` flags that wrap the operation as a v4 proposal instead of executing it directly.

## What's in this PR (5 commits, follow in order)

1. **`feat(squads): foundation — read-only multisig support (v3 + v4)`** — squads module skeleton, vault → multisig resolution with persistent cache, `members` / `inspect` / `list` subcommands, IDL-driven instruction-arg decoding, `KnownProgram` registry, ConfigTransaction/Batch/ALT-resolved-account decoding, ISO8601 timestamps, summary block.
2. **`feat(squads): vote and execute (v3 + v4)`** — approve / reject / cancel / execute instruction builders + CLI subcommands. v3 execute does dedup + writable-promotion + signer-strip; v4 execute assembles `remaining_accounts` per the per-LUT writable/readonly order Squads validates.
3. **`feat(squads): proposer-side compactor and --squads on wallet ops`** — message compactor with LUT support so fat instruction sets fit under the 1232-byte limit; `--squads` / `--memo` on nine wallet ops; bare-instruction builders alongside existing message-builders. JSON output augmented with `multisig` / `vault` / `vault_index` / `transaction_index` so reviewers can immediately `squads inspect <vault> --index <n>` post-submit.
4. **`feat(squads): list subcommand, README docs, asset burn fix, ALT→LUT rename`** — `squads list` open-proposal scan, README `squads` section, internal ALT→LUT rename for codebase consistency. **Includes a fix for a pre-existing `asset::burn_message` bug**: bubblegum's on-chain burn handler forwards `remaining_accounts` to spl-account-compression's `replace_leaf` for Merkle-proof verification, but the existing message builder was only using the proof for priority-fee account hints, not the actual ix accounts. `assets burn` and `hotspots burn` were silently broken on master; the fix is shared with the new Squads-mode wrappers.
5. **`refactor(squads): typed errors and silent-failure hardening (review-driven)`** — typed `SquadsError` sub-enum retires 14 `*Error::other(format!(...))` escape hatches; RPC error responses surface their actual code/message; IDL load failures become loud (compile-time invariant); compactor length casts go through `try_u8` / `try_u16` so wire-format limit violations surface cleanly; inspect-side bails on missing LUT to match execute; corrupt `program_id_index` and out-of-range timestamps surface via typed errors.

## Out of scope (intentionally not in this PR)

- New-multisig creation (Helium uses Squads for treasury, not member admin via wallet).
- `swap` (Jupiter returns a fully-built signed v0 tx; can't extract instructions cleanly), `hotspots update` / `hotspots add` (DeWi onboarding-server signs), `dc burn-delegated` (router-authority op, not a vault use case), `memo` (trivial, doesn't justify multisig review), `assets/hotspots rewards claim` (recipient-PDA flow needs more design).
- Integration tests against a known multisig — unit tests cover instruction shapes; an end-to-end devnet round-trip is the natural next follow-up before relying on this in production.

## CLI surface added

```
helium-wallet squads members <multisig|vault>
helium-wallet squads list    <multisig|vault>
helium-wallet squads inspect <target> [--index <n>]
helium-wallet squads approve <target> [--index <n>] --commit
helium-wallet squads reject  <target> [--index <n>] --commit
helium-wallet squads cancel  <target> [--index <n>] --commit
helium-wallet squads execute <target> [--index <n>] --commit
```

`<target>` accepts a multisig PDA, vault PDA, or self-identifying transaction/proposal PDA. The transaction PDAs `squads list` emits feed straight into the action verbs.

Wallet ops gain `--squads <multisig|vault>` and `--memo <text>`:

| Command | Wraps |
|---|---|
| `transfer one`, `transfer multi` | Token transfer from the vault |
| `burn` | Subdao token burn from the vault |
| `dc mint` | HNT → DC mint |
| `dc burn` (non-router branch) | DC burn from the vault |
| `dc delegate` | DC delegation from the vault |
| `assets transfer`, `assets burn` | cNFT transfer/burn |
| `hotspots transfer`, `hotspots burn` | Hotspot transfer/burn |

## Notes for reviewers

- Commit 4's `fix(asset)` paragraph is worth a careful look — it's a real correctness fix to existing master code, not just Squads scope.
- Commit 3 changes `propose_ixs_with_luts` to return `(Vec<Instruction>, u64)` — the second element is the proposal's `transaction_index`, threaded out for the JSON-augment in `submit_proposal_with`. `propose_ixs` (the no-LUT delegate) drops the second element for callers that don't need it.
- All 5 commits compile + pass clippy `--all-features --locked -- -D clippy::all` + 32 unit tests on their own.