### PR TITLE
feat(ledger): add Ledger hardware-wallet support to the CLI

### DIFF
--- a/.github/workflows/geiger.yml
+++ b/.github/workflows/geiger.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup | Tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler libudev-dev
 
       - name: Setup | Cache
         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup | Tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler libudev-dev
 
       - name: Setup | Cache
         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
@@ -80,7 +80,7 @@ jobs:
         shell: bash
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-              sudo apt-get install -y protobuf-compiler
+              sudo apt-get install -y protobuf-compiler libudev-dev
           elif [ "$RUNNER_OS" == "macOS" ]; then
               brew install protobuf
           else

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -625,7 +625,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -995,28 +995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2b_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
-name = "blake2s_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee29928bad1e3f94c9d1528da29e07a1d3d04817ae8332de1e8b846c8439f4b3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
 name = "blake3"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,7 +1034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1500,15 +1478,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -2031,7 +2000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2509,16 +2478,17 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helium-crypto"
-version = "0.9.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ae6081be123db88474f4c5f12f9b0d3d90b9f5ce15171dee64fe92e3cae2dd"
+checksum = "c82c4001f4ecd017e4d0d36595ea9b7379d8ac23852945ee00db8752845950bf"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "bs58",
  "byteorder",
  "ed25519-compact",
  "k256",
- "multihash",
+ "ledger-apdu",
+ "ledger-transport-hid",
  "p256",
  "rand_core 0.6.4",
  "rsa",
@@ -2538,7 +2508,7 @@ dependencies = [
  "anchor-spl 0.31.1",
  "angry-purple-tiger",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bincode",
  "bytemuck",
  "chrono",
@@ -2621,6 +2591,7 @@ version = "2.3.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "bs58",
  "byteorder",
  "chrono",
  "clap",
@@ -2662,6 +2633,19 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hidapi"
+version = "2.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b71e1f4791fb9e93b9d7ee03d70b501ab48f6151432fbcadeabc30fe15396e"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "histogram"
@@ -3245,6 +3229,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ledger-apdu"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c21ffd28d97c9252671ab2ebe7078c9fa860ff3c5a125039e174d25ec6872169"
+dependencies = [
+ "arrayref",
+ "no-std-compat",
+ "snafu",
+]
+
+[[package]]
+name = "ledger-transport"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f18de77d956a030dbc5869ced47d404bbd641216ef2f9dce7ca90833ca64ff"
+dependencies = [
+ "async-trait",
+ "ledger-apdu",
+]
+
+[[package]]
+name = "ledger-transport-hid"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e34341e2708fbf805a9ada44ef6182170c6464c4fc068ab801abb7562fd5e8"
+dependencies = [
+ "byteorder",
+ "cfg-if",
+ "hex",
+ "hidapi",
+ "ledger-transport",
+ "libc",
+ "log",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,37 +3509,6 @@ source = "git+https://github.com/helium/proto?branch=master#e81cec790eca9a5bd3be
 dependencies = [
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "multihash"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
-dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "blake3",
- "core2",
- "digest 0.10.7",
- "multihash-derive",
- "sha2 0.10.9",
- "sha3",
- "unsigned-varint",
-]
-
-[[package]]
-name = "multihash-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
-dependencies = [
- "proc-macro-crate 1.1.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -4041,45 +4031,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
-dependencies = [
- "thiserror 1.0.69",
- "toml 0.5.11",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit 0.23.10+spec-1.0.0",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -4711,7 +4667,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4790,7 +4746,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5194,6 +5150,27 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "socket2"
@@ -8192,7 +8169,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8787,12 +8764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9035,7 +9006,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { version = "0", features = ["serde"] }
 serde = "1"
 serde_json = "1"
 rust_decimal = { version = "1", features = ["serde-float"] }
-helium-crypto = { version = "0.9" }
+helium-crypto = { version = "0.10" }
 helium-proto = { git = "https://github.com/helium/proto", branch = "master", features = [
   "services",
 ] }

--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -6,7 +6,7 @@ use crate::{
     entity_key::{self, AsEntityKey},
     error::{DecodeError, Error},
     helium_entity_manager,
-    keypair::{serde_opt_pubkey, serde_pubkey, Keypair, Pubkey},
+    keypair::{serde_opt_pubkey, serde_pubkey, Pubkey},
     kta, message,
     priority_fee::{compute_budget_instruction, compute_price_instruction_for_accounts},
     programs::{SPL_NOOP_PROGRAM_ID, TOKEN_METADATA_PROGRAM_ID},
@@ -510,7 +510,7 @@ pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     pubkey: &Pubkey,
     recipient: &Pubkey,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (mut txn, block_height) = transfer_transaction(client, pubkey, recipient, opts).await?;
@@ -607,7 +607,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
 pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     pubkey: &Pubkey,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (msg, block_height) = burn_message(client, pubkey, opts).await?;

--- a/helium-lib/src/boosting.rs
+++ b/helium-lib/src/boosting.rs
@@ -3,7 +3,7 @@ use crate::{
     client::SolanaRpcClient,
     error::Error,
     hexboosting,
-    keypair::{Keypair, Pubkey},
+    keypair::Pubkey,
     message, priority_fee,
     solana_sdk::{instruction::Instruction, signer::Signer},
     transaction, TransactionOpts,
@@ -25,7 +25,7 @@ pub trait StartBoostingHex {
 /// Builds a message that activates hex boosting for a set of hexes.
 pub async fn start_boost_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     updates: impl IntoIterator<Item = impl StartBoostingHex>,
     opts: &TransactionOpts,
 ) -> Result<(message::VersionedMessage, u64), Error> {
@@ -83,7 +83,7 @@ pub async fn start_boost_message<C: AsRef<SolanaRpcClient>>(
 pub async fn start_boost<C: AsRef<SolanaRpcClient>>(
     client: &C,
     updates: impl IntoIterator<Item = impl StartBoostingHex>,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(transaction::VersionedTransaction, u64), Error> {
     let (msg, block_height) = start_boost_message(client, keypair, updates, opts).await?;

--- a/helium-lib/src/dc.rs
+++ b/helium-lib/src/dc.rs
@@ -7,7 +7,7 @@ use crate::{
     entity_key::AsEntityKey,
     error::{DecodeError, Error},
     helium_sub_daos,
-    keypair::{Keypair, Pubkey},
+    keypair::Pubkey,
     message, priority_fee,
     solana_sdk::{instruction::Instruction, signer::Signer},
     token::{Token, TokenAmount},
@@ -90,7 +90,7 @@ pub async fn mint<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: TokenAmount,
     payee: &Pubkey,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (msg, block_height) = mint_message(client, amount, payee, &keypair.pubkey(), opts).await?;
@@ -164,7 +164,7 @@ pub async fn delegate<C: AsRef<SolanaRpcClient>>(
     subdao: SubDao,
     payer_key: &str,
     amount: u64,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (msg, block_height) =
@@ -223,7 +223,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
 pub async fn burn<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: u64,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (msg, block_height) = burn_message(client, amount, &keypair.pubkey(), opts).await?;
@@ -307,7 +307,7 @@ pub async fn burn_delegated_message<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
 pub async fn burn_delegated<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     client: &C,
     sub_dao: SubDao,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     amount: u64,
     router_key: &E,
     opts: &TransactionOpts,

--- a/helium-lib/src/hotspot/dataonly.rs
+++ b/helium-lib/src/hotspot/dataonly.rs
@@ -8,7 +8,7 @@ use crate::{
     error::{DecodeError, EncodeError, Error},
     helium_entity_manager, helium_sub_daos, hotspot,
     hotspot::{HotspotInfoUpdate, ECC_VERIFIER},
-    keypair::{Keypair, Pubkey},
+    keypair::Pubkey,
     kta, message, priority_fee,
     programs::{SPL_NOOP_PROGRAM_ID, TOKEN_METADATA_PROGRAM_ID},
     solana_sdk::{
@@ -242,7 +242,7 @@ pub async fn onboard<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAcc
     subdao: SubDao,
     hotspot_key: &helium_crypto::PublicKey,
     assertion: &HotspotInfoUpdate,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (mut txn, block_height) = onboard_transaction(
@@ -402,7 +402,7 @@ pub async fn issue<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     verifier: &str,
     add_tx: &mut BlockchainTxnAddGatewayV1,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (mut txn, block_height) =

--- a/helium-lib/src/hotspot/mod.rs
+++ b/helium-lib/src/hotspot/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     data_credits,
     error::{DecodeError, EncodeError, Error},
     helium_entity_manager, is_zero,
-    keypair::{pubkey, serde_opt_pubkey, serde_pubkey, Keypair, Pubkey},
+    keypair::{pubkey, serde_opt_pubkey, serde_pubkey, Pubkey},
     kta, message, onboarding, priority_fee,
     solana_sdk::{
         instruction::{AccountMeta, Instruction},
@@ -253,7 +253,7 @@ pub async fn direct_update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot: &helium_crypto::PublicKey,
     update: &HotspotInfoUpdate,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (mut txn, block_height) =
@@ -273,7 +273,7 @@ pub async fn update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     onboarding_server: Option<String>,
     hotspot: &helium_crypto::PublicKey,
     update: &HotspotInfoUpdate,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<VersionedTransaction, Error> {
     let public_key = keypair.pubkey();
@@ -336,7 +336,7 @@ pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot_key: &helium_crypto::PublicKey,
     recipient: &Pubkey,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let kta = kta::for_entity_key(hotspot_key).await?;
@@ -357,7 +357,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
 pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot_key: &helium_crypto::PublicKey,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let kta = kta::for_entity_key(hotspot_key).await?;

--- a/helium-lib/src/jupiter.rs
+++ b/helium-lib/src/jupiter.rs
@@ -1,6 +1,6 @@
 use crate::{
     client::SolanaRpcClient,
-    keypair::{Keypair, Pubkey},
+    keypair::Pubkey,
     transaction::VersionedTransaction,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
@@ -223,7 +223,7 @@ impl Client {
         input_mint: &Pubkey,
         output_mint: &Pubkey,
         amount: u64,
-        keypair: &Keypair,
+        keypair: &dyn Signer,
     ) -> Result<(VersionedTransaction, u64, OrderResponse), JupiterError> {
         let order = self
             .order(input_mint, output_mint, amount, &keypair.pubkey())

--- a/helium-lib/src/jupiter.rs
+++ b/helium-lib/src/jupiter.rs
@@ -1,8 +1,4 @@
-use crate::{
-    client::SolanaRpcClient,
-    keypair::Pubkey,
-    transaction::VersionedTransaction,
-};
+use crate::{client::SolanaRpcClient, keypair::Pubkey, transaction::VersionedTransaction};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde::{Deserialize, Serialize};
 use solana_sdk::signer::Signer;

--- a/helium-lib/src/memo.rs
+++ b/helium-lib/src/memo.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::SolanaRpcClient,
     error::Error,
-    keypair::{Keypair, Pubkey},
+    keypair::Pubkey,
     message, priority_fee,
     solana_sdk::signer::Signer,
     transaction, TransactionOpts,
@@ -33,7 +33,7 @@ pub async fn memo_message<C: AsRef<SolanaRpcClient>>(
 pub async fn memo<C: AsRef<SolanaRpcClient>>(
     client: &C,
     data: &str,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(transaction::VersionedTransaction, u64), Error> {
     let (msg, block_height) = memo_message(client, data, &keypair.pubkey(), opts).await?;

--- a/helium-lib/src/memo.rs
+++ b/helium-lib/src/memo.rs
@@ -1,10 +1,6 @@
 use crate::{
-    client::SolanaRpcClient,
-    error::Error,
-    keypair::Pubkey,
-    message, priority_fee,
-    solana_sdk::signer::Signer,
-    transaction, TransactionOpts,
+    client::SolanaRpcClient, error::Error, keypair::Pubkey, message, priority_fee,
+    solana_sdk::signer::Signer, transaction, TransactionOpts,
 };
 
 /// Builds a message that records an on-chain memo.

--- a/helium-lib/src/queue.rs
+++ b/helium-lib/src/queue.rs
@@ -1,7 +1,6 @@
 use crate::{
     client::{DasClient, GetAnchorAccount, SolanaRpcClient},
     error::Error,
-    keypair::Keypair,
     message, priority_fee,
     programs::hpl_crons,
     solana_sdk::{instruction::Instruction, pubkey},
@@ -73,7 +72,7 @@ pub async fn claim_wallet<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnch
     client: &C,
     task_queue_key: &Pubkey,
     wallet: &Pubkey,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let task_queue = client.anchor_account(task_queue_key).await?;

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -7,7 +7,7 @@ use crate::{
     entity_key::{self, AsEntityKey, EncodedEntityKey},
     error::{DecodeError, Error},
     helium_entity_manager,
-    keypair::{Keypair, Pubkey},
+    keypair::Pubkey,
     kta, lazy_distributor,
     message::{self, mk_message},
     priority_fee, rewards_oracle,
@@ -318,7 +318,7 @@ pub async fn claim<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccou
     token: ClaimableToken,
     amount: Option<u64>,
     encoded_entity_key: &entity_key::EncodedEntityKey,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<Option<(VersionedTransaction, u64)>, Error> {
     let ticket = ClaimTicket::new(encoded_entity_key.to_owned(), amount)?;
@@ -939,7 +939,7 @@ pub mod recipient {
         client: &C,
         token: ClaimableToken,
         entity_key: &E,
-        keypair: &Keypair,
+        keypair: &dyn Signer,
         opts: &TransactionOpts,
     ) -> Result<(VersionedTransaction, u64), Error> {
         let (msg, block_height) =
@@ -1139,7 +1139,7 @@ pub mod recipient {
             token: ClaimableToken,
             entity_key: &E,
             destination: &Pubkey,
-            keypair: &Keypair,
+            keypair: &dyn Signer,
             opts: &TransactionOpts,
         ) -> Result<(VersionedTransaction, u64), Error> {
             let (msg, block_height) = update_message(

--- a/helium-lib/src/schedule.rs
+++ b/helium-lib/src/schedule.rs
@@ -4,7 +4,6 @@ use crate::{
     dao::Dao,
     entity_key::EncodedEntityKey,
     error::Error,
-    keypair::Keypair,
     message, priority_fee,
     programs::hpl_crons::{self, accounts::CronJobV0, types::RemoveEntityFromCronArgsV0},
     queue,
@@ -103,7 +102,7 @@ pub async fn init<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccoun
     cron_id: u32,
     (schedule, name): (&str, &str),
     fund: Option<u64>,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let task_queue = client.anchor_account(task_queue_key).await?;
@@ -202,7 +201,7 @@ pub async fn requeue<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAcc
     task_queue_key: &Pubkey,
     cron_id: u32,
     name: &str,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let task_queue = client.anchor_account(task_queue_key).await?;
@@ -313,7 +312,7 @@ pub async fn close<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccou
     cron_job_key: &Pubkey,
     cron_id: u32,
     name: &str,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let cron_job: CronJobV0 = client.anchor_account(cron_job_key).await?;
@@ -407,7 +406,7 @@ pub async fn claim_wallet<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnch
     client: &C,
     cron_job_key: &Pubkey,
     wallet: &Pubkey,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let cron_job = client.anchor_account(cron_job_key).await?;
@@ -476,7 +475,7 @@ pub async fn claim_asset<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAncho
     client: &C,
     cron_job_key: &Pubkey,
     encoded_entity_key: &EncodedEntityKey,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let cron_job = client.anchor_account(cron_job_key).await?;

--- a/helium-lib/src/token.rs
+++ b/helium-lib/src/token.rs
@@ -3,7 +3,7 @@ use crate::{
     anchor_spl, circuit_breaker,
     client::SolanaRpcClient,
     error::{DecodeError, Error},
-    keypair::{serde_pubkey, Keypair, Pubkey},
+    keypair::{serde_pubkey, Pubkey},
     message, priority_fee,
     solana_sdk::{account::Account, signer::Signer},
     transaction::{mk_transaction, VersionedTransaction},
@@ -102,7 +102,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
 pub async fn burn<C: AsRef<SolanaRpcClient>>(
     client: &C,
     token_amount: &TokenAmount,
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (msg, block_height) = burn_message(client, token_amount, &keypair.pubkey(), opts).await?;
@@ -196,7 +196,7 @@ pub async fn transfer_message<C: AsRef<SolanaRpcClient>>(
 pub async fn transfer<C: AsRef<SolanaRpcClient>>(
     client: &C,
     transfers: &[(Pubkey, TokenAmount)],
-    keypair: &Keypair,
+    keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (msg, block_height) = transfer_message(client, transfers, &keypair.pubkey(), opts).await?;
@@ -289,8 +289,8 @@ pub async fn close_accounts<C: AsRef<SolanaRpcClient>>(
     client: &C,
     accounts: &[Pubkey],
     destination: &Pubkey,
-    owner: &Keypair,
-    fee_payer: &Keypair,
+    owner: &dyn Signer,
+    fee_payer: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (msg, block_height) = close_accounts_message(
@@ -302,7 +302,7 @@ pub async fn close_accounts<C: AsRef<SolanaRpcClient>>(
         opts,
     )
     .await?;
-    let signers: Vec<&Keypair> = if fee_payer.pubkey() == owner.pubkey() {
+    let signers: Vec<&dyn Signer> = if fee_payer.pubkey() == owner.pubkey() {
         vec![owner]
     } else {
         vec![fee_payer, owner]
@@ -317,8 +317,8 @@ pub async fn close_account<C: AsRef<SolanaRpcClient>>(
     client: &C,
     account: &Pubkey,
     destination: &Pubkey,
-    owner: &Keypair,
-    fee_payer: &Keypair,
+    owner: &dyn Signer,
+    fee_payer: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     close_accounts(client, &[*account], destination, owner, fee_payer, opts).await
@@ -607,8 +607,27 @@ pub struct TokenBalance {
 }
 
 /// Map of token type to balance, used for multi-token wallet summaries.
-#[derive(Debug, serde::Serialize, Clone, Default)]
+///
+/// Serializes as a flat `{ "<token>": <amount> }` object. Amounts follow the
+/// same numeric convention as [`TokenAmount`]: integer for 0-decimal tokens
+/// (DC), floating-point for the rest.
+#[derive(Debug, Clone, Default)]
 pub struct TokenBalanceMap(HashMap<Token, TokenBalance>);
+
+impl serde::Serialize for TokenBalanceMap {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        for (token, balance) in &self.0 {
+            if token.decimals() == 0 {
+                map.serialize_entry(&token.to_string(), &balance.amount.amount)?;
+            } else {
+                map.serialize_entry(&token.to_string(), &f64::from(&balance.amount))?;
+            }
+        }
+        map.end()
+    }
+}
 
 impl AsRef<HashMap<Token, TokenBalance>> for TokenBalanceMap {
     fn as_ref(&self) -> &HashMap<Token, TokenBalance> {
@@ -851,6 +870,27 @@ mod tests {
         };
         let json = serde_json::to_string(&balance).unwrap();
         assert!(json.contains("\"amount\":{\"token\":\"mobile\",\"amount\":10.5}"));
+    }
+
+    #[test]
+    fn test_token_balance_map_serialization_is_flat() {
+        let address = Pubkey::new_unique();
+        let mut map = TokenBalanceMap::default();
+        map.as_mut().insert(
+            Token::Hnt,
+            Token::Hnt.to_balance(address, 1_50_000_000), // 1.5 HNT (8 decimals)
+        );
+        map.as_mut().insert(
+            Token::Dc,
+            Token::Dc.to_balance(address, 100), // 100 DC (0 decimals)
+        );
+        let value: serde_json::Value = serde_json::to_value(&map).unwrap();
+        assert_eq!(value.get("hnt"), Some(&serde_json::json!(1.5)));
+        assert_eq!(value.get("dc"), Some(&serde_json::json!(100)));
+        // Per-ATA address and nested amount struct should not appear.
+        let json = serde_json::to_string(&value).unwrap();
+        assert!(!json.contains("\"address\""));
+        assert!(!json.contains("\"token\":"));
     }
 
     #[test]

--- a/helium-wallet/Cargo.toml
+++ b/helium-wallet/Cargo.toml
@@ -35,4 +35,5 @@ tokio = { version = "1.0", features = ["full"] }
 helium-lib = { path = "../helium-lib", features = ["clap", "mnemonic"] }
 helium-mnemonic = { path = "../helium-mnemonic" }
 helium-proto = { workspace = true }
-helium-crypto = { workspace = true, features = ["multisig", "solana"] }
+helium-crypto = { workspace = true, features = ["solana", "ledger"] }
+bs58 = "0.5"

--- a/helium-wallet/src/cmd/assets/burn.rs
+++ b/helium-wallet/src/cmd/assets/burn.rs
@@ -24,8 +24,7 @@ pub struct Cmd {
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let client = opts.client()?;
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let transaction_opts = self.commit.transaction_opts(&client);
         let asset = asset::for_entity_key(&client, &self.entity_key.as_entity_key()?).await?;
 
@@ -36,7 +35,7 @@ impl Cmd {
                 client_ref,
                 squads_target,
                 self.memo.clone(),
-                &keypair,
+                &*signer,
                 &self.commit,
                 &transaction_opts,
                 |vault| async move {
@@ -49,7 +48,7 @@ impl Cmd {
             .await;
         }
 
-        let (tx, _) = asset::burn(&client, &asset.id, &keypair, &transaction_opts).await?;
+        let (tx, _) = asset::burn(&client, &asset.id, &*signer, &transaction_opts).await?;
 
         print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }

--- a/helium-wallet/src/cmd/assets/claim/one.rs
+++ b/helium-wallet/src/cmd/assets/claim/one.rs
@@ -22,8 +22,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
 
@@ -35,7 +34,7 @@ impl Cmd {
             self.token,
             token_amount,
             &self.entity_key,
-            &keypair,
+            &*signer,
             &transaction_opts,
         )
         .await?

--- a/helium-wallet/src/cmd/assets/claim/queue.rs
+++ b/helium-wallet/src/cmd/assets/claim/queue.rs
@@ -53,14 +53,13 @@ impl ClaimWalletCmd {
         let wallet = opts.maybe_wallet_key(self.wallet)?;
         let client = opts.client()?;
 
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let transaction_opts = self.commit.transaction_opts(&client);
         let (tx, _) = queue::claim_wallet(
             &client,
             &queue::TASK_QUEUE_ID,
             &wallet,
-            &keypair,
+            &*signer,
             &transaction_opts,
         )
         .await?;

--- a/helium-wallet/src/cmd/assets/claim/schedule.rs
+++ b/helium-wallet/src/cmd/assets/claim/schedule.rs
@@ -89,8 +89,7 @@ impl InitCmd {
             return print_json(&json!({ "result": "ok"}));
         }
 
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let fund = self
             .fund
             .map(|amount| token::TokenAmount::from_f64(token::Token::Sol, amount).amount);
@@ -100,7 +99,7 @@ impl InitCmd {
             0,
             (&self.schedule, SCHEDULE_NAME),
             fund,
-            &keypair,
+            &*signer,
             &transaction_opts,
         )
         .await?;
@@ -123,14 +122,13 @@ impl RequeueCmd {
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
 
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let (tx, _) = schedule::requeue(
             &client,
             &queue::TASK_QUEUE_ID,
             0,
             SCHEDULE_NAME,
-            &keypair,
+            &*signer,
             &transaction_opts,
         )
         .await?;
@@ -197,19 +195,18 @@ pub struct CloseCmd {
 
 impl CloseCmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
 
-        let cron_job_key = schedule::cron_job_key_for_wallet(&keypair.pubkey(), 0);
+        let cron_job_key = schedule::cron_job_key_for_wallet(&signer.pubkey(), 0);
 
         let (tx, _) = schedule::close(
             &client,
             &cron_job_key,
             0,
             SCHEDULE_NAME,
-            &keypair,
+            &*signer,
             &transaction_opts,
         )
         .await?;
@@ -255,12 +252,11 @@ impl ClaimWalletCmd {
             return print_json(&claim_info);
         }
 
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let transaction_opts = self.commit.transaction_opts(&client);
-        let cron_job_key = schedule::cron_job_key_for_wallet(&keypair.pubkey(), 0);
+        let cron_job_key = schedule::cron_job_key_for_wallet(&signer.pubkey(), 0);
         let (tx, _) =
-            schedule::claim_wallet(&client, &cron_job_key, &wallet, &keypair, &transaction_opts)
+            schedule::claim_wallet(&client, &cron_job_key, &wallet, &*signer, &transaction_opts)
                 .await?;
 
         print_json(&self.commit.maybe_commit(tx, &client).await.to_json())
@@ -287,15 +283,14 @@ pub struct ClaimOneCmd {
 impl ClaimOneCmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let client = opts.client()?;
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let transaction_opts = self.commit.transaction_opts(&client);
-        let cron_job_key = schedule::cron_job_key_for_wallet(&keypair.pubkey(), 0);
+        let cron_job_key = schedule::cron_job_key_for_wallet(&signer.pubkey(), 0);
         let (tx, _) = schedule::claim_asset(
             &client,
             &cron_job_key,
             &self.entity_key,
-            &keypair,
+            &*signer,
             &transaction_opts,
         )
         .await?;

--- a/helium-wallet/src/cmd/assets/rewards.rs
+++ b/helium-wallet/src/cmd/assets/rewards.rs
@@ -115,13 +115,12 @@ impl RecipientInitCmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let (tx, _) = reward::recipient::init(
             &client,
             self.token,
             &self.entity_key.as_entity_key()?,
-            &keypair,
+            &*signer,
             &transaction_opts,
         )
         .await?;
@@ -151,14 +150,13 @@ impl RecipientUpdateCmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let (tx, _) = reward::recipient::destination::update(
             &client,
             self.token,
             &self.entity_key.as_entity_key()?,
             &self.destination,
-            &keypair,
+            &*signer,
             &transaction_opts,
         )
         .await?;

--- a/helium-wallet/src/cmd/assets/transfer.rs
+++ b/helium-wallet/src/cmd/assets/transfer.rs
@@ -27,8 +27,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
         let kta = kta::for_entity_key(&self.entity_key.as_entity_key()?).await?;
@@ -41,7 +40,7 @@ impl Cmd {
                 client_ref,
                 squads_target,
                 self.memo.clone(),
-                &keypair,
+                &*signer,
                 &self.commit,
                 &transaction_opts,
                 |vault| async move {
@@ -62,14 +61,14 @@ impl Cmd {
             .await;
         }
 
-        if keypair.pubkey() == self.recipient {
+        if signer.pubkey() == self.recipient {
             bail!("recipient already owner of hotspot");
         }
         let (tx, _) = asset::transfer(
             &client,
             &kta.asset,
             &self.recipient,
-            &keypair,
+            &*signer,
             &transaction_opts,
         )
         .await?;

--- a/helium-wallet/src/cmd/burn.rs
+++ b/helium-wallet/src/cmd/burn.rs
@@ -21,8 +21,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let txn_opts = self.commit.transaction_opts(&client);
 
@@ -33,7 +32,7 @@ impl Cmd {
                 &client,
                 squads_target,
                 self.memo.clone(),
-                &keypair,
+                &*signer,
                 &self.commit,
                 &txn_opts,
                 |vault| async move {
@@ -46,7 +45,7 @@ impl Cmd {
             .await;
         }
 
-        let (tx, _) = token::burn(&client, &token_amount, &keypair, &txn_opts).await?;
+        let (tx, _) = token::burn(&client, &token_amount, &*signer, &txn_opts).await?;
         print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/dc/burn.rs
+++ b/helium-wallet/src/cmd/dc/burn.rs
@@ -28,8 +28,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
 
@@ -41,7 +40,7 @@ impl Cmd {
                 &client,
                 squads_target,
                 self.memo.clone(),
-                &keypair,
+                &*signer,
                 &self.commit,
                 &transaction_opts,
                 |vault| async move { Ok(vec![dc::burn_instruction(self.dc, vault.as_pubkey())]) },
@@ -54,14 +53,14 @@ impl Cmd {
                 dc::burn_delegated(
                     &client,
                     subdao,
-                    &keypair,
+                    &*signer,
                     self.dc,
                     router_key,
                     &transaction_opts,
                 )
                 .await?
             }
-            (None, None) => dc::burn(&client, self.dc, &keypair, &transaction_opts).await?,
+            (None, None) => dc::burn(&client, self.dc, &*signer, &transaction_opts).await?,
             _ => bail!("both router and subdao must be specified"),
         };
         print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())

--- a/helium-wallet/src/cmd/dc/delegate.rs
+++ b/helium-wallet/src/cmd/dc/delegate.rs
@@ -28,8 +28,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
 
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
@@ -39,7 +38,7 @@ impl Cmd {
                 &client,
                 squads_target,
                 self.memo.clone(),
-                &keypair,
+                &*signer,
                 &self.commit,
                 &transaction_opts,
                 |vault| async move {
@@ -59,7 +58,7 @@ impl Cmd {
             self.subdao,
             &self.payer,
             self.dc,
-            &keypair,
+            &*signer,
             &transaction_opts,
         )
         .await?;

--- a/helium-wallet/src/cmd/dc/mint.rs
+++ b/helium-wallet/src/cmd/dc/mint.rs
@@ -40,8 +40,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
 
         let client = opts.client()?;
         let amount = match (self.hnt, self.dc) {
@@ -58,7 +57,7 @@ impl Cmd {
                 client_ref,
                 squads_target,
                 self.memo.clone(),
-                &keypair,
+                &*signer,
                 &self.commit,
                 &transaction_opts,
                 |vault| async move {
@@ -74,8 +73,8 @@ impl Cmd {
             .await;
         }
 
-        let payee = self.payee.unwrap_or(keypair.pubkey());
-        let (tx, _) = dc::mint(&client, amount, &payee, &keypair, &transaction_opts).await?;
+        let payee = self.payee.unwrap_or(signer.pubkey());
+        let (tx, _) = dc::mint(&client, amount, &payee, &*signer, &transaction_opts).await?;
         print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/hotspots/add.rs
+++ b/helium-wallet/src/cmd/hotspots/add.rs
@@ -97,8 +97,7 @@ async fn perform_add(
     commit: &CommitOpts,
     opts: &Opts,
 ) -> Result {
-    let password = get_wallet_password(false)?;
-    let keypair = opts.load_keypair(password.as_bytes())?;
+    let signer = opts.load_signer()?;
     let gateway = helium_crypto::PublicKey::from_bytes(&txn.gateway)?;
     let client = opts.client()?;
     let hotspot_issued = asset::for_entity_key(&client, &gateway).await.is_ok();
@@ -112,7 +111,7 @@ async fn perform_add(
 
     let issue_response = if !hotspot_issued {
         let (tx, _) =
-            hotspot::dataonly::issue(&client, verifier, &mut txn, &keypair, transaction_opts)
+            hotspot::dataonly::issue(&client, verifier, &mut txn, &*signer, transaction_opts)
                 .await?;
         commit.maybe_commit(tx, &client).await?
     } else {
@@ -128,7 +127,7 @@ async fn perform_add(
             subdao,
             &gateway,
             &update,
-            &keypair,
+            &*signer,
             transaction_opts,
         )
         .await?;

--- a/helium-wallet/src/cmd/hotspots/burn.rs
+++ b/helium-wallet/src/cmd/hotspots/burn.rs
@@ -23,8 +23,7 @@ pub struct Cmd {
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let client = opts.client()?;
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let transaction_opts = self.commit.transaction_opts(&client);
 
         if let Some(squads_target) = self.squads {
@@ -34,7 +33,7 @@ impl Cmd {
                 client_ref,
                 squads_target,
                 self.memo.clone(),
-                &keypair,
+                &*signer,
                 &self.commit,
                 &transaction_opts,
                 |vault| async move {
@@ -47,7 +46,7 @@ impl Cmd {
             .await;
         }
 
-        let (tx, _) = hotspot::burn(&client, &self.address, &keypair, &transaction_opts).await?;
+        let (tx, _) = hotspot::burn(&client, &self.address, &*signer, &transaction_opts).await?;
 
         print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }

--- a/helium-wallet/src/cmd/hotspots/transfer.rs
+++ b/helium-wallet/src/cmd/hotspots/transfer.rs
@@ -25,8 +25,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
 
@@ -38,7 +37,7 @@ impl Cmd {
                 client_ref,
                 squads_target,
                 self.memo.clone(),
-                &keypair,
+                &*signer,
                 &self.commit,
                 &transaction_opts,
                 |vault| async move {
@@ -59,14 +58,14 @@ impl Cmd {
             .await;
         }
 
-        if keypair.pubkey() == self.recipient {
+        if signer.pubkey() == self.recipient {
             bail!("recipient already owner of hotspot");
         }
         let (tx, _) = hotspot::transfer(
             &client,
             &self.address,
             &self.recipient,
-            &keypair,
+            &*signer,
             &transaction_opts,
         )
         .await?;

--- a/helium-wallet/src/cmd/hotspots/update.rs
+++ b/helium-wallet/src/cmd/hotspots/update.rs
@@ -61,8 +61,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
 
         let server = self.onboarding.as_ref().map(|value| {
             match value.as_str() {
@@ -85,7 +84,7 @@ impl Cmd {
             server,
             &self.gateway,
             &update,
-            &keypair,
+            &*signer,
             &transaction_opts,
         )
         .await?;

--- a/helium-wallet/src/cmd/info.rs
+++ b/helium-wallet/src/cmd/info.rs
@@ -1,8 +1,9 @@
 use crate::{
-    cmd::{print_json, Opts},
+    cmd::{print_json, Opts, WalletSource},
     result::{Error, Result},
     wallet::Wallet,
 };
+use helium_crypto::ledger;
 use helium_lib::keypair::{to_helium_pubkey, to_pubkey, Pubkey};
 use qr2term::print_qr;
 use serde_json::json;
@@ -23,13 +24,24 @@ impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
         if let Some(address) = &self.address {
             let pubkey = parse_address(address)?;
-            print_address(&pubkey)
-        } else {
-            let wallet = opts.load_wallet()?;
-            if self.qr {
-                print_qr(wallet.public_key.to_string()).map_err(Error::from)
-            } else {
-                print_wallet(&wallet)
+            return print_address(&pubkey);
+        }
+        match opts.sources().first() {
+            Some(WalletSource::Ledger { path, serial, .. }) => {
+                let pubkey = opts.load_pubkey()?;
+                if self.qr {
+                    print_qr(pubkey.to_string()).map_err(Error::from)
+                } else {
+                    print_ledger(&pubkey, path, serial.as_deref())
+                }
+            }
+            _ => {
+                let wallet = opts.load_wallet()?;
+                if self.qr {
+                    print_qr(wallet.public_key.to_string()).map_err(Error::from)
+                } else {
+                    print_wallet(&wallet)
+                }
             }
         }
     }
@@ -64,5 +76,25 @@ pub(crate) fn print_wallet(wallet: &Wallet) -> Result {
             "helium": helium_address,
         },
     });
+    print_json(&json)
+}
+
+fn print_ledger(
+    address: &Pubkey,
+    path: &ledger::DerivationPath,
+    serial: Option<&str>,
+) -> Result {
+    let helium_address = to_helium_pubkey(address)?;
+    let mut json = json!({
+        "source": "ledger",
+        "path": path.to_string(),
+        "address": {
+            "solana": address.to_string(),
+            "helium": helium_address.to_string(),
+        },
+    });
+    if let Some(serial) = serial {
+        json["serial"] = json!(serial);
+    }
     print_json(&json)
 }

--- a/helium-wallet/src/cmd/info.rs
+++ b/helium-wallet/src/cmd/info.rs
@@ -79,11 +79,7 @@ pub(crate) fn print_wallet(wallet: &Wallet) -> Result {
     print_json(&json)
 }
 
-fn print_ledger(
-    address: &Pubkey,
-    path: &ledger::DerivationPath,
-    serial: Option<&str>,
-) -> Result {
+fn print_ledger(address: &Pubkey, path: &ledger::DerivationPath, serial: Option<&str>) -> Result {
     let helium_address = to_helium_pubkey(address)?;
     let mut json = json!({
         "source": "ledger",

--- a/helium-wallet/src/cmd/ledger.rs
+++ b/helium-wallet/src/cmd/ledger.rs
@@ -1,0 +1,210 @@
+use crate::cmd::*;
+use helium_crypto::{ledger, Network};
+use helium_lib::{
+    keypair::{to_helium_pubkey, to_pubkey, Pubkey},
+    token::{self, Token, TokenBalanceMap},
+};
+
+/// Operations on a connected Ledger device.
+#[derive(Debug, clap::Args)]
+pub struct Cmd {
+    #[command(subcommand)]
+    cmd: SubCmd,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum SubCmd {
+    List(ListCmd),
+    Devices(DevicesCmd),
+}
+
+impl Cmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        match &self.cmd {
+            SubCmd::List(cmd) => cmd.run(opts).await,
+            SubCmd::Devices(cmd) => cmd.run().await,
+        }
+    }
+}
+
+/// Enumerate every Ledger device USB-HID can see — useful for finding a
+/// device's USB serial to pass via `usb://ledger?serial=...` when multiple
+/// Ledgers are attached.
+#[derive(Debug, clap::Args)]
+pub struct DevicesCmd;
+
+impl DevicesCmd {
+    pub async fn run(&self) -> Result {
+        let devices = ledger::list_devices()?;
+        print_json(&json!({ "devices": devices }))
+    }
+}
+
+/// Enumerate Solana-derivation accounts on a connected Ledger and annotate
+/// each with its on-chain balances.
+///
+/// Both Solana derivation-path families are scanned by default:
+/// - 4-level `m/44'/501'/N'/0'` — Ledger Live and recent Phantom default.
+/// - 3-level `m/44'/501'/N'` — Solana CLI, older Phantom, some other wallets.
+///
+/// The two families produce different addresses for the same account index;
+/// scanning both ensures we don't miss a funded account just because Phantom
+/// happened to use one form when the user originally connected the device.
+///
+/// Funded accounts are listed first; empty accounts are hidden unless
+/// `--all`. Each entry includes a copy-pasteable `usb://ledger?key=...`
+/// URL that can be passed to `--file`. Requires the Solana app to be open
+/// on the device.
+#[derive(Debug, clap::Args)]
+pub struct ListCmd {
+    /// Number of accounts to enumerate, starting from account 0.
+    #[arg(long, default_value_t = 10)]
+    count: u32,
+
+    /// Include accounts with no balance. Default hides empty accounts when
+    /// balances are available.
+    #[arg(long)]
+    all: bool,
+
+    /// Skip the on-chain balance lookup. Useful for offline / air-gapped
+    /// derivation when no RPC is reachable.
+    #[arg(long)]
+    no_balance: bool,
+
+    /// USB serial of the Ledger to scan. When omitted, the first connected
+    /// device is opened.
+    #[arg(long)]
+    serial: Option<String>,
+}
+
+struct Entry {
+    url: String,
+    path: String,
+    solana: Pubkey,
+    helium: helium_crypto::PublicKey,
+    balance: Option<TokenBalanceMap>,
+}
+
+impl Entry {
+    fn is_funded(&self) -> bool {
+        self.balance
+            .as_ref()
+            .is_some_and(|b| !b.as_ref().is_empty())
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        let mut value = json!({
+            "url": self.url,
+            "path": self.path,
+            "address": {
+                "solana": self.solana.to_string(),
+                "helium": self.helium.to_string(),
+            },
+        });
+        if let Some(balance) = &self.balance {
+            value["balance"] = serde_json::to_value(balance).unwrap_or(json!({}));
+        }
+        value
+    }
+}
+
+impl ListCmd {
+    pub async fn run(&self, opts: Opts) -> Result {
+        // 1. Derive accounts on the device — both 3-level and 4-level path
+        //    families per index, since Phantom/Ledger Live/Solana CLI vary
+        //    across versions and configurations.
+        let serial = self.serial.as_deref();
+        let mut entries: Vec<Entry> = Vec::with_capacity(self.count as usize * 2);
+        for n in 0..self.count {
+            entries.push(derive(
+                ledger::DerivationPath::solana(n, 0),
+                n,
+                Some(0),
+                serial,
+            )?);
+            entries.push(derive(
+                ledger::DerivationPath::solana_cli(n),
+                n,
+                None,
+                serial,
+            )?);
+        }
+
+        // 2. Bulk-fetch balances unless explicitly disabled. On RPC failure,
+        //    fall back to address-only output with a warning so the discovery
+        //    flow still works in degraded conditions.
+        let mut warning: Option<String> = None;
+        if !self.no_balance {
+            match fetch_balances(&opts, &entries).await {
+                Ok(balances) => {
+                    for (entry, balance) in entries.iter_mut().zip(balances) {
+                        entry.balance = Some(balance);
+                    }
+                }
+                Err(err) => {
+                    warning = Some(format!("balance lookup failed: {err}"));
+                }
+            }
+        }
+
+        // 3. Sort funded first when balances are available; otherwise keep
+        //    derivation order.
+        let have_balances = !self.no_balance && warning.is_none();
+        if have_balances {
+            entries.sort_by_key(|e| !e.is_funded());
+        }
+
+        // 4. Hide empty accounts unless --all or balances unavailable.
+        if have_balances && !self.all {
+            entries.retain(Entry::is_funded);
+        }
+
+        // 5. Emit JSON.
+        let accounts: Vec<_> = entries.iter().map(Entry::to_json).collect();
+        let mut out = json!({ "accounts": accounts });
+        if let Some(w) = warning {
+            out["warning"] = json!(w);
+        }
+        print_json(&out)
+    }
+}
+
+fn derive(
+    path: ledger::DerivationPath,
+    account: u32,
+    change: Option<u32>,
+    serial: Option<&str>,
+) -> Result<Entry> {
+    let kp = ledger::Keypair::from_derivation_path(Network::MainNet, path.clone(), serial)?;
+    let solana = to_pubkey(&kp.public_key)?;
+    let helium = to_helium_pubkey(&solana)?;
+    let url = match change {
+        Some(change) => format!("usb://ledger?key={account}/{change}"),
+        None => format!("usb://ledger?key={account}"),
+    };
+    Ok(Entry {
+        url,
+        path: path.to_string(),
+        solana,
+        helium,
+        balance: None,
+    })
+}
+
+/// Bulk-query SOL + Helium ATA balances for every entry in one
+/// getMultipleAccounts roundtrip (chunked internally to Solana's 100/call cap).
+async fn fetch_balances(opts: &Opts, entries: &[Entry]) -> Result<Vec<TokenBalanceMap>> {
+    let client = opts.client()?;
+    let tokens_per_owner = Token::all().len();
+
+    let mut atas: Vec<Pubkey> = Vec::with_capacity(entries.len() * tokens_per_owner);
+    for entry in entries {
+        atas.extend(Token::associated_token_addresses(&entry.solana));
+    }
+
+    let balances = token::balance_for_addresses(&client, &atas).await?;
+    Ok(balances
+        .chunks(tokens_per_owner)
+        .map(|chunk| TokenBalanceMap::from(chunk.to_vec()))
+        .collect())
+}

--- a/helium-wallet/src/cmd/memo.rs
+++ b/helium-wallet/src/cmd/memo.rs
@@ -14,12 +14,11 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
         let (tx, _) =
-            helium_lib::memo::memo(&client, &self.message, &keypair, &transaction_opts).await?;
+            helium_lib::memo::memo(&client, &self.message, &*signer, &transaction_opts).await?;
         print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -5,13 +5,14 @@ use crate::{
 use helium_lib::{
     b64,
     client::{self, SolanaRpcClient},
-    keypair::{Keypair, Pubkey},
+    keypair::{to_pubkey, Keypair, Pubkey, Signer},
     message, priority_fee,
     solana_client::{
         self, rpc_config::RpcSendTransactionConfig, rpc_request::RpcResponseErrorData,
         rpc_response::RpcSimulateTransactionResult,
     },
-    solana_sdk::transaction::VersionedTransaction,
+    solana_sdk::{commitment_config::CommitmentConfig, transaction::VersionedTransaction},
+    transaction::{self as lib_transaction, SignatureStatus},
     TransactionOpts,
 };
 use serde_json::json;
@@ -20,6 +21,7 @@ use std::{
     ops::Deref,
     path::{Path, PathBuf},
     sync::Arc,
+    time::Duration,
 };
 
 pub mod assets;
@@ -30,26 +32,31 @@ pub mod dc;
 pub mod export;
 pub mod hotspots;
 pub mod info;
+pub mod ledger;
 pub mod memo;
 pub mod price;
 pub mod router;
 pub mod sign;
+pub mod source;
 pub mod squads;
 pub mod swap;
 pub mod transfer;
 pub mod upgrade;
 
+pub use source::WalletSource;
+
 /// Common options for most wallet commands
 #[derive(Debug, clap::Args, Clone)]
 pub struct Opts {
-    /// File(s) to use
+    /// Wallet source(s) to use. Either a path to an encrypted key file, or a
+    /// Ledger device URL (`usb://ledger?key=<account>/<change>`).
     #[arg(
         short = 'f',
         long = "file",
         number_of_values(1),
         default_value = "wallet.key"
     )]
-    files: Vec<PathBuf>,
+    files: Vec<WalletSource>,
 
     /// Solana RPC URL to use.
     #[arg(long, default_value = "m")]
@@ -57,27 +64,54 @@ pub struct Opts {
 }
 
 impl Opts {
+    pub fn sources(&self) -> &[WalletSource] {
+        &self.files
+    }
+
+    /// Resolve the wallet's Solana public key, opening a Ledger if the source
+    /// requires it. Does not prompt for a password.
+    pub fn load_pubkey(&self) -> Result<Pubkey> {
+        match self.files.first() {
+            None => bail!("at least one wallet source expected"),
+            Some(WalletSource::Ledger { path, serial, .. }) => {
+                if self.files.len() > 1 {
+                    bail!("a Ledger source cannot be combined with other wallets");
+                }
+                let kp = helium_crypto::ledger::Keypair::from_derivation_path(
+                    helium_crypto::Network::MainNet,
+                    path.clone(),
+                    serial.as_deref(),
+                )?;
+                to_pubkey(&kp.public_key).map_err(Error::from)
+            }
+            Some(WalletSource::File(_)) => Ok(self.load_wallet()?.public_key),
+        }
+    }
+
     pub fn maybe_wallet_key(&self, wallet: Option<Pubkey>) -> Result<Pubkey> {
-        let pubkey = if let Some(pubkey) = wallet {
-            pubkey
-        } else {
-            self.load_wallet()?.public_key
-        };
-        Ok(pubkey)
+        match wallet {
+            Some(pubkey) => Ok(pubkey),
+            None => self.load_pubkey(),
+        }
     }
 
     pub fn load_wallet(&self) -> Result<Wallet> {
-        let mut files_iter = self.files.iter();
+        let mut files_iter = self.files.iter().map(|s| match s {
+            WalletSource::File(path) => Ok(path),
+            WalletSource::Ledger { .. } => Err(anyhow!(
+                "this command does not yet support Ledger sources; use a key file"
+            )),
+        });
         let mut first_wallet = match files_iter.next() {
             Some(path) => {
-                let mut reader = fs::File::open(path)?;
+                let mut reader = fs::File::open(path?)?;
                 Wallet::read(&mut reader)?
             }
             None => bail!("At least one wallet file expected"),
         };
 
         for path in files_iter {
-            let mut reader = fs::File::open(path)?;
+            let mut reader = fs::File::open(path?)?;
             let w = Wallet::read(&mut reader)?;
             first_wallet.absorb_shard(&w)?;
         }
@@ -90,9 +124,48 @@ impl Opts {
         wallet.decrypt(password)
     }
 
+    /// Resolve the wallet to a Solana SDK signer. For File sources this
+    /// prompts for a password and decrypts the keyfile; for Ledger sources
+    /// it opens the device (no password). The returned signer can be passed
+    /// to any helium-lib function expecting `&dyn Signer`.
+    pub fn load_signer(&self) -> Result<Arc<dyn Signer + Send + Sync>> {
+        match self.files.first() {
+            None => bail!("at least one wallet source expected"),
+            Some(WalletSource::Ledger { path, serial, .. }) => {
+                if self.files.len() > 1 {
+                    bail!("a Ledger source cannot be combined with other wallets");
+                }
+                let kp = helium_crypto::ledger::Keypair::from_derivation_path(
+                    helium_crypto::Network::MainNet,
+                    path.clone(),
+                    serial.as_deref(),
+                )?
+                .with_blind_sign_hook(print_blind_sign_hash);
+                Ok(Arc::new(kp))
+            }
+            Some(WalletSource::File(_)) => {
+                let password = get_wallet_password(false)?;
+                Ok(self.load_keypair(password.as_bytes())?)
+            }
+        }
+    }
+
     pub fn client(&self) -> Result<client::Client> {
         Ok(client::Client::try_from(self.url.as_str())?)
     }
+}
+
+/// Blind-sign hook installed on every Ledger keypair we hand out. Fires
+/// just before the device receives a SIGN_MESSAGE APDU that's going to
+/// blind-sign (any program outside the Solana app's clear-sign whitelist).
+/// Prints the SHA-256 the device will display in base58 to stderr so the
+/// user can compare. helium-crypto no longer prints this itself; it's our
+/// job to surface for any caller that wants the UX.
+fn print_blind_sign_hash(hash: &[u8; 32]) {
+    eprintln!(
+        "→ Ledger blind-sign — verify hash on device: {}",
+        bs58::encode(hash).into_string()
+    );
 }
 
 #[derive(Debug, Clone, clap::Args)]
@@ -109,6 +182,13 @@ pub struct CommitOpts {
     /// Commit the transaction
     #[arg(long)]
     commit: bool,
+    /// Seconds to wait for the submitted transaction to confirm. The wallet
+    /// returns success only when the signature reaches `confirmed`
+    /// commitment. Bump this if you're signing on a slow device (e.g.
+    /// reading a blind-sign hash on a Ledger Flex) and the recent_blockhash
+    /// might expire before submission.
+    #[arg(long, default_value_t = 90)]
+    confirm_timeout_secs: u64,
 }
 
 impl CommitOpts {
@@ -152,12 +232,43 @@ impl CommitOpts {
                 skip_preflight: self.skip_preflight,
                 ..Default::default()
             };
-            client
+            let signature = client
                 .as_ref()
                 .send_transaction_with_config(&versioned_tx, config)
                 .await
-                .map(Into::into)
-                .map_err(context_err)
+                .map_err(context_err)?;
+
+            // Submission ≠ confirmation. Solana's send_transaction returns
+            // the locally-computed signature regardless of whether the tx
+            // ever lands — by far the most common Ledger failure mode is
+            // the recent_blockhash expiring while the user reads the device
+            // and approves. Poll for confirmation so a non-landing tx
+            // surfaces as an error instead of looking identical to a
+            // successful one. See `transaction::confirm_signatures` in
+            // helium-lib for the underlying primitive.
+            let timeout = Duration::from_secs(self.confirm_timeout_secs);
+            let poll_interval = Duration::from_secs(2);
+            let statuses = lib_transaction::confirm_signatures(
+                client,
+                &[signature],
+                CommitmentConfig::confirmed(),
+                timeout,
+                poll_interval,
+            )
+            .await?;
+
+            match statuses.get(&signature) {
+                Some(SignatureStatus::Confirmed) => Ok(CommitResponse::Signature(signature)),
+                Some(SignatureStatus::Failed(err)) => {
+                    Err(anyhow!("transaction failed on-chain: {err}"))
+                }
+                Some(SignatureStatus::NotFound) | None => Err(anyhow!(
+                    "transaction did not confirm within {}s — likely the blockhash \
+                     expired while signing on the device, or the RPC dropped it before \
+                     reaching leaders. Submitted signature: {signature}",
+                    timeout.as_secs(),
+                )),
+            }
         } else {
             client
                 .as_ref()

--- a/helium-wallet/src/cmd/sign.rs
+++ b/helium-wallet/src/cmd/sign.rs
@@ -249,7 +249,10 @@ impl VerifyCmd {
 /// [body]
 /// ```
 fn build_offchain_envelope(signer: &Pubkey, format: u8, body: &[u8]) -> Vec<u8> {
-    debug_assert!(body.len() <= u16::MAX as usize, "body length checked upstream");
+    debug_assert!(
+        body.len() <= u16::MAX as usize,
+        "body length checked upstream"
+    );
     let mut env = Vec::with_capacity(V0_HEADER_LEN + body.len());
     env.extend_from_slice(SIGNING_DOMAIN);
     env.push(0); // version
@@ -388,7 +391,10 @@ mod tests {
         let content = vec![0xab; 100_000];
         let body = hex_lower(&Sha256::digest(&content));
         assert_eq!(body.len(), 64);
-        assert_eq!(pick_format(body.as_bytes()).unwrap(), FORMAT_RESTRICTED_ASCII);
+        assert_eq!(
+            pick_format(body.as_bytes()).unwrap(),
+            FORMAT_RESTRICTED_ASCII
+        );
         let env = build_offchain_envelope(&pubkey, FORMAT_RESTRICTED_ASCII, body.as_bytes());
         // Envelope stays small even though file is 100KB.
         assert_eq!(env.len(), V0_HEADER_LEN + 64);

--- a/helium-wallet/src/cmd/sign.rs
+++ b/helium-wallet/src/cmd/sign.rs
@@ -1,5 +1,25 @@
 use crate::cmd::*;
+use helium_lib::keypair::{to_helium_pubkey, Pubkey, Signer};
 use serde_json::json;
+use sha2::{Digest, Sha256};
+
+/// Solana off-chain message signing domain (16 bytes).
+const SIGNING_DOMAIN: &[u8; 16] = b"\xffsolana offchain";
+/// Application domain for generic (non-app-specific) off-chain signing.
+const APPLICATION_DOMAIN: &[u8; 32] = &[0u8; 32];
+
+const FORMAT_RESTRICTED_ASCII: u8 = 0;
+const FORMAT_LIMITED_UTF8: u8 = 1;
+
+/// Header byte count for v0 envelopes:
+/// signing-domain (16) + version (1) + application_domain (32) + format (1)
+/// + signers_count (1) + signer (32) + body_length (2 LE).
+const V0_HEADER_LEN: usize = 16 + 1 + 32 + 1 + 1 + 32 + 2;
+
+/// Body byte cap that fits in the Solana app's off-chain buffer.
+/// `MAX_OFFCHAIN_MESSAGE_LENGTH` is 1232 (Solana wire MTU); subtract our
+/// header length and round down.
+const MAX_BODY_LEN: usize = 1232 - V0_HEADER_LEN;
 
 #[derive(Debug, clap::Args)]
 pub struct Cmd {
@@ -13,11 +33,28 @@ impl Cmd {
     }
 }
 
-/// Commands for signing or verifying data
+/// Sign or verify off-chain messages and files.
+///
+/// Signatures are produced over an off-chain message envelope in the format
+/// the [LedgerHQ Solana app] parses: signing domain + v0 header
+/// (application domain + format + signers + length) + body. Verifiers must
+/// re-hash the envelope, not the original input.
+///
+/// `sign msg` puts the message text directly in the envelope body.
+/// `sign file` hashes the file content and hex-encodes the digest as the
+/// body — file size is unbounded, the on-the-wire envelope stays small,
+/// and the device displays the hex hash for verification.
+///
+/// Format byte is auto-selected: printable ASCII → `RestrictedAscii`
+/// (device shows the body directly), other UTF-8 ≤ ~1100 bytes →
+/// `LimitedUtf8` (device shows hash; requires "Allow off-chain message
+/// signing" enabled in the Solana app on the Ledger).
+///
+/// [LedgerHQ Solana app]: https://github.com/LedgerHQ/app-solana
 #[derive(Debug, clap::Subcommand)]
 pub enum SubCmd {
-    File(File),
-    Msg(Msg),
+    File(FileCmd),
+    Msg(MsgCmd),
     Verify(VerifyCmd),
 }
 
@@ -31,141 +68,371 @@ impl SubCmd {
     }
 }
 
-/// Sign a given file
+/// Sign a file by its SHA-256.
+///
+/// The envelope body is `hex(SHA-256(file))` (64 ASCII chars). File size is
+/// unbounded; the on-the-wire envelope stays small. Verifiers reproduce the
+/// hash to confirm the signature describes the same file.
 #[derive(Debug, clap::Args)]
-pub struct File {
-    /// Path to file to sign
+pub struct FileCmd {
+    /// Path to the file to sign.
     input: PathBuf,
 }
 
-impl File {
+impl FileCmd {
     pub async fn run(&self, opts: Opts) -> Result {
         use std::io::Read;
-        let password = get_wallet_password(false)?;
-        let wallet = opts.load_wallet()?;
-        let keypair = wallet.decrypt(password.as_bytes())?;
-        let mut data = Vec::new();
-        fs::File::open(&self.input)?.read_to_end(&mut data)?;
-
-        let signature = keypair.sign(&data)?;
-        print_signature(&wallet, signature.as_ref())
+        let mut content = Vec::new();
+        fs::File::open(&self.input)?.read_to_end(&mut content)?;
+        let body = hex_lower(&Sha256::digest(&content));
+        sign_envelope(&opts, body.as_bytes(), BodyKind::FileSha256).await
     }
 }
 
-/// Sign a given message string
+/// Sign a message string.
 #[derive(Debug, clap::Args)]
-pub struct Msg {
-    /// Message to sign
+pub struct MsgCmd {
+    /// Message to sign.
     msg: String,
 }
 
-impl Msg {
+impl MsgCmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let wallet = opts.load_wallet()?;
-        let keypair = wallet.decrypt(password.as_bytes())?;
-        let signature = keypair.sign(self.msg.as_bytes())?;
-        print_signature(&wallet, signature.as_ref())
+        sign_envelope(&opts, self.msg.as_bytes(), BodyKind::Message).await
     }
 }
 
-/// Verify a file or message with a given signature
-#[derive(clap::Args, Debug)]
-pub struct VerifyCmd {
-    #[command(subcommand)]
-    cmd: Verify,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum BodyKind {
+    /// Body is the literal message bytes.
+    Message,
+    /// Body is the hex-encoded SHA-256 of a file's content (64 ASCII chars).
+    FileSha256,
 }
 
-impl VerifyCmd {
-    pub async fn run(&self, opts: Opts) -> Result {
-        self.cmd.run(opts).await
+async fn sign_envelope(opts: &Opts, body: &[u8], body_kind: BodyKind) -> Result {
+    if body.is_empty() {
+        bail!("cannot sign an empty body");
     }
-}
+    if body.len() > MAX_BODY_LEN {
+        bail!(
+            "body too large: {} bytes (Ledger off-chain limit is {})",
+            body.len(),
+            MAX_BODY_LEN,
+        );
+    }
 
-#[derive(clap::Subcommand, Debug)]
-pub enum Verify {
-    File(VerifyFile),
-    Msg(VerifyMsg),
-}
+    let pubkey = opts.load_pubkey()?;
+    let format = pick_format(body)?;
+    let envelope = build_offchain_envelope(&pubkey, format, body);
 
-impl Verify {
-    pub async fn run(&self, opts: Opts) -> Result {
-        match self {
-            Self::File(cmd) => cmd.run(opts).await,
-            Self::Msg(cmd) => cmd.run(opts).await,
+    // The signing primitive forks by source. Ledger keypairs need
+    // SIGN_OFFCHAIN_MESSAGE explicitly — `try_sign_message` would route
+    // through SIGN_MESSAGE which the Solana app refuses for non-tx data.
+    let signature: [u8; 64] = match opts.sources().first() {
+        Some(WalletSource::Ledger { path, serial, .. }) => {
+            let kp = helium_crypto::ledger::Keypair::from_derivation_path(
+                helium_crypto::Network::MainNet,
+                path.clone(),
+                serial.as_deref(),
+            )?;
+            // For LimitedUtf8, the device displays a SHA-256 of the body
+            // (post-header) on its blind-sign screen. Print the matching
+            // hash on stderr so the user can compare. RestrictedAscii has
+            // the body displayed verbatim — no hint needed.
+            if format == FORMAT_LIMITED_UTF8 {
+                let body_hash = Sha256::digest(body);
+                eprintln!(
+                    "→ Ledger off-chain blind-sign — verify hash on device: {}",
+                    bs58::encode(body_hash).into_string()
+                );
+            }
+            kp.sign_offchain_envelope(&envelope)?
         }
-    }
-}
+        _ => {
+            let password = get_wallet_password(false)?;
+            let kp = opts.load_keypair(password.as_bytes())?;
+            let sig = kp.try_sign_message(&envelope)?;
+            sig.as_ref()
+                .try_into()
+                .map_err(|_| anyhow!("unexpected ed25519 signature length"))?
+        }
+    };
 
-/// Verify the signature of a file
-#[derive(clap::Args, Debug)]
-pub struct VerifyFile {
-    /// Path to file to sign
-    input: PathBuf,
-
-    /// Signature to verify
-    #[arg(long, short)]
-    signature: String,
-}
-
-impl VerifyFile {
-    pub async fn run(&self, opts: Opts) -> Result {
-        use helium_crypto::Verify;
-        use std::io::Read;
-        let wallet = opts.load_wallet()?;
-        let mut data = Vec::new();
-        fs::File::open(&self.input)?.read_to_end(&mut data)?;
-        let signature = b64::decode(&self.signature)?;
-        let verified = wallet.helium_pubkey()?.verify(&data, &signature).is_ok();
-        print_verified(&wallet, verified)
-    }
-}
-
-/// Verify the signature of a message
-#[derive(clap::Args, Debug)]
-pub struct VerifyMsg {
-    /// Message to sign
-    msg: String,
-
-    /// Signature to verify
-    #[arg(long, short)]
-    signature: String,
-}
-
-impl VerifyMsg {
-    pub async fn run(&self, opts: Opts) -> Result {
-        use helium_crypto::Verify;
-        let wallet = opts.load_wallet()?;
-        let signature = b64::decode(&self.signature)?;
-        let verified = wallet
-            .helium_pubkey()?
-            .verify(self.msg.as_bytes(), &signature)
-            .is_ok();
-        print_verified(&wallet, verified)
-    }
-}
-
-fn json_address(wallet: &Wallet) -> Result<serde_json::Value> {
-    let helium_address = wallet.helium_address()?;
-    let address = wallet.address()?;
-    Ok(json!({
-        "solana": address,
-        "helium": helium_address,
+    let helium = to_helium_pubkey(&pubkey)?;
+    print_json(&json!({
+        "address": {
+            "solana": pubkey.to_string(),
+            "helium": helium.to_string(),
+        },
+        "format": format_label(format),
+        "body_kind": body_kind,
+        "envelope": helium_lib::b64::encode(&envelope),
+        "signature": bs58::encode(signature).into_string(),
     }))
 }
 
-fn print_signature(wallet: &Wallet, signature: &[u8]) -> Result {
-    let json = json!({
-        "address": json_address(wallet)?,
-        "signature": b64::encode(signature)
-    });
-    print_json(&json)
+/// Verify a previously-signed off-chain message.
+///
+/// The signer pubkey is extracted from the envelope. For file signatures,
+/// pass `--file <path>` so the original file's hex SHA-256 is compared
+/// against the envelope body.
+#[derive(Debug, clap::Args)]
+pub struct VerifyCmd {
+    /// Base64 envelope from a previous sign invocation.
+    #[arg(long)]
+    envelope: String,
+    /// Base58 signature.
+    #[arg(long, short)]
+    signature: String,
+    /// Original file, for `sign file` signatures. Its hex SHA-256 is
+    /// compared against the envelope body.
+    #[arg(long)]
+    file: Option<PathBuf>,
 }
 
-fn print_verified(wallet: &Wallet, verified: bool) -> Result {
-    let json = json!({
-        "address": json_address(wallet)?,
-        "verified": verified
-    });
-    print_json(&json)
+impl VerifyCmd {
+    pub async fn run(&self, _opts: Opts) -> Result {
+        use helium_crypto::Verify;
+
+        let envelope = helium_lib::b64::decode(&self.envelope)?;
+        let signature = bs58::decode(&self.signature)
+            .into_vec()
+            .map_err(|e| anyhow!("signature is not valid base58: {e}"))?;
+        let parsed = parse_offchain_envelope(&envelope)?;
+
+        let signer_helium = to_helium_pubkey(&parsed.signer)?;
+        let sig_ok = signer_helium.verify(&envelope, &signature).is_ok();
+
+        let mut json = json!({
+            "address": {
+                "solana": parsed.signer.to_string(),
+                "helium": signer_helium.to_string(),
+            },
+            "format": format_label(parsed.format),
+            "verified": sig_ok,
+        });
+
+        if let Some(path) = &self.file {
+            use std::io::Read;
+            let mut content = Vec::new();
+            fs::File::open(path)?.read_to_end(&mut content)?;
+            let expected = hex_lower(&Sha256::digest(&content));
+            let body_str = std::str::from_utf8(parsed.body).unwrap_or("");
+            let file_matches = body_str == expected;
+            json["body_kind"] = json!(BodyKind::FileSha256);
+            json["file_matches"] = json!(file_matches);
+            json["verified"] = json!(sig_ok && file_matches);
+        } else if let Ok(text) = std::str::from_utf8(parsed.body) {
+            json["body_kind"] = json!(BodyKind::Message);
+            json["body"] = json!(text);
+        } else {
+            json["body_kind"] = json!("opaque");
+        }
+
+        print_json(&json)
+    }
+}
+
+/// Build a v0 off-chain message envelope in the layout the Solana Ledger
+/// app's `parse_offchain_message_header` expects:
+///
+/// ```text
+/// [signing_domain (16)]      \xffsolana offchain
+/// [version       (1)]        0
+/// [app_domain    (32)]       all zeros (generic)
+/// [format        (1)]        0=RestrictedAscii, 1=LimitedUtf8
+/// [signers_count (1)]        1
+/// [signer        (32)]       caller's pubkey
+/// [body_length   (2 LE)]
+/// [body]
+/// ```
+fn build_offchain_envelope(signer: &Pubkey, format: u8, body: &[u8]) -> Vec<u8> {
+    debug_assert!(body.len() <= u16::MAX as usize, "body length checked upstream");
+    let mut env = Vec::with_capacity(V0_HEADER_LEN + body.len());
+    env.extend_from_slice(SIGNING_DOMAIN);
+    env.push(0); // version
+    env.extend_from_slice(APPLICATION_DOMAIN);
+    env.push(format);
+    env.push(1); // signers_count — firmware rejects 0
+    env.extend_from_slice(signer.as_ref());
+    env.extend_from_slice(&(body.len() as u16).to_le_bytes());
+    env.extend_from_slice(body);
+    env
+}
+
+struct ParsedEnvelope<'a> {
+    format: u8,
+    signer: Pubkey,
+    body: &'a [u8],
+}
+
+fn parse_offchain_envelope(env: &[u8]) -> Result<ParsedEnvelope<'_>> {
+    if env.len() < V0_HEADER_LEN {
+        bail!("envelope too short ({} bytes)", env.len());
+    }
+    if &env[..16] != SIGNING_DOMAIN {
+        bail!("envelope missing Solana off-chain signing domain prefix");
+    }
+    let mut cursor = 16;
+    let version = env[cursor];
+    cursor += 1;
+    if version != 0 {
+        bail!("unsupported envelope version {version}");
+    }
+    cursor += 32; // skip application_domain
+    let format = env[cursor];
+    cursor += 1;
+    let signers_count = env[cursor];
+    cursor += 1;
+    if signers_count != 1 {
+        bail!("envelope must declare exactly 1 signer (got {signers_count})");
+    }
+    let signer = Pubkey::try_from(&env[cursor..cursor + 32])
+        .map_err(|_| anyhow!("invalid signer pubkey in envelope"))?;
+    cursor += 32;
+    let body_len = u16::from_le_bytes([env[cursor], env[cursor + 1]]) as usize;
+    cursor += 2;
+    if env.len() != cursor + body_len {
+        bail!(
+            "envelope body length mismatch: header claims {body_len} bytes, \
+             {} actually present",
+            env.len() - cursor,
+        );
+    }
+    Ok(ParsedEnvelope {
+        format,
+        signer,
+        body: &env[cursor..cursor + body_len],
+    })
+}
+
+/// Pick the format byte the Solana app should clear-sign (`RestrictedAscii`)
+/// vs blind-sign by hash (`LimitedUtf8`). Mirrors the heuristic in
+/// `solana-offchain-message`.
+fn pick_format(body: &[u8]) -> Result<u8> {
+    if body.iter().all(|b| (0x20..=0x7e).contains(b)) {
+        Ok(FORMAT_RESTRICTED_ASCII)
+    } else if std::str::from_utf8(body).is_ok() {
+        Ok(FORMAT_LIMITED_UTF8)
+    } else {
+        bail!("body must be valid UTF-8")
+    }
+}
+
+fn format_label(format: u8) -> &'static str {
+    match format {
+        0 => "restricted_ascii",
+        1 => "limited_utf8",
+        _ => "unknown",
+    }
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(&mut s, "{b:02x}");
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use helium_lib::keypair::Keypair;
+
+    #[test]
+    fn envelope_layout_matches_v0_spec() {
+        let pubkey = Pubkey::new_unique();
+        let body = b"abc";
+        let env = build_offchain_envelope(&pubkey, FORMAT_RESTRICTED_ASCII, body);
+        // domain(16) + version(1) + app_domain(32) + format(1) + signers(1)
+        // + signer(32) + length(2) + body
+        assert_eq!(env.len(), V0_HEADER_LEN + 3);
+        assert_eq!(&env[..16], SIGNING_DOMAIN);
+        assert_eq!(env[16], 0); // version
+        assert_eq!(&env[17..49], APPLICATION_DOMAIN); // app_domain zeroed
+        assert_eq!(env[49], FORMAT_RESTRICTED_ASCII);
+        assert_eq!(env[50], 1); // signers_count
+        assert_eq!(&env[51..83], pubkey.as_ref());
+        assert_eq!(&env[83..85], &3u16.to_le_bytes());
+        assert_eq!(&env[85..], body);
+    }
+
+    #[test]
+    fn parse_roundtrip() {
+        let kp = Keypair::generate();
+        let body = b"hello off-chain";
+        let env = build_offchain_envelope(&kp.pubkey(), FORMAT_RESTRICTED_ASCII, body);
+
+        let parsed = parse_offchain_envelope(&env).expect("parse");
+        assert_eq!(parsed.format, FORMAT_RESTRICTED_ASCII);
+        assert_eq!(parsed.signer, kp.pubkey());
+        assert_eq!(parsed.body, body);
+    }
+
+    #[test]
+    fn pick_format_ascii_then_utf8() {
+        assert_eq!(pick_format(b"hello").unwrap(), FORMAT_RESTRICTED_ASCII);
+        assert_eq!(
+            pick_format("héllo".as_bytes()).unwrap(),
+            FORMAT_LIMITED_UTF8
+        );
+    }
+
+    #[test]
+    fn file_hash_body_is_hex_ascii() {
+        let pubkey = Pubkey::new_unique();
+        let content = vec![0xab; 100_000];
+        let body = hex_lower(&Sha256::digest(&content));
+        assert_eq!(body.len(), 64);
+        assert_eq!(pick_format(body.as_bytes()).unwrap(), FORMAT_RESTRICTED_ASCII);
+        let env = build_offchain_envelope(&pubkey, FORMAT_RESTRICTED_ASCII, body.as_bytes());
+        // Envelope stays small even though file is 100KB.
+        assert_eq!(env.len(), V0_HEADER_LEN + 64);
+    }
+
+    #[test]
+    fn software_sign_and_verify_roundtrip() {
+        use helium_crypto::Verify;
+        let kp = Keypair::generate();
+        let body = b"verify me";
+        let env = build_offchain_envelope(&kp.pubkey(), FORMAT_RESTRICTED_ASCII, body);
+
+        let sig = kp.try_sign_message(&env).expect("sign");
+        let parsed = parse_offchain_envelope(&env).expect("parse");
+        let helium = to_helium_pubkey(&parsed.signer).expect("helium pk");
+        assert!(helium.verify(&env, sig.as_ref()).is_ok());
+    }
+
+    #[test]
+    fn verify_rejects_tampered_body() {
+        use helium_crypto::Verify;
+        let kp = Keypair::generate();
+        let env = build_offchain_envelope(&kp.pubkey(), FORMAT_RESTRICTED_ASCII, b"original");
+        let sig = kp.try_sign_message(&env).expect("sign");
+
+        let mut tampered = env.clone();
+        let last = tampered.len() - 1;
+        tampered[last] ^= 0x01;
+
+        let helium = to_helium_pubkey(&kp.pubkey()).expect("helium pk");
+        assert!(helium.verify(&tampered, sig.as_ref()).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_bad_domain() {
+        let mut env = build_offchain_envelope(&Pubkey::new_unique(), 0, b"x");
+        env[0] = 0x00;
+        assert!(parse_offchain_envelope(&env).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_truncated() {
+        let env = build_offchain_envelope(&Pubkey::new_unique(), 0, b"hello");
+        let truncated = &env[..env.len() - 1];
+        assert!(parse_offchain_envelope(truncated).is_err());
+    }
 }

--- a/helium-wallet/src/cmd/source.rs
+++ b/helium-wallet/src/cmd/source.rs
@@ -1,0 +1,204 @@
+use crate::result::{anyhow, bail, Result};
+use helium_crypto::ledger;
+use std::{path::PathBuf, str::FromStr};
+
+/// A wallet source: either a path to an encrypted key file on disk, or a
+/// reference to a key on a connected Ledger device.
+///
+/// Parsed from the `-f`/`--file` argument. Anything that doesn't start with
+/// the `usb://ledger` prefix is treated as a file path (matching the existing
+/// behaviour). A Ledger reference takes the form:
+///
+/// ```text
+/// usb://ledger[?key=<account>[/<change>][&serial=<usb_serial>]]
+/// ```
+///
+/// `key` defaults to `0/0` — the 4-level path `m/44'/501'/0'/0'` used by
+/// Ledger Live and recent Phantom versions. A single component (`key=N`)
+/// selects the 3-level Solana CLI path `m/44'/501'/N'`, which the Solana
+/// CLI and older Phantom configurations use. Run `wallet ledger list` to
+/// see which path family your funded accounts live on.
+/// `serial` filters by USB serial when multiple Ledgers are attached.
+#[derive(Debug, Clone)]
+pub enum WalletSource {
+    File(PathBuf),
+    Ledger {
+        path: ledger::DerivationPath,
+        // Preserved for URL round-tripping; the Display form of `path` is
+        // the BIP32 `m/...'` notation, not the `key=N[/M]` URL form.
+        account: u32,
+        change: Option<u32>,
+        serial: Option<String>,
+    },
+}
+
+const LEDGER_PREFIX: &str = "usb://ledger";
+
+impl WalletSource {
+    pub fn is_ledger(&self) -> bool {
+        matches!(self, Self::Ledger { .. })
+    }
+}
+
+impl FromStr for WalletSource {
+    type Err = crate::result::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let Some(rest) = s.strip_prefix(LEDGER_PREFIX) else {
+            return Ok(Self::File(PathBuf::from(s)));
+        };
+
+        let mut account: u32 = 0;
+        let mut change: Option<u32> = Some(0);
+        let mut serial = None;
+
+        let query = match rest {
+            "" => "",
+            r if r.starts_with('?') => &r[1..],
+            _ => bail!("invalid ledger url: {s}"),
+        };
+
+        if !query.is_empty() {
+            for pair in query.split('&') {
+                let (key, value) = pair
+                    .split_once('=')
+                    .ok_or_else(|| anyhow!("invalid ledger url query pair: {pair}"))?;
+                match key {
+                    "key" => (account, change) = parse_key_path(value)?,
+                    "serial" => serial = Some(value.to_string()),
+                    other => bail!("unknown ledger url query key: {other}"),
+                }
+            }
+        }
+
+        let path = match change {
+            Some(change) => ledger::DerivationPath::solana(account, change),
+            None => ledger::DerivationPath::solana_cli(account),
+        };
+        Ok(Self::Ledger {
+            path,
+            account,
+            change,
+            serial,
+        })
+    }
+}
+
+impl std::fmt::Display for WalletSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::File(path) => write!(f, "{}", path.display()),
+            Self::Ledger {
+                account,
+                change,
+                serial,
+                path: _,
+            } => {
+                write!(f, "{LEDGER_PREFIX}?key={account}")?;
+                if let Some(change) = change {
+                    write!(f, "/{change}")?;
+                }
+                if let Some(serial) = serial {
+                    write!(f, "&serial={serial}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+fn parse_key_path(s: &str) -> Result<(u32, Option<u32>)> {
+    let parts: Vec<&str> = s.split('/').collect();
+    let parse = |p: &str| -> Result<u32> {
+        p.parse::<u32>()
+            .map_err(|e| anyhow!("invalid ledger key component '{p}': {e}"))
+    };
+    match parts.as_slice() {
+        [account] => Ok((parse(account)?, None)),
+        [account, change] => Ok((parse(account)?, Some(parse(change)?))),
+        _ => bail!("invalid ledger key path '{s}': expected <account> or <account>/<change>"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_path_passthrough() {
+        let src: WalletSource = "wallet.key".parse().unwrap();
+        match src {
+            WalletSource::File(p) => assert_eq!(p, PathBuf::from("wallet.key")),
+            _ => panic!("expected File"),
+        }
+    }
+
+    #[test]
+    fn ledger_default_path() {
+        let src: WalletSource = "usb://ledger".parse().unwrap();
+        match src {
+            WalletSource::Ledger {
+                path,
+                account,
+                change,
+                serial,
+            } => {
+                assert_eq!(path.to_string(), "m/44'/501'/0'/0'");
+                assert_eq!(account, 0);
+                assert_eq!(change, Some(0));
+                assert!(serial.is_none());
+            }
+            _ => panic!("expected Ledger"),
+        }
+    }
+
+    #[test]
+    fn ledger_explicit_path() {
+        let src: WalletSource = "usb://ledger?key=3/1".parse().unwrap();
+        match src {
+            WalletSource::Ledger { path, .. } => {
+                assert_eq!(path.to_string(), "m/44'/501'/3'/1'");
+            }
+            _ => panic!("expected Ledger"),
+        }
+    }
+
+    #[test]
+    fn ledger_three_level_path() {
+        let src: WalletSource = "usb://ledger?key=2".parse().unwrap();
+        match src {
+            WalletSource::Ledger { path, .. } => {
+                assert_eq!(path.to_string(), "m/44'/501'/2'");
+            }
+            _ => panic!("expected Ledger"),
+        }
+    }
+
+    #[test]
+    fn ledger_serial() {
+        let src: WalletSource = "usb://ledger?key=0/0&serial=ABC123".parse().unwrap();
+        match src {
+            WalletSource::Ledger { serial, .. } => {
+                assert_eq!(serial.as_deref(), Some("ABC123"));
+            }
+            _ => panic!("expected Ledger"),
+        }
+    }
+
+    #[test]
+    fn ledger_unknown_query_param_rejected() {
+        assert!("usb://ledger?foo=bar".parse::<WalletSource>().is_err());
+    }
+
+    #[test]
+    fn ledger_malformed_url_rejected() {
+        assert!("usb://ledgerstuff".parse::<WalletSource>().is_err());
+    }
+
+    #[test]
+    fn ledger_url_roundtrips_via_display() {
+        let s = "usb://ledger?key=1/0&serial=XYZ";
+        let src: WalletSource = s.parse().unwrap();
+        assert_eq!(src.to_string(), s);
+    }
+}

--- a/helium-wallet/src/cmd/squads/execute.rs
+++ b/helium-wallet/src/cmd/squads/execute.rs
@@ -22,11 +22,10 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let txn_opts = self.commit.transaction_opts(&client);
-        let member = keypair.pubkey();
+        let member = signer.pubkey();
 
         let resolved = squads::resolve_proposal_target(&client, &self.target, self.index).await?;
         // Pre-flight: v4 requires the Execute permission; v3 has no
@@ -57,7 +56,7 @@ impl Cmd {
         let ixs = &[ix];
         let (msg, _block_height) =
             message::mk_message(&client, ixs, &txn_opts.lut_addresses, &member).await?;
-        let tx = mk_transaction(msg, &[&*keypair])?;
+        let tx = mk_transaction(msg, &[&*signer])?;
         print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/squads/members.rs
+++ b/helium-wallet/src/cmd/squads/members.rs
@@ -100,8 +100,7 @@ impl PermissionFlag {
 
 impl AddCmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let txn_opts = self.commit.transaction_opts(&client);
 
@@ -123,7 +122,7 @@ impl AddCmd {
             self.target,
             vec![action],
             self.memo.clone(),
-            &keypair,
+            &*signer,
             &self.commit,
             &txn_opts,
         )
@@ -155,8 +154,7 @@ pub struct RemoveCmd {
 
 impl RemoveCmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let txn_opts = self.commit.transaction_opts(&client);
 
@@ -168,7 +166,7 @@ impl RemoveCmd {
             self.target,
             vec![action],
             self.memo.clone(),
-            &keypair,
+            &*signer,
             &self.commit,
             &txn_opts,
         )

--- a/helium-wallet/src/cmd/squads/mod.rs
+++ b/helium-wallet/src/cmd/squads/mod.rs
@@ -1,13 +1,12 @@
 use crate::cmd::*;
 use helium_lib::{
-    keypair::{Keypair, Pubkey, Signer},
+    keypair::{Pubkey, Signer},
     message, solana_sdk,
     squads::{self as lib_squads, MemberAction, MultisigKey, VaultKey},
     transaction::mk_transaction,
     TransactionOpts,
 };
 use solana_sdk::{instruction::Instruction, transaction::VersionedTransaction};
-use std::sync::Arc;
 
 mod execute;
 mod inspect;
@@ -44,7 +43,7 @@ pub(crate) async fn submit_proposal_with<C, F, Fut>(
     client: &C,
     squads_target: Pubkey,
     memo: Option<String>,
-    keypair: &Arc<Keypair>,
+    keypair: &dyn Signer,
     commit: &CommitOpts,
     txn_opts: &TransactionOpts,
     build_ixs: F,
@@ -96,7 +95,7 @@ pub(crate) async fn submit_config_proposal<C>(
     target: Pubkey,
     actions: Vec<helium_lib::squads::v4::ConfigActionInput>,
     memo: Option<String>,
-    keypair: &Arc<Keypair>,
+    keypair: &dyn Signer,
     commit: &CommitOpts,
     txn_opts: &TransactionOpts,
 ) -> Result
@@ -119,7 +118,7 @@ where
     .await?;
     let (msg, _block_height) =
         message::mk_message(client, &proposal_ixs, &txn_opts.lut_addresses, &proposer).await?;
-    let tx = mk_transaction(msg, &[&**keypair])?;
+    let tx = mk_transaction(msg, &[keypair])?;
     let response = commit.maybe_commit(tx, client).await?;
     let mut json = response.to_json();
     if let serde_json::Value::Object(map) = &mut json {
@@ -147,7 +146,7 @@ pub(crate) async fn wrap_as_proposal<C: AsRef<helium_lib::client::SolanaRpcClien
     vault_index: u8,
     inner_ixs: &[Instruction],
     memo: Option<String>,
-    keypair: &Arc<Keypair>,
+    keypair: &dyn Signer,
     txn_opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64)> {
     let proposer = keypair.pubkey();
@@ -163,7 +162,7 @@ pub(crate) async fn wrap_as_proposal<C: AsRef<helium_lib::client::SolanaRpcClien
     .await?;
     let (msg, _block_height) =
         message::mk_message(client, &proposal_ixs, &txn_opts.lut_addresses, &proposer).await?;
-    let tx = mk_transaction(msg, &[&**keypair])?;
+    let tx = mk_transaction(msg, &[keypair])?;
     Ok((tx, transaction_index))
 }
 

--- a/helium-wallet/src/cmd/squads/threshold.rs
+++ b/helium-wallet/src/cmd/squads/threshold.rs
@@ -23,8 +23,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let txn_opts = self.commit.transaction_opts(&client);
 
@@ -36,7 +35,7 @@ impl Cmd {
             self.target,
             vec![action],
             self.memo.clone(),
-            &keypair,
+            &*signer,
             &self.commit,
             &txn_opts,
         )

--- a/helium-wallet/src/cmd/squads/vote.rs
+++ b/helium-wallet/src/cmd/squads/vote.rs
@@ -138,13 +138,12 @@ enum VoteKind {
 
 impl VoteTarget {
     async fn run(&self, opts: Opts, kind: VoteKind) -> Result {
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let txn_opts = self.commit.transaction_opts(&client);
 
         let resolved = squads::resolve_proposal_target(&client, &self.target, self.index).await?;
-        let member = keypair.pubkey();
+        let member = signer.pubkey();
         // Pre-flight: the on-chain program rejects votes from non-members
         // or members lacking the Vote permission. Surface a clear local
         // error instead of letting the user pay simulation fees on a
@@ -156,7 +155,7 @@ impl VoteTarget {
         let ixs = &[vote_ix];
         let (msg, _block_height) =
             message::mk_message(&client, ixs, &txn_opts.lut_addresses, &member).await?;
-        let tx = mk_transaction(msg, &[&*keypair])?;
+        let tx = mk_transaction(msg, &[&*signer])?;
         print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
     }
 }

--- a/helium-wallet/src/cmd/swap.rs
+++ b/helium-wallet/src/cmd/swap.rs
@@ -24,8 +24,7 @@ impl Cmd {
             bail!("swap amount must be a positive finite number");
         }
 
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
 
         let jupiter_client = jupiter::Client::from_env()?;
@@ -36,7 +35,7 @@ impl Cmd {
             helium_lib::token::TokenAmount::from_f64(self.input_token, self.amount).amount;
 
         let (tx, _, order) = jupiter_client
-            .swap(&client, input_mint, output_mint, raw_amount, &keypair)
+            .swap(&client, input_mint, output_mint, raw_amount, &*signer)
             .await?;
 
         let response = self.commit.maybe_commit(tx, &client).await?;

--- a/helium-wallet/src/cmd/transfer.rs
+++ b/helium-wallet/src/cmd/transfer.rs
@@ -103,8 +103,7 @@ pub struct Multi {
 impl PayCmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let payments = self.collect_payments()?;
-        let password = get_wallet_password(false)?;
-        let keypair = opts.load_keypair(password.as_bytes())?;
+        let signer = opts.load_signer()?;
         let client = opts.client()?;
         let txn_opts = self.commit().transaction_opts(&client);
 
@@ -113,7 +112,7 @@ impl PayCmd {
                 &client,
                 squads_target,
                 self.squads_memo().cloned(),
-                &keypair,
+                &*signer,
                 self.commit(),
                 &txn_opts,
                 |vault| async move {
@@ -123,7 +122,7 @@ impl PayCmd {
             .await;
         }
 
-        let (tx, _) = token::transfer(&client, &payments, &keypair, &txn_opts).await?;
+        let (tx, _) = token::transfer(&client, &payments, &*signer, &txn_opts).await?;
 
         print_json(&self.commit().maybe_commit(tx, &client).await?.to_json())
     }

--- a/helium-wallet/src/main.rs
+++ b/helium-wallet/src/main.rs
@@ -4,8 +4,8 @@
 use clap::Parser;
 use helium_wallet::{
     cmd::{
-        assets, balance, burn, create, dc, export, hotspots, info, memo, price, router, sign,
-        squads, swap, transfer, upgrade, Opts,
+        assets, balance, burn, create, dc, export, hotspots, info, ledger, memo, price, router,
+        sign, squads, swap, transfer, upgrade, Opts,
     },
     result::Result,
 };
@@ -45,6 +45,7 @@ pub enum Cmd {
     Squads(squads::Cmd),
     Memo(memo::Cmd),
     Assets(assets::Cmd),
+    Ledger(ledger::Cmd),
 }
 
 #[allow(clippy::needless_return)]
@@ -76,6 +77,7 @@ impl Cli {
             Cmd::Squads(cmd) => cmd.run(self.opts).await,
             Cmd::Memo(cmd) => cmd.run(self.opts).await,
             Cmd::Assets(cmd) => cmd.run(self.opts).await,
+            Cmd::Ledger(cmd) => cmd.run(self.opts).await,
         }
     }
 }

--- a/helium-wallet/src/read_write.rs
+++ b/helium-wallet/src/read_write.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use helium_crypto::{ecc_compact, ed25519, multisig, KeyType};
+use helium_crypto::{ecc_compact, ed25519, KeyType};
 use io::{Read, Write};
 use std::io;
 
@@ -21,7 +21,6 @@ impl ReadWrite for helium_crypto::PublicKey {
         let key_size = match KeyType::try_from(data[0])? {
             KeyType::Ed25519 => ed25519::PUBLIC_KEY_LENGTH,
             KeyType::EccCompact => ecc_compact::PUBLIC_KEY_LENGTH,
-            KeyType::MultiSig => multisig::PUBLIC_KEY_LENGTH,
             KeyType::Secp256k1 => bail!("Secp256k1 key type unsupported for read.",),
             KeyType::Rsa => bail!("RSA key type unsupported for read."),
         };


### PR DESCRIPTION
End-to-end Ledger Nano X / Nano S Plus / Stax / Flex support via the
official Solana app over USB-HID. Consumes the `ledger` feature on
helium-crypto 0.10.

## Wallet source layer

* New `WalletSource` enum: `-f` accepts either a key file path or a
  `usb://ledger?key=<account>[/<change>][&serial=...]` URL.
* Default key path is `m/44'/501'/0'/0'` — the 4-level Ledger Live
  form. Single-component `key=N` selects the 3-level Solana CLI form
  (`m/44'/501'/N'`).
* `?serial=` filters by USB serial when multiple Ledgers are attached.
  Most Ledger hardware reports the generic serial `0001`; useful
  mainly for distinguishing differently-flashed devices.

## helium-lib refactor (no behaviour change for software keypairs)

* Public signing functions in `token.rs`, `dc.rs`, `asset.rs`,
  `schedule.rs`, `reward.rs`, `queue.rs`, `jupiter.rs`, `memo.rs`,
  `boosting.rs`, `hotspot/{mod,dataonly}.rs` converted from
  `&Keypair` to `&dyn solana_sdk::Signer`. Internal `pubkey()`,
  `try_sign_message()`, `try_partial_sign(&[s])`, and
  `mk_transaction(msg, &[s])` calls were already trait-driven.
* `hotspot/cert.rs` and the gateway-side helium-format signing in
  `hotspot/dataonly.rs` deliberately stay typed against software
  `&Keypair` — those paths sign helium-format envelopes the Solana
  Ledger app refuses (returns `0x6a80` invalid Solana message).

## Wallet command surface

* `Opts::load_signer()` returns `Arc<dyn Signer + Send + Sync>`:
  opens the device for Ledger sources (no password); prompts for
  password and decrypts the keyfile for File sources. Each command
  passes `&*signer` into the now-generic helium-lib API.
* `Opts::load_pubkey()` resolves just the pubkey (no password prompt)
  for read-only commands.
* The Ledger keypair built in `load_signer` installs a blind-sign
  hook that prints the SHA-256 hash on stderr right before the device
  prompts. Users can compare the printed hash against what the Ledger
  shows on the blind-sign confirmation screen.
* Squads helpers (`submit_proposal_with`, `wrap_as_proposal`,
  `submit_config_proposal`) similarly take `&dyn Signer`, so a Ledger
  keypair can act as the proposer for v4 multisig flows.
* Software-only commands (`upgrade`, `hotspots add mobile cert`)
  surface a clear "this command does not yet support Ledger sources;
  use a key file" error if invoked with a Ledger URL.
* `CommitOpts::maybe_commit` now polls `getSignatureStatuses` after
  submission and returns success only on `confirmed` commitment.
  The previous behaviour returned the locally-computed signature
  regardless of whether the tx landed — a Ledger blind-sign approval
  can easily blow past the ~60s blockhash validity window, in which
  case the tx was silently dropped. `--confirm-timeout-secs` (default
  90) tunes the wait.

## `wallet ledger` subcommand

* `list` enumerates the first N (default 10) Solana accounts on the
  device, bulk-fetches SOL and Helium ATA balances in one
  `getMultipleAccounts` round-trip, sorts funded accounts first, hides
  empties unless `--all`. Scans both 3-level and 4-level derivation
  paths per account so Phantom / Ledger Live / Solana CLI variants
  all surface. `--no-balance` for offline use, `--serial` to pin one
  device, `--count` overrides N. RPC failure falls back to
  address-only output with a warning.
* `devices` enumerates connected Ledgers via hidapi (vendor / product
  IDs, USB serial, manufacturer / product strings).

## `wallet sign` rewrite (BREAKING — JSON output format changed)

* Now produces an off-chain message envelope in the format the LedgerHQ
  Solana app's `parse_offchain_message_header` parses (signing-domain
  prefix + v0 header with `application_domain`, `format`, `signers`,
  `length`, body) and signs via `SIGN_OFFCHAIN_MESSAGE` (INS 0x07) on
  Ledger. This is **not** the canonical sRFC-38 v0 layout (which omits
  `application_domain` and `signers`); the Ledger app explicitly
  requires both.
* `sign msg "..."` puts the message text in the envelope body.
  Printable-ASCII bodies use `RestrictedAscii` format (the device
  displays the text directly; clear-sign). Other UTF-8 ≤ ~1100 bytes
  uses `LimitedUtf8` (device shows hash; CLI prints the matching
  base58 body hash on stderr for verification).
* `sign file <path>` hashes file content with SHA-256, hex-encodes
  to 64 ASCII chars, and uses that as the body. File size is unbounded;
  the on-the-wire envelope stays small. The device displays the hex
  hash for verification.
* `sign verify --envelope <b64> --signature <b58> [--file <path>]`
  extracts the signer from the envelope, verifies the signature,
  surfaces the decoded body. `--file` additionally compares
  `hex(SHA-256(file))` against the envelope body.
* Encoding convention: envelopes are base64 (variable-length payload),
  signatures are base58 (matches the wallet's `txid` field and Solana
  CLI).

## `TokenBalanceMap` flatten (BREAKING — affects `wallet balance` JSON)

Manual `Serialize` impl that emits a flat `{ "<token>": <amount> }`
object. Amounts follow the existing `TokenAmount` convention: integer
for 0-decimal tokens (DC), float for the rest. Drops the per-balance
`address` field (deterministic from owner via
`Token::associated_token_address`).

## Misc

`read_write.rs`: drop the `KeyType::MultiSig` arm now that the
multisig variant is gone from helium-crypto 0.10.

## Validated against a real Ledger Flex on Solana app v1.12.0

- Account discovery via `wallet ledger list` / `wallet ledger devices`.
- `info` / `balance`: read via Ledger, no password.
- `transfer one` (SOL): clear-signed on device, signed, confirmed.
- `dc mint` (Helium HSD Anchor blind-sign): hash printed on CLI matched
  device, user approved, signed, confirmed.
- `squads members add` + `approve` + `execute` (three v4
  ConfigTransaction blind-signs in sequence): all signed on device,
  all confirmed.
- `sign msg "..."` (off-chain RestrictedAscii): device displayed the
  message literally; roundtrip verify true.
- `sign file ./Cargo.toml`: device displayed hex SHA-256 (matched
  `shasum -a 256`); roundtrip verify --file true.