### PR TITLE
fix(cli): surface --commit state via committed field in JSON output

### DIFF
--- a/helium-wallet/src/cmd/assets/claim/schedule.rs
+++ b/helium-wallet/src/cmd/assets/claim/schedule.rs
@@ -86,7 +86,10 @@ impl InitCmd {
                     cronjob.name
                 );
             }
-            return print_json(&json!({ "result": "ok"}));
+            return print_json(&json!({
+                "result": "ok",
+                "committed": false,
+            }));
         }
 
         let signer = opts.load_signer()?;

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -382,9 +382,13 @@ impl ToJson for CommitResponse {
         match self {
             Self::Signature(signature) => json!({
                 "result": "ok",
+                "committed": true,
                 "txid": signature.to_string(),
             }),
-            Self::None => json!({"result": "ok"}),
+            Self::None => json!({
+                "result": "ok",
+                "committed": false,
+            }),
         }
     }
 }
@@ -410,6 +414,7 @@ pub fn print_simulation_response(
     }
     print_json(&json!({
         "result": "ok",
+        "committed": false,
     }))
 }
 
@@ -419,4 +424,35 @@ pub fn phrase_to_words(phrase: &str) -> Vec<&str> {
 
 pub trait ToJson {
     fn to_json(&self) -> serde_json::Value;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use helium_lib::keypair::Signature;
+
+    #[test]
+    fn commit_response_signature_serializes_with_committed_true() {
+        let signature = Signature::from([7u8; 64]);
+        let value = CommitResponse::Signature(signature).to_json();
+        assert_eq!(value["result"], json!("ok"));
+        assert_eq!(value["committed"], json!(true));
+        assert_eq!(value["txid"], json!(signature.to_string()));
+    }
+
+    #[test]
+    fn commit_response_none_serializes_with_committed_false() {
+        let value = CommitResponse::None.to_json();
+        assert_eq!(value["result"], json!("ok"));
+        assert_eq!(value["committed"], json!(false));
+        assert!(value.get("txid").is_none());
+    }
+
+    #[test]
+    fn commit_response_error_keeps_existing_shape() {
+        let err: Result<CommitResponse> = Err(anyhow!("boom").into());
+        let value = err.to_json();
+        assert_eq!(value["result"], json!("error"));
+        assert!(value.get("committed").is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Closes #463.

The wallet refrains from posting any transaction unless \`--commit\` is passed, but the default JSON output (\`result: \"ok\"\`) reads identically whether the transaction was actually committed or only simulated. First-time users routinely interpret the simulated-only result as a successful on-chain submission.

Add a boolean \`committed\` field to every success response so the distinction is machine-readable without scraping for the presence of \`txid\`:

| Path | committed |
|---|---|
| \`CommitResponse::Signature(_)\` | \`true\` |
| \`CommitResponse::None\` | \`false\` |
| \`print_simulation_response\` | \`false\` |
| \`assets/claim schedule\` no-op (existing schedule already present) | \`false\` |

Existing \`result\` and \`txid\` keys are preserved so this is additive for downstream consumers. Error responses are unchanged.

## Test plan

- [x] \`cargo build --locked\` clean
- [x] \`cargo clippy --all-features --locked -- -D clippy::all\` clean
- [x] 3 new unit tests in \`helium-wallet::cmd::tests\` pinning all three serialization shapes (\`committed: true\` with txid, \`committed: false\` without txid, error path unchanged) — pass