### PR TITLE
chore(asset): move DAS poll to helium-lib, adopt backon, thread asset through onboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "futures-timer",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,6 +2250,9 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers",
+]
 
 [[package]]
 name = "futures-util"
@@ -2328,6 +2341,18 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2509,6 +2534,7 @@ dependencies = [
  "anchor-spl 0.31.1",
  "angry-purple-tiger",
  "async-trait",
+ "backon",
  "base64 0.22.1",
  "bincode",
  "bytemuck",

--- a/helium-lib/Cargo.toml
+++ b/helium-lib/Cargo.toml
@@ -28,6 +28,7 @@ itertools = "0.14"
 jsonrpc_client = { version = "0.7", features = ["reqwest"] }
 futures.workspace = true
 futures-timer = "3"
+backon = { version = "1", default-features = false, features = ["std", "futures-timer-sleep"] }
 tracing = "0"
 base64 = { workspace = true }
 solana-sdk = "2.2.1"

--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -19,7 +19,7 @@ use futures::{stream, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use solana_sdk::{signature::NullSigner, signer::Signer};
-use std::{collections::HashMap, result::Result as StdResult, str::FromStr};
+use std::{collections::HashMap, result::Result as StdResult, str::FromStr, time::Duration};
 
 /// Fetches a compressed NFT asset for a given Helium entity key (e.g., hotspot public key).
 pub async fn for_entity_key<E, C: AsRef<DasClient>>(
@@ -31,6 +31,36 @@ where
 {
     let kta = kta::for_entity_key(entity_key).await?;
     for_kta(client, &kta).await
+}
+
+/// Polls for an entity's asset until it becomes visible to the DAS indexer or `timeout` elapses.
+///
+/// The DAS indexer can trail Solana confirmation by a few seconds after a
+/// `dataonly::issue` transaction commits, so an immediate read via `for_entity_key`
+/// (or anything that goes through it, like `dataonly::onboard_transaction`) bubbles
+/// up a transient `AccountNotFound`. This helper retries only `AccountNotFound` at
+/// `poll_interval` cadence; every other error passes through. Signature mirrors
+/// `transaction::confirm_signatures` so both poll helpers behave consistently.
+pub async fn wait_for_entity_key<E, C>(
+    client: &C,
+    entity_key: &E,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> Result<Asset, Error>
+where
+    E: AsEntityKey,
+    C: AsRef<DasClient>,
+{
+    use backon::{ConstantBuilder, Retryable};
+    let max_times = ((timeout.as_secs_f64() / poll_interval.as_secs_f64()).ceil() as usize).max(1);
+    let backoff = ConstantBuilder::default()
+        .with_delay(poll_interval)
+        .with_max_times(max_times);
+    (|| async { for_entity_key(client, entity_key).await })
+        .retry(backoff)
+        .sleep(futures_timer::Delay::new)
+        .when(|err: &Error| err.is_account_not_found())
+        .await
 }
 
 /// Fetches compressed NFT assets for multiple entity keys in batch.

--- a/helium-lib/src/hotspot/dataonly.rs
+++ b/helium-lib/src/hotspot/dataonly.rs
@@ -204,19 +204,72 @@ pub async fn onboard_transaction<
     owner: &Pubkey,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
+    let kta = kta::for_entity_key(hotspot_key).await?;
+    let (asset, asset_proof) = asset::for_kta_with_proof(client, &kta).await?;
+    build_onboard_transaction(
+        client,
+        subdao,
+        hotspot_key,
+        (&asset, &asset_proof),
+        assertion,
+        owner,
+        opts,
+    )
+    .await
+}
+
+/// Builds an unsigned onboard transaction using a pre-fetched asset, skipping the asset re-fetch.
+///
+/// Use this when the caller already holds a fresh `Asset` for `hotspot_key` (e.g. just returned
+/// by [`asset::wait_for_entity_key`]) so onboard's DAS round-trip can be replaced with a
+/// proof-only fetch.
+pub async fn onboard_transaction_with_asset<
+    C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount,
+>(
+    client: &C,
+    subdao: SubDao,
+    hotspot_key: &helium_crypto::PublicKey,
+    asset: &asset::Asset,
+    assertion: &HotspotInfoUpdate,
+    owner: &Pubkey,
+    opts: &TransactionOpts,
+) -> Result<(VersionedTransaction, u64), Error> {
+    let asset_proof = asset::proof::get(client, &asset.id).await?;
+    build_onboard_transaction(
+        client,
+        subdao,
+        hotspot_key,
+        (asset, &asset_proof),
+        assertion,
+        owner,
+        opts,
+    )
+    .await
+}
+
+async fn build_onboard_transaction<
+    C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount,
+>(
+    client: &C,
+    subdao: SubDao,
+    hotspot_key: &helium_crypto::PublicKey,
+    asset_and_proof: (&asset::Asset, &asset::AssetProof),
+    assertion: &HotspotInfoUpdate,
+    owner: &Pubkey,
+    opts: &TransactionOpts,
+) -> Result<(VersionedTransaction, u64), Error> {
+    let (asset, asset_proof) = asset_and_proof;
     let config_account = client
         .anchor_account::<helium_entity_manager::accounts::DataOnlyConfigV0>(
             &Dao::Hnt.dataonly_config_key(),
         )
         .await?;
-    let kta = kta::for_entity_key(hotspot_key).await?;
-    let (asset, asset_proof) = asset::for_kta_with_proof(client, &kta).await?;
     let ix = onboard_instruction(
         subdao,
         hotspot_key,
         &config_account,
-        &asset,
-        &asset_proof,
+        asset,
+        asset_proof,
         assertion,
         owner,
     )?;
@@ -249,6 +302,33 @@ pub async fn onboard<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAcc
         client,
         subdao,
         hotspot_key,
+        assertion,
+        &keypair.pubkey(),
+        opts,
+    )
+    .await?;
+    let message_data = txn.message.serialize();
+    let signature = keypair.try_sign_message(&message_data)?;
+    txn.signatures[0] = signature;
+    Ok((txn, block_height))
+}
+
+/// Signs and returns an onboard transaction using a pre-fetched asset; see
+/// [`onboard_transaction_with_asset`] for the rationale.
+pub async fn onboard_with_asset<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccount>(
+    client: &C,
+    subdao: SubDao,
+    hotspot_key: &helium_crypto::PublicKey,
+    asset: &asset::Asset,
+    assertion: &HotspotInfoUpdate,
+    keypair: &dyn Signer,
+    opts: &TransactionOpts,
+) -> Result<(VersionedTransaction, u64), Error> {
+    let (mut txn, block_height) = onboard_transaction_with_asset(
+        client,
+        subdao,
+        hotspot_key,
+        asset,
         assertion,
         &keypair.pubkey(),
         opts,

--- a/helium-wallet/src/cmd/assets/claim/schedule.rs
+++ b/helium-wallet/src/cmd/assets/claim/schedule.rs
@@ -86,10 +86,7 @@ impl InitCmd {
                     cronjob.name
                 );
             }
-            return print_json(&json!({
-                "result": "ok",
-                "committed": false,
-            }));
+            return print_json(&CommitResponse::None.to_json());
         }
 
         let signer = opts.load_signer()?;

--- a/helium-wallet/src/cmd/hotspots/add.rs
+++ b/helium-wallet/src/cmd/hotspots/add.rs
@@ -2,7 +2,7 @@ use crate::{cmd::*, result::Context, txn_envelope::TxnEnvelope};
 use chrono::{DateTime, Utc};
 use helium_crypto::{KeyTag, PublicKey};
 use helium_lib::{
-    asset, client as lib_client,
+    asset,
     client::{VERIFIER_URL_DEVNET, VERIFIER_URL_MAINNET},
     dao::SubDao,
     hotspot::{self, cert, HotspotInfoUpdate},
@@ -12,35 +12,8 @@ use rand::rngs::OsRng;
 use serde::Serialize;
 use std::{io::Write, time::Duration};
 
-// After `issue` commits, the new asset takes a few RPC reads to become
-// visible to the next subprogram call (Solana confirmation propagation +
-// DAS indexer lag). Polling for the asset before invoking `onboard`
-// avoids the AccountNotFound error users see on the first 1-2 attempts
-// of `hotspots add iot --commit` against a brand-new gateway (#398).
-const ISSUED_ASSET_POLL_TIMEOUT: Duration = Duration::from_secs(60);
-const ISSUED_ASSET_POLL_INITIAL_BACKOFF: Duration = Duration::from_millis(500);
-const ISSUED_ASSET_POLL_MAX_BACKOFF: Duration = Duration::from_secs(5);
-
-async fn wait_for_issued_asset(
-    client: &lib_client::Client,
-    gateway: &helium_crypto::PublicKey,
-) -> Result {
-    let deadline = std::time::Instant::now() + ISSUED_ASSET_POLL_TIMEOUT;
-    let mut backoff = ISSUED_ASSET_POLL_INITIAL_BACKOFF;
-    loop {
-        match asset::for_entity_key(client, gateway).await {
-            Ok(_) => return Ok(()),
-            Err(err) if err.is_account_not_found() => {
-                if std::time::Instant::now() >= deadline {
-                    return Err(err.into());
-                }
-                tokio::time::sleep(backoff).await;
-                backoff = (backoff * 2).min(ISSUED_ASSET_POLL_MAX_BACKOFF);
-            }
-            Err(err) => return Err(err.into()),
-        }
-    }
-}
+const ISSUED_ASSET_VISIBILITY_TIMEOUT: Duration = Duration::from_secs(60);
+const ISSUED_ASSET_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, clap::Args)]
 pub struct Cmd {
@@ -130,7 +103,11 @@ async fn perform_add(
     let signer = opts.load_signer()?;
     let gateway = helium_crypto::PublicKey::from_bytes(&txn.gateway)?;
     let client = opts.client()?;
-    let hotspot_issued = asset::for_entity_key(&client, &gateway).await.is_ok();
+    // Capture the Asset on the precheck so we can hand it to onboard later and
+    // skip the duplicate DAS fetch (`onboard_transaction` would otherwise read
+    // it again as part of `for_kta_with_proof`).
+    let mut prefetched_asset = asset::for_entity_key(&client, &gateway).await.ok();
+    let hotspot_issued = prefetched_asset.is_some();
     let verifier_key = verifier.as_ref().unwrap_or(&opts.url);
     let verifier = match verifier_key.as_str() {
         "m" | "mainnet-beta" => VERIFIER_URL_MAINNET,
@@ -152,25 +129,35 @@ async fn perform_add(
     // visible before invoking onboard, which queries it through DAS and
     // would otherwise bubble up a transient AccountNotFound (#398).
     if matches!(issue_response, CommitResponse::Signature(_)) {
-        wait_for_issued_asset(&client, &gateway).await?;
+        prefetched_asset = Some(
+            asset::wait_for_entity_key(
+                &client,
+                &gateway,
+                ISSUED_ASSET_VISIBILITY_TIMEOUT,
+                ISSUED_ASSET_POLL_INTERVAL,
+            )
+            .await?,
+        );
     }
     // Only assert the Hotspot if either (a) it has already been issued before this cli
     // was run or (b) `commit` is enabled which means the previous command should have created it.
     // Without this, the command will always fail for brand new hotspots when --commit is not
     // enabled, as it cannot find the key_to_asset account or asset account.
-    let onboard_response = if hotspot_issued || commit.commit {
-        let (tx, _) = hotspot::dataonly::onboard(
-            &client,
-            subdao,
-            &gateway,
-            &update,
-            &*signer,
-            transaction_opts,
-        )
-        .await?;
-        commit.maybe_commit(tx, &client).await?
-    } else {
-        CommitResponse::None
+    let onboard_response = match prefetched_asset {
+        Some(asset) if hotspot_issued || commit.commit => {
+            let (tx, _) = hotspot::dataonly::onboard_with_asset(
+                &client,
+                subdao,
+                &gateway,
+                &asset,
+                &update,
+                &*signer,
+                transaction_opts,
+            )
+            .await?;
+            commit.maybe_commit(tx, &client).await?
+        }
+        _ => CommitResponse::None,
     };
     let json = json!({
         "issue": issue_response.to_json(),

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -412,10 +412,7 @@ pub fn print_simulation_response(
         let _ = print_json(&result);
         bail!("Transaction simulation failed");
     }
-    print_json(&json!({
-        "result": "ok",
-        "committed": false,
-    }))
+    print_json(&CommitResponse::None.to_json())
 }
 
 pub fn phrase_to_words(phrase: &str) -> Vec<&str> {


### PR DESCRIPTION
## Summary

Follow-up cleanup to two PRs that landed earlier:

- **#530** (\`fix(cli): surface --commit state via committed field in JSON output\`)
- **#531** (\`fix(hotspots): poll for newly issued asset before onboarding\`)

### Changes

- **\`helium-lib::asset::wait_for_entity_key\`** (new public): moves the DAS-visibility poll that #531 added in the wallet into helium-lib alongside its sibling fetchers. Signature \`(client, entity_key, timeout, poll_interval)\` mirrors \`transaction::confirm_signatures\` so both poll helpers behave consistently. backon is used internally and **not exposed** in the API — callers needing a custom backoff strategy in the future will get a sibling \`_with_backoff\` function then.
- **\`backon\` dep added** to helium-lib with \`default-features = false\` and the \`futures-timer-sleep\` feature so the lib stays runtime-agnostic (same idiom \`transaction::confirm_signatures\` uses). \`transaction::confirm_signatures\` is **not** migrated — its batched-state-accumulator semantics don't map cleanly onto backon's retry-on-error model.
- **\`onboard_with_asset\` / \`onboard_transaction_with_asset\`** (new public): added alongside the existing \`onboard\` / \`onboard_transaction\` (kept for external consumers like \`helium/oracles\`). Both routes share a private \`build_onboard_transaction\` helper. The wallet now captures the asset on the precheck (or from \`wait_for_entity_key\`) and passes it through, saving one DAS round-trip per \`hotspots add\`.
- **\`CommitResponse::None.to_json()\` reuse**: \`print_simulation_response\` and the \`assets/claim/schedule\` no-op (both added in #530) now route through \`CommitResponse::None.to_json()\` so the shape is canonical.

### Notes

- No user-visible behavior change. One fewer DAS call per successful add.
- Race window for stale precheck-asset → onboard exists in the dry-run-then-commit-later path. Funds are not at risk (bubblegum rejects the tx on mismatched data_hash). Mentioned for the record.
- Cargo.lock shows new entries for \`gloo-timers\`/\`wasm-bindgen\`/\`js-sys\` via backon's wasm-cfg'd \`futures-timer\` feature. \`resolver = "2"\` excludes these from non-wasm builds — verified empirically: \`target/release/deps\` contains only \`backon\` + \`futures-timer\`, no wasm crates.