### PR TITLE
feat(wallet): named contacts (address book) for CLI args and JSON output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,6 +2637,7 @@ dependencies = [
  "sha2 0.10.9",
  "shamirsecretsharing",
  "sodiumoxide",
+ "tempfile",
  "tokio",
 ]
 

--- a/helium-wallet/Cargo.toml
+++ b/helium-wallet/Cargo.toml
@@ -37,3 +37,6 @@ helium-mnemonic = { path = "../helium-mnemonic" }
 helium-proto = { workspace = true }
 helium-crypto = { workspace = true, features = ["solana", "ledger"] }
 bs58 = "0.5"
+
+[dev-dependencies]
+tempfile = "3"

--- a/helium-wallet/src/cmd/assets/burn.rs
+++ b/helium-wallet/src/cmd/assets/burn.rs
@@ -1,4 +1,7 @@
-use crate::cmd::{squads as cmd_squads, *};
+use crate::{
+    cmd::{squads as cmd_squads, *},
+    contacts,
+};
 use helium_lib::{asset, dao, entity_key, keypair::Pubkey};
 
 #[derive(Clone, Debug, clap::Args)]
@@ -11,7 +14,7 @@ pub struct Cmd {
     entity_key: entity_key::EncodedEntityKey,
     /// Submit as a Squads v4 proposal — see `transfer one --squads`.
     /// The asset's current owner must be the resolved vault.
-    #[arg(long)]
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     squads: Option<Pubkey>,
     /// Memo recorded on the v4 proposal (`--squads` only).
     #[arg(long)]

--- a/helium-wallet/src/cmd/assets/claim/queue.rs
+++ b/helium-wallet/src/cmd/assets/claim/queue.rs
@@ -1,4 +1,4 @@
-use crate::cmd::*;
+use crate::{cmd::*, contacts};
 use helium_lib::{keypair::Pubkey, queue, token};
 
 #[derive(Debug, Clone, clap::Args)]
@@ -40,8 +40,9 @@ impl Command {
 /// between 0.05 and 0.1 SOL, with the top end allowing for a lot of growth.
 #[derive(Clone, Debug, clap::Args)]
 pub struct ClaimWalletCmd {
-    /// The wallet to claim all hotspots for.
+    /// The wallet to claim all hotspots for. Accepts a contact name.
     /// Defaults to active wallet
+    #[arg(value_parser = contacts::parse_address_or_name)]
     pub wallet: Option<Pubkey>,
     /// Commit the claim request transaction.
     #[command(flatten)]
@@ -73,8 +74,9 @@ impl ClaimWalletCmd {
 /// This includes the current balance of the claim wallet funding the claims
 #[derive(Clone, Debug, clap::Args)]
 pub struct InfoCmd {
-    /// The wallet to look up claim information for
+    /// The wallet to look up claim information for. Accepts a contact name.
     /// Defaults to active wallet
+    #[arg(value_parser = contacts::parse_address_or_name)]
     pub wallet: Option<Pubkey>,
 }
 

--- a/helium-wallet/src/cmd/assets/claim/schedule.rs
+++ b/helium-wallet/src/cmd/assets/claim/schedule.rs
@@ -1,4 +1,4 @@
-use crate::cmd::*;
+use crate::{cmd::*, contacts};
 use helium_lib::{
     entity_key,
     keypair::{Pubkey, Signer},
@@ -143,8 +143,9 @@ impl RequeueCmd {
 /// separate from the wallets for each of the jobs that run within the schedule.
 #[derive(Clone, Debug, clap::Args)]
 pub struct InfoCmd {
-    /// The wallet to look up claim information for
+    /// The wallet to look up claim information for. Accepts a contact name.
     /// Defaults to active wallet
+    #[arg(value_parser = contacts::parse_address_or_name)]
     pub wallet: Option<Pubkey>,
 }
 
@@ -228,8 +229,9 @@ impl CloseCmd {
 /// between 0.05 and 0.1 SOL, with the top end allowing for a lot of growth.
 #[derive(Clone, Debug, clap::Args)]
 pub struct ClaimWalletCmd {
-    /// The wallet to claim all hotspots for.
+    /// The wallet to claim all hotspots for. Accepts a contact name.
     /// Defaults to active wallet
+    #[arg(value_parser = contacts::parse_address_or_name)]
     pub wallet: Option<Pubkey>,
     /// Get the claim wallet balance
     #[arg(long)]

--- a/helium-wallet/src/cmd/assets/transfer.rs
+++ b/helium-wallet/src/cmd/assets/transfer.rs
@@ -1,4 +1,7 @@
-use crate::cmd::{squads as cmd_squads, *};
+use crate::{
+    cmd::{squads as cmd_squads, *},
+    contacts,
+};
 use helium_lib::{
     asset, entity_key,
     keypair::{Pubkey, Signer},
@@ -11,11 +14,12 @@ pub struct Cmd {
     #[clap(flatten)]
     pub entity_key: entity_key::EncodedEntityKey,
 
-    /// Solana address of Recipient of Hotspot
+    /// Recipient of the Hotspot — base58 Solana pubkey or contact name.
+    #[arg(value_parser = contacts::parse_address_or_name)]
     recipient: Pubkey,
     /// Submit as a Squads v4 proposal — see `transfer one --squads`.
     /// The asset's current owner must be the resolved vault.
-    #[arg(long)]
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     squads: Option<Pubkey>,
     /// Memo recorded on the v4 proposal (`--squads` only).
     #[arg(long)]

--- a/helium-wallet/src/cmd/balance.rs
+++ b/helium-wallet/src/cmd/balance.rs
@@ -1,4 +1,4 @@
-use crate::cmd::*;
+use crate::{cmd::*, contacts};
 use helium_lib::{
     keypair::Pubkey,
     token::{self, Token},
@@ -6,8 +6,10 @@ use helium_lib::{
 
 #[derive(Debug, clap::Args)]
 /// Get the balance for a wallet or a given public key. The balance is given for
-/// each of the Helium related holdings of a given Solana address
+/// each of the Helium related holdings of a given Solana address. The
+/// address may be a base58 Solana pubkey or a contact name.
 pub struct Cmd {
+    #[arg(value_parser = contacts::parse_address_or_name)]
     address: Option<Pubkey>,
 }
 
@@ -18,10 +20,13 @@ impl Cmd {
         let balances =
             token::balance_for_addresses(&client, &Token::associated_token_addresses(&address))
                 .await?;
-        let json = json!({
+        let mut json = json!({
             "address": address.to_string(),
             "balance": token::TokenBalanceMap::from(balances),
         });
+        if let Some(contact) = contacts::cached().find_by_address(&address) {
+            json["name"] = json!(contact.name);
+        }
         print_json(&json)
     }
 }

--- a/helium-wallet/src/cmd/burn.rs
+++ b/helium-wallet/src/cmd/burn.rs
@@ -1,4 +1,7 @@
-use crate::cmd::{squads as cmd_squads, *};
+use crate::{
+    cmd::{squads as cmd_squads, *},
+    contacts,
+};
 use helium_lib::{dao::SubDao, keypair::Pubkey, token};
 
 #[derive(Debug, Clone, clap::Args)]
@@ -9,7 +12,7 @@ pub struct Cmd {
     /// Amount to burn
     amount: f64,
     /// Submit as a Squads v4 proposal — see `transfer one --squads`.
-    #[arg(long)]
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     squads: Option<Pubkey>,
     /// Memo recorded on the v4 proposal (`--squads` only).
     #[arg(long)]

--- a/helium-wallet/src/cmd/contacts.rs
+++ b/helium-wallet/src/cmd/contacts.rs
@@ -1,0 +1,103 @@
+use crate::{
+    cmd::{print_json, Opts},
+    contacts::{Contact, ContactBook},
+    result::Result,
+};
+use helium_lib::keypair::Pubkey;
+
+/// Manage the address book of named Solana addresses.
+///
+/// Contacts live at `$XDG_CONFIG_HOME/helium-wallet/contacts.json`
+/// (overridable via `HELIUM_WALLET_CONTACTS`). Once a contact exists,
+/// its name can be used wherever an address is accepted on the command
+/// line — `transfer one --payee alice 1 hnt`, `hotspots transfer
+/// <key> alice`, etc. A literal base58 pubkey always parses as itself,
+/// so a contact named `7xK...` can never shadow a real address.
+#[derive(Debug, clap::Args)]
+pub struct Cmd {
+    #[command(subcommand)]
+    cmd: SubCmd,
+}
+
+impl Cmd {
+    pub async fn run(&self, _opts: Opts) -> Result {
+        let path = ContactBook::default_path()?;
+        match &self.cmd {
+            SubCmd::List(c) => c.run(&path),
+            SubCmd::Show(c) => c.run(&path),
+            SubCmd::Add(c) => c.run(&path),
+            SubCmd::Remove(c) => c.run(&path),
+        }
+    }
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum SubCmd {
+    List(ListCmd),
+    Show(ShowCmd),
+    Add(AddCmd),
+    Remove(RemoveCmd),
+}
+
+/// List every contact in the book.
+#[derive(Debug, clap::Args)]
+pub struct ListCmd;
+
+impl ListCmd {
+    fn run(&self, path: &std::path::Path) -> Result {
+        let book = ContactBook::load(path)?;
+        print_json(&book)
+    }
+}
+
+/// Show a single contact by name.
+#[derive(Debug, clap::Args)]
+pub struct ShowCmd {
+    name: String,
+}
+
+impl ShowCmd {
+    fn run(&self, path: &std::path::Path) -> Result {
+        let book = ContactBook::load(path)?;
+        let contact = book
+            .find_by_name(&self.name)
+            .ok_or_else(|| crate::result::anyhow!("no contact named '{}'", self.name))?;
+        print_json(contact)
+    }
+}
+
+/// Add a new contact. `<address>` must be a literal Solana base58
+/// pubkey — names never resolve to other names.
+#[derive(Debug, clap::Args)]
+pub struct AddCmd {
+    name: String,
+    address: Pubkey,
+}
+
+impl AddCmd {
+    fn run(&self, path: &std::path::Path) -> Result {
+        let mut book = ContactBook::load(path)?;
+        let contact = Contact {
+            name: self.name.clone(),
+            address: self.address,
+        };
+        book.add(contact.clone())?;
+        book.save(path)?;
+        print_json(&contact)
+    }
+}
+
+/// Remove a contact by name. Prints the removed entry.
+#[derive(Debug, clap::Args)]
+pub struct RemoveCmd {
+    name: String,
+}
+
+impl RemoveCmd {
+    fn run(&self, path: &std::path::Path) -> Result {
+        let mut book = ContactBook::load(path)?;
+        let removed = book.remove(&self.name)?;
+        book.save(path)?;
+        print_json(&removed)
+    }
+}

--- a/helium-wallet/src/cmd/dc/burn.rs
+++ b/helium-wallet/src/cmd/dc/burn.rs
@@ -1,4 +1,7 @@
-use crate::cmd::{squads as cmd_squads, *};
+use crate::{
+    cmd::{squads as cmd_squads, *},
+    contacts,
+};
 use helium_lib::{dao, dc, keypair::Pubkey};
 
 #[derive(Debug, Clone, clap::Args)]
@@ -16,7 +19,7 @@ pub struct Cmd {
     /// Submit as a Squads v4 proposal — see `transfer one --squads`.
     /// Only supported for the non-delegated (no router) burn path; the
     /// DC is sourced from the resolved vault's DC ATA.
-    #[arg(long)]
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     squads: Option<Pubkey>,
     /// Memo recorded on the v4 proposal (`--squads` only).
     #[arg(long)]

--- a/helium-wallet/src/cmd/dc/delegate.rs
+++ b/helium-wallet/src/cmd/dc/delegate.rs
@@ -1,4 +1,7 @@
-use crate::cmd::{squads as cmd_squads, *};
+use crate::{
+    cmd::{squads as cmd_squads, *},
+    contacts,
+};
 use helium_lib::{dao::SubDao, dc, keypair::Pubkey};
 
 #[derive(Debug, Clone, clap::Args)]
@@ -15,7 +18,7 @@ pub struct Cmd {
 
     /// Submit as a Squads v4 proposal — see `transfer one --squads`.
     /// The DC is sourced from the resolved vault's DC ATA.
-    #[arg(long)]
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     squads: Option<Pubkey>,
     /// Memo recorded on the v4 proposal (`--squads` only).
     #[arg(long)]

--- a/helium-wallet/src/cmd/dc/mint.rs
+++ b/helium-wallet/src/cmd/dc/mint.rs
@@ -1,4 +1,7 @@
-use crate::cmd::{squads as cmd_squads, *};
+use crate::{
+    cmd::{squads as cmd_squads, *},
+    contacts,
+};
 use helium_lib::{
     dc,
     keypair::{Pubkey, Signer},
@@ -12,8 +15,8 @@ use helium_lib::{
 /// can be specified.
 pub struct Cmd {
     /// Account address to send the resulting DC to. Defaults to the active
-    /// wallet.
-    #[arg(long)]
+    /// wallet. Accepts a contact name.
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     payee: Option<Pubkey>,
 
     /// Amount of HNT to convert to DC
@@ -27,7 +30,7 @@ pub struct Cmd {
     /// Submit as a Squads v4 proposal — see `transfer one --squads`.
     /// HNT is sourced from the resolved vault; the wallet only signs as
     /// proposer.
-    #[arg(long)]
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     squads: Option<Pubkey>,
     /// Memo recorded on the v4 proposal (`--squads` only).
     #[arg(long)]

--- a/helium-wallet/src/cmd/hotspots/burn.rs
+++ b/helium-wallet/src/cmd/hotspots/burn.rs
@@ -1,4 +1,7 @@
-use crate::cmd::{squads as cmd_squads, *};
+use crate::{
+    cmd::{squads as cmd_squads, *},
+    contacts,
+};
 use helium_lib::{dao, hotspot, keypair::Pubkey};
 
 #[derive(Clone, Debug, clap::Args)]
@@ -10,7 +13,7 @@ pub struct Cmd {
     address: helium_crypto::PublicKey,
     /// Submit as a Squads v4 proposal — see `transfer one --squads`.
     /// The hotspot's current owner must be the resolved vault.
-    #[arg(long)]
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     squads: Option<Pubkey>,
     /// Memo recorded on the v4 proposal (`--squads` only).
     #[arg(long)]

--- a/helium-wallet/src/cmd/hotspots/list.rs
+++ b/helium-wallet/src/cmd/hotspots/list.rs
@@ -1,10 +1,12 @@
-use crate::cmd::*;
+use crate::{cmd::*, contacts};
 use helium_lib::{hotspot, keypair::Pubkey};
 
 #[derive(Clone, Debug, clap::Args)]
-/// Get the list of Hotspots for the active or a given wallet
+/// Get the list of Hotspots for the active or a given wallet. The
+/// wallet may be a base58 Solana pubkey or a contact name.
 pub struct Cmd {
     /// The alternate wallet to get the list of Hotspots for
+    #[arg(value_parser = contacts::parse_address_or_name)]
     wallet: Option<Pubkey>,
 }
 
@@ -13,10 +15,13 @@ impl Cmd {
         let owner = opts.maybe_wallet_key(self.wallet)?;
         let client = opts.client()?;
         let hotspots = hotspot::for_owner(&client, &owner).await?;
-        let json = json!( {
+        let mut json = json!( {
             "address": owner.to_string(),
             "hotspots": hotspots,
         });
+        if let Some(contact) = contacts::cached().find_by_address(&owner) {
+            json["name"] = json!(contact.name);
+        }
         print_json(&json)
     }
 }

--- a/helium-wallet/src/cmd/hotspots/rewards.rs
+++ b/helium-wallet/src/cmd/hotspots/rewards.rs
@@ -1,4 +1,4 @@
-use crate::cmd::*;
+use crate::{cmd::*, contacts};
 use client::DasClient;
 use helium_lib::{entity_key::EncodedEntityKey, hotspot, keypair::Pubkey, reward};
 
@@ -60,8 +60,8 @@ pub struct PendingCmd {
     token: reward::ClaimableToken,
     /// Hotspots to lookup
     hotspots: Option<Vec<helium_crypto::PublicKey>>,
-    /// Wallet to look up hotspots for
-    #[arg(long)]
+    /// Wallet to look up hotspots for. Accepts a contact name.
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     owner: Option<Pubkey>,
 }
 
@@ -92,8 +92,8 @@ pub struct LifetimeCmd {
     token: reward::ClaimableToken,
     /// Hotspots to lookup
     hotspots: Option<Vec<helium_crypto::PublicKey>>,
-    /// Wallet to look up hotspots for
-    #[arg(long)]
+    /// Wallet to look up hotspots for. Accepts a contact name.
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     owner: Option<Pubkey>,
 }
 

--- a/helium-wallet/src/cmd/hotspots/transfer.rs
+++ b/helium-wallet/src/cmd/hotspots/transfer.rs
@@ -1,4 +1,7 @@
-use crate::cmd::{squads as cmd_squads, *};
+use crate::{
+    cmd::{squads as cmd_squads, *},
+    contacts,
+};
 use helium_lib::{
     hotspot,
     keypair::{Pubkey, Signer},
@@ -9,11 +12,12 @@ use helium_lib::{
 pub struct Cmd {
     /// Key of Hotspot
     address: helium_crypto::PublicKey,
-    /// Solana address of Recipient of Hotspot
+    /// Recipient of the Hotspot — base58 Solana pubkey or contact name.
+    #[arg(value_parser = contacts::parse_address_or_name)]
     recipient: Pubkey,
     /// Submit as a Squads v4 proposal — see `transfer one --squads`.
     /// The hotspot's current owner must be the resolved vault.
-    #[arg(long)]
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     squads: Option<Pubkey>,
     /// Memo recorded on the v4 proposal (`--squads` only).
     #[arg(long)]

--- a/helium-wallet/src/cmd/info.rs
+++ b/helium-wallet/src/cmd/info.rs
@@ -49,11 +49,14 @@ impl Cmd {
 }
 
 fn parse_address(address: &str) -> Result<Pubkey> {
-    if let Ok(pk) = Pubkey::from_str(address) {
+    // Solana literal → contact-name lookup is the same precedence the
+    // global value parser pins. Falling back to helium-base58 is what
+    // this command adds on top, so `info` accepts the helium hotspot
+    // address format too. Keeping the contact step centralized means
+    // any future tweak (case-insensitive match, etc) applies here for
+    // free.
+    if let Ok(pk) = contacts::resolve_with(contacts::cached(), address) {
         return Ok(pk);
-    }
-    if let Some(contact) = contacts::cached().find_by_name(address) {
-        return Ok(contact.address);
     }
     let helium_pubkey = helium_crypto::PublicKey::from_str(address)?;
     to_pubkey(&helium_pubkey).map_err(Error::from)

--- a/helium-wallet/src/cmd/info.rs
+++ b/helium-wallet/src/cmd/info.rs
@@ -1,5 +1,6 @@
 use crate::{
     cmd::{print_json, Opts, WalletSource},
+    contacts,
     result::{Error, Result},
     wallet::Wallet,
 };
@@ -48,20 +49,27 @@ impl Cmd {
 }
 
 fn parse_address(address: &str) -> Result<Pubkey> {
-    Pubkey::from_str(address).or_else(|_| {
-        let helium_pubkey = helium_crypto::PublicKey::from_str(address)?;
-        to_pubkey(&helium_pubkey).map_err(Error::from)
-    })
+    if let Ok(pk) = Pubkey::from_str(address) {
+        return Ok(pk);
+    }
+    if let Some(contact) = contacts::cached().find_by_name(address) {
+        return Ok(contact.address);
+    }
+    let helium_pubkey = helium_crypto::PublicKey::from_str(address)?;
+    to_pubkey(&helium_pubkey).map_err(Error::from)
 }
 
 fn print_address(address: &Pubkey) -> Result {
     let helium_address = to_helium_pubkey(address)?;
-    let json = json!({
+    let mut json = json!({
         "address": {
             "solana": address.to_string(),
             "helium": helium_address.to_string(),
         },
     });
+    if let Some(contact) = contacts::cached().find_by_address(address) {
+        json["name"] = json!(contact.name);
+    }
     print_json(&json)
 }
 

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -27,6 +27,7 @@ use std::{
 pub mod assets;
 pub mod balance;
 pub mod burn;
+pub mod contacts;
 pub mod create;
 pub mod dc;
 pub mod export;

--- a/helium-wallet/src/cmd/squads/execute.rs
+++ b/helium-wallet/src/cmd/squads/execute.rs
@@ -1,4 +1,4 @@
-use crate::cmd::*;
+use crate::{cmd::*, contacts};
 use helium_lib::{
     keypair::{Pubkey, Signer},
     message,
@@ -11,7 +11,9 @@ use helium_lib::{
 /// multisig (v3).
 #[derive(Debug, Clone, clap::Args)]
 pub struct Cmd {
-    /// Multisig PDA, vault PDA, or transaction/proposal PDA.
+    /// Multisig PDA, vault PDA, or transaction/proposal PDA. Also
+    /// accepts a contact name.
+    #[arg(value_parser = contacts::parse_address_or_name)]
     target: Pubkey,
     /// Transaction index. Required if `target` is a multisig or vault.
     #[arg(long)]

--- a/helium-wallet/src/cmd/squads/inspect.rs
+++ b/helium-wallet/src/cmd/squads/inspect.rs
@@ -1,4 +1,4 @@
-use crate::cmd::*;
+use crate::{cmd::*, contacts};
 use helium_lib::{keypair::Pubkey, squads};
 
 /// Decode a Squads proposal (v3 or v4): status, votes, and the inner
@@ -11,6 +11,8 @@ use helium_lib::{keypair::Pubkey, squads};
 #[derive(Debug, Clone, clap::Args)]
 pub struct Cmd {
     /// Multisig PDA, vault PDA, transaction PDA, or proposal PDA.
+    /// Also accepts a contact name.
+    #[arg(value_parser = contacts::parse_address_or_name)]
     target: Pubkey,
 
     /// Transaction index. Required when `target` is a multisig or vault;

--- a/helium-wallet/src/cmd/squads/inspect.rs
+++ b/helium-wallet/src/cmd/squads/inspect.rs
@@ -26,6 +26,8 @@ impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let client = opts.client()?;
         let info = squads::inspect_target(&client, &self.target, self.index).await?;
-        print_json(&info)
+        let mut value = serde_json::to_value(&info)?;
+        contacts::enrich_pubkeys_in_place(&mut value);
+        print_json(&value)
     }
 }

--- a/helium-wallet/src/cmd/squads/list.rs
+++ b/helium-wallet/src/cmd/squads/list.rs
@@ -1,4 +1,4 @@
-use crate::cmd::*;
+use crate::{cmd::*, contacts};
 use chrono::{Duration, Utc};
 use helium_lib::{keypair::Pubkey, squads};
 
@@ -15,6 +15,8 @@ use helium_lib::{keypair::Pubkey, squads};
 #[derive(Debug, Clone, clap::Args)]
 pub struct Cmd {
     /// Multisig, vault, or any transaction/proposal PDA in the multisig.
+    /// Also accepts a contact name.
+    #[arg(value_parser = contacts::parse_address_or_name)]
     target: Pubkey,
 
     /// Also include Draft proposals. Drafts are pre-activation

--- a/helium-wallet/src/cmd/squads/members.rs
+++ b/helium-wallet/src/cmd/squads/members.rs
@@ -1,8 +1,12 @@
-use crate::cmd::{squads as cmd_squads, *};
+use crate::{
+    cmd::{squads as cmd_squads, *},
+    contacts,
+};
 use helium_lib::{
     keypair::Pubkey,
-    squads::{self, v4::ConfigActionInput, MemberPermissions},
+    squads::{self, v4::ConfigActionInput, MemberInfo, MemberPermissions, MultisigInfo},
 };
+use serde::Serialize;
 
 /// Manage the member roster of a Squads multisig.
 #[derive(Debug, Clone, clap::Args)]
@@ -37,6 +41,8 @@ pub enum SubCmd {
 #[derive(Debug, Clone, clap::Args)]
 pub struct ListCmd {
     /// Multisig, vault, or any transaction/proposal PDA in the multisig.
+    /// Also accepts a contact name.
+    #[arg(value_parser = contacts::parse_address_or_name)]
     target: Pubkey,
 }
 
@@ -44,7 +50,52 @@ impl ListCmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let client = opts.client()?;
         let info = squads::get_multisig_info(&client, &self.target).await?;
-        print_json(&info)
+        print_json(&NamedMultisigInfo::new(&info))
+    }
+}
+
+/// Display wrapper for `MultisigInfo` that annotates each member with
+/// their contact-book name when one is known. JSON shape matches the
+/// upstream `MultisigInfo` except for the per-member `name` field,
+/// which is omitted when no contact is found — existing consumers see
+/// no change.
+#[derive(Serialize)]
+struct NamedMultisigInfo<'a> {
+    address: &'a squads::MultisigKey,
+    version: &'a squads::Version,
+    threshold: u16,
+    transaction_index: u64,
+    members: Vec<NamedMember<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resolved_from_vault: Option<&'a squads::VaultKey>,
+}
+
+#[derive(Serialize)]
+struct NamedMember<'a> {
+    #[serde(flatten)]
+    inner: &'a MemberInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<&'a str>,
+}
+
+impl<'a> NamedMultisigInfo<'a> {
+    fn new(info: &'a MultisigInfo) -> Self {
+        let book = contacts::cached();
+        Self {
+            address: &info.address,
+            version: &info.version,
+            threshold: info.threshold,
+            transaction_index: info.transaction_index,
+            members: info
+                .members
+                .iter()
+                .map(|m| NamedMember {
+                    inner: m,
+                    name: book.find_by_address(&m.key).map(|c| c.name.as_str()),
+                })
+                .collect(),
+            resolved_from_vault: info.resolved_from_vault.as_ref(),
+        }
     }
 }
 
@@ -57,9 +108,12 @@ impl ListCmd {
 #[derive(Debug, Clone, clap::Args)]
 pub struct AddCmd {
     /// Multisig, vault, or any transaction/proposal PDA in the multisig.
+    /// Also accepts a contact name.
+    #[arg(value_parser = contacts::parse_address_or_name)]
     target: Pubkey,
 
-    /// Pubkey of the new member.
+    /// Pubkey of the new member. Also accepts a contact name.
+    #[arg(value_parser = contacts::parse_address_or_name)]
     new_member: Pubkey,
 
     /// Permissions the new member receives. Defaults to all three
@@ -139,9 +193,12 @@ impl AddCmd {
 #[derive(Debug, Clone, clap::Args)]
 pub struct RemoveCmd {
     /// Multisig, vault, or any transaction/proposal PDA in the multisig.
+    /// Also accepts a contact name.
+    #[arg(value_parser = contacts::parse_address_or_name)]
     target: Pubkey,
 
-    /// Pubkey of the member to remove.
+    /// Pubkey of the member to remove. Also accepts a contact name.
+    #[arg(value_parser = contacts::parse_address_or_name)]
     old_member: Pubkey,
 
     /// Memo recorded on the proposal.

--- a/helium-wallet/src/cmd/squads/members.rs
+++ b/helium-wallet/src/cmd/squads/members.rs
@@ -4,9 +4,8 @@ use crate::{
 };
 use helium_lib::{
     keypair::Pubkey,
-    squads::{self, v4::ConfigActionInput, MemberInfo, MemberPermissions, MultisigInfo},
+    squads::{self, v4::ConfigActionInput, MemberPermissions},
 };
-use serde::Serialize;
 
 /// Manage the member roster of a Squads multisig.
 #[derive(Debug, Clone, clap::Args)]
@@ -50,52 +49,9 @@ impl ListCmd {
     pub async fn run(&self, opts: Opts) -> Result {
         let client = opts.client()?;
         let info = squads::get_multisig_info(&client, &self.target).await?;
-        print_json(&NamedMultisigInfo::new(&info))
-    }
-}
-
-/// Display wrapper for `MultisigInfo` that annotates each member with
-/// their contact-book name when one is known. JSON shape matches the
-/// upstream `MultisigInfo` except for the per-member `name` field,
-/// which is omitted when no contact is found — existing consumers see
-/// no change.
-#[derive(Serialize)]
-struct NamedMultisigInfo<'a> {
-    address: &'a squads::MultisigKey,
-    version: &'a squads::Version,
-    threshold: u16,
-    transaction_index: u64,
-    members: Vec<NamedMember<'a>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    resolved_from_vault: Option<&'a squads::VaultKey>,
-}
-
-#[derive(Serialize)]
-struct NamedMember<'a> {
-    #[serde(flatten)]
-    inner: &'a MemberInfo,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
-}
-
-impl<'a> NamedMultisigInfo<'a> {
-    fn new(info: &'a MultisigInfo) -> Self {
-        let book = contacts::cached();
-        Self {
-            address: &info.address,
-            version: &info.version,
-            threshold: info.threshold,
-            transaction_index: info.transaction_index,
-            members: info
-                .members
-                .iter()
-                .map(|m| NamedMember {
-                    inner: m,
-                    name: book.find_by_address(&m.key).map(|c| c.name.as_str()),
-                })
-                .collect(),
-            resolved_from_vault: info.resolved_from_vault.as_ref(),
-        }
+        let mut value = serde_json::to_value(&info)?;
+        contacts::enrich_pubkeys_in_place(&mut value);
+        print_json(&value)
     }
 }
 

--- a/helium-wallet/src/cmd/squads/mod.rs
+++ b/helium-wallet/src/cmd/squads/mod.rs
@@ -1,4 +1,4 @@
-use crate::cmd::*;
+use crate::{cmd::*, contacts};
 use helium_lib::{
     keypair::{Pubkey, Signer},
     message, solana_sdk,
@@ -76,11 +76,29 @@ where
     let mut json = response.to_json();
     if let serde_json::Value::Object(map) = &mut json {
         map.insert("multisig".to_string(), multisig.to_string().into());
+        insert_contact_name(map, "multisig_name", multisig.as_pubkey());
         map.insert("vault".to_string(), vault.to_string().into());
+        insert_contact_name(map, "vault_name", vault.as_pubkey());
         map.insert("vault_index".to_string(), vault_index.into());
         map.insert("transaction_index".to_string(), transaction_index.into());
     }
     print_json(&json)
+}
+
+/// Augment a JSON object with a `<field>` entry holding the contact
+/// name registered for `addr`, when one exists. No-op otherwise — the
+/// caller's existing pubkey field carries the address either way.
+fn insert_contact_name(
+    map: &mut serde_json::Map<String, serde_json::Value>,
+    field: &str,
+    addr: &Pubkey,
+) {
+    if let Some(contact) = contacts::cached().find_by_address(addr) {
+        map.insert(
+            field.to_string(),
+            serde_json::Value::String(contact.name.clone()),
+        );
+    }
 }
 
 /// Sibling of `submit_proposal_with` for ConfigTransaction proposals
@@ -123,6 +141,7 @@ where
     let mut json = response.to_json();
     if let serde_json::Value::Object(map) = &mut json {
         map.insert("multisig".to_string(), multisig.to_string().into());
+        insert_contact_name(map, "multisig_name", multisig.as_pubkey());
         map.insert("transaction_index".to_string(), transaction_index.into());
     }
     print_json(&json)

--- a/helium-wallet/src/cmd/squads/mod.rs
+++ b/helium-wallet/src/cmd/squads/mod.rs
@@ -76,29 +76,12 @@ where
     let mut json = response.to_json();
     if let serde_json::Value::Object(map) = &mut json {
         map.insert("multisig".to_string(), multisig.to_string().into());
-        insert_contact_name(map, "multisig_name", multisig.as_pubkey());
         map.insert("vault".to_string(), vault.to_string().into());
-        insert_contact_name(map, "vault_name", vault.as_pubkey());
         map.insert("vault_index".to_string(), vault_index.into());
         map.insert("transaction_index".to_string(), transaction_index.into());
     }
+    contacts::enrich_pubkeys_in_place(&mut json);
     print_json(&json)
-}
-
-/// Augment a JSON object with a `<field>` entry holding the contact
-/// name registered for `addr`, when one exists. No-op otherwise — the
-/// caller's existing pubkey field carries the address either way.
-fn insert_contact_name(
-    map: &mut serde_json::Map<String, serde_json::Value>,
-    field: &str,
-    addr: &Pubkey,
-) {
-    if let Some(contact) = contacts::cached().find_by_address(addr) {
-        map.insert(
-            field.to_string(),
-            serde_json::Value::String(contact.name.clone()),
-        );
-    }
 }
 
 /// Sibling of `submit_proposal_with` for ConfigTransaction proposals
@@ -141,9 +124,9 @@ where
     let mut json = response.to_json();
     if let serde_json::Value::Object(map) = &mut json {
         map.insert("multisig".to_string(), multisig.to_string().into());
-        insert_contact_name(map, "multisig_name", multisig.as_pubkey());
         map.insert("transaction_index".to_string(), transaction_index.into());
     }
+    contacts::enrich_pubkeys_in_place(&mut json);
     print_json(&json)
 }
 

--- a/helium-wallet/src/cmd/squads/threshold.rs
+++ b/helium-wallet/src/cmd/squads/threshold.rs
@@ -1,4 +1,7 @@
-use crate::cmd::{squads as cmd_squads, *};
+use crate::{
+    cmd::{squads as cmd_squads, *},
+    contacts,
+};
 use helium_lib::{keypair::Pubkey, squads::v4::ConfigActionInput};
 
 /// Propose a new approval threshold for the multisig (v4 only). Once
@@ -8,6 +11,8 @@ use helium_lib::{keypair::Pubkey, squads::v4::ConfigActionInput};
 #[derive(Debug, Clone, clap::Args)]
 pub struct Cmd {
     /// Multisig, vault, or any transaction/proposal PDA in the multisig.
+    /// Also accepts a contact name.
+    #[arg(value_parser = contacts::parse_address_or_name)]
     target: Pubkey,
 
     /// New approval threshold.

--- a/helium-wallet/src/cmd/squads/vote.rs
+++ b/helium-wallet/src/cmd/squads/vote.rs
@@ -1,4 +1,4 @@
-use crate::cmd::*;
+use crate::{cmd::*, contacts};
 use helium_lib::{
     keypair::{Pubkey, Signer},
     message, solana_sdk,
@@ -116,7 +116,8 @@ impl Cancel {
 #[derive(Debug, Clone, clap::Args)]
 pub struct VoteTarget {
     /// Multisig PDA, vault PDA, or transaction/proposal PDA. Same shapes
-    /// `squads inspect` accepts.
+    /// `squads inspect` accepts. Also accepts a contact name.
+    #[arg(value_parser = contacts::parse_address_or_name)]
     target: Pubkey,
     /// Transaction index. Required if `target` is a multisig or vault;
     /// inferred from the body otherwise.

--- a/helium-wallet/src/cmd/transfer.rs
+++ b/helium-wallet/src/cmd/transfer.rs
@@ -4,7 +4,7 @@ use crate::{
     result::Result,
 };
 use helium_lib::{
-    keypair::{serde_pubkey, Pubkey},
+    keypair::Pubkey,
     token::{self, Token, TokenAmount},
 };
 use serde::Deserialize;
@@ -168,8 +168,10 @@ impl PayCmd {
 #[derive(Debug, Deserialize, clap::Args)]
 pub struct Payee {
     /// Address to send the tokens to. Accepts a base58 Solana pubkey or
-    /// a contact name from the address book.
-    #[serde(with = "serde_pubkey")]
+    /// a contact name from the address book — works both on the
+    /// command line (`transfer one --payee alice`) and inside the
+    /// JSON file consumed by `transfer multi`.
+    #[serde(with = "contacts::serde_address_or_name")]
     #[arg(value_parser = contacts::parse_address_or_name)]
     address: Pubkey,
     /// Amount of token to send

--- a/helium-wallet/src/cmd/transfer.rs
+++ b/helium-wallet/src/cmd/transfer.rs
@@ -1,5 +1,6 @@
 use crate::{
     cmd::{squads as cmd_squads, *},
+    contacts,
     result::Result,
 };
 use helium_lib::{
@@ -43,8 +44,8 @@ pub struct One {
     /// Accepts a multisig PDA or a vault PDA — when a vault is given the
     /// multisig is resolved through the local cache. The transfer's
     /// source becomes the vault's ATA (not the wallet's), and the wallet
-    /// just signs as proposer.
-    #[arg(long)]
+    /// just signs as proposer. Also accepts a contact name.
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     squads: Option<Pubkey>,
     /// Memo recorded on the v4 proposal (`--squads` only).
     #[arg(long)]
@@ -90,7 +91,7 @@ pub struct Multi {
     /// File to read multiple payments from.
     path: PathBuf,
     /// Submit as a Squads v4 proposal — see `transfer one --squads`.
-    #[arg(long)]
+    #[arg(long, value_parser = contacts::parse_address_or_name)]
     squads: Option<Pubkey>,
     /// Memo recorded on the v4 proposal (`--squads` only).
     #[arg(long)]
@@ -166,8 +167,10 @@ impl PayCmd {
 
 #[derive(Debug, Deserialize, clap::Args)]
 pub struct Payee {
-    /// Address to send the tokens to.
+    /// Address to send the tokens to. Accepts a base58 Solana pubkey or
+    /// a contact name from the address book.
     #[serde(with = "serde_pubkey")]
+    #[arg(value_parser = contacts::parse_address_or_name)]
     address: Pubkey,
     /// Amount of token to send
     amount: f64,

--- a/helium-wallet/src/contacts.rs
+++ b/helium-wallet/src/contacts.rs
@@ -1,0 +1,307 @@
+//! Named-contact address book.
+//!
+//! Persisted as JSON at `$XDG_CONFIG_HOME/helium-wallet/contacts.json`
+//! (overridable via `HELIUM_WALLET_CONTACTS`). A contact name can be
+//! used anywhere an address is accepted on the command line — a literal
+//! base58 pubkey always wins over a same-named contact, so a malicious
+//! contacts file can never redirect a hand-typed address.
+
+use crate::result::{anyhow, bail, Result};
+use helium_lib::keypair::{serde_pubkey, Pubkey};
+use serde::{Deserialize, Serialize};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::OnceLock,
+};
+
+const ENV_VAR: &str = "HELIUM_WALLET_CONTACTS";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ContactBook {
+    #[serde(default)]
+    pub contacts: Vec<Contact>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Contact {
+    pub name: String,
+    #[serde(with = "serde_pubkey")]
+    pub address: Pubkey,
+}
+
+impl ContactBook {
+    /// Resolve the on-disk path: `$HELIUM_WALLET_CONTACTS` if set,
+    /// otherwise `$XDG_CONFIG_HOME/helium-wallet/contacts.json` with the
+    /// usual `$HOME/.config` fallback.
+    pub fn default_path() -> Result<PathBuf> {
+        if let Some(path) = env::var_os(ENV_VAR).filter(|s| !s.is_empty()) {
+            return Ok(PathBuf::from(path));
+        }
+        let base = match env::var_os("XDG_CONFIG_HOME").filter(|s| !s.is_empty()) {
+            Some(p) => PathBuf::from(p),
+            None => PathBuf::from(env::var_os("HOME").ok_or_else(|| anyhow!("$HOME not set"))?)
+                .join(".config"),
+        };
+        Ok(base.join("helium-wallet").join("contacts.json"))
+    }
+
+    /// Load from disk. A missing file yields an empty book — users who
+    /// never create one see no errors.
+    pub fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let bytes = fs::read(path)?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+
+    /// Atomic write: temp file in the same dir, then rename. The tmp
+    /// file is cleaned up on any failure after it's been written so
+    /// cross-filesystem `rename` errors or a crash mid-rename don't
+    /// leave a `.tmp` artifact next to the real file.
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("json.tmp");
+        let bytes = serde_json::to_vec_pretty(self)?;
+        if let Err(err) = fs::write(&tmp, &bytes) {
+            let _ = fs::remove_file(&tmp);
+            return Err(err.into());
+        }
+        if let Err(err) = fs::rename(&tmp, path) {
+            let _ = fs::remove_file(&tmp);
+            return Err(err.into());
+        }
+        Ok(())
+    }
+
+    pub fn find_by_name(&self, name: &str) -> Option<&Contact> {
+        self.contacts.iter().find(|c| c.name == name)
+    }
+
+    pub fn find_by_address(&self, address: &Pubkey) -> Option<&Contact> {
+        self.contacts.iter().find(|c| c.address == *address)
+    }
+
+    pub fn add(&mut self, contact: Contact) -> Result<()> {
+        let name = &contact.name;
+        if name.is_empty() {
+            bail!("contact name must not be empty");
+        }
+        if name.chars().any(char::is_whitespace) {
+            bail!("contact name '{name}' contains whitespace; names must be a single CLI argument");
+        }
+        if Pubkey::from_str(name).is_ok() {
+            bail!("contact name '{name}' parses as a Solana address; pick a non-pubkey name");
+        }
+        if self.find_by_name(name).is_some() {
+            bail!("contact named '{name}' already exists");
+        }
+        self.contacts.push(contact);
+        Ok(())
+    }
+
+    pub fn remove(&mut self, name: &str) -> Result<Contact> {
+        let idx = self
+            .contacts
+            .iter()
+            .position(|c| c.name == name)
+            .ok_or_else(|| anyhow!("no contact named '{name}'"))?;
+        Ok(self.contacts.remove(idx))
+    }
+}
+
+/// Process-wide cached read of the default book. Loads lazily on first
+/// use; a missing or malformed file degrades to an empty book so name
+/// resolution can never break commands that don't use the feature.
+pub fn cached() -> &'static ContactBook {
+    static BOOK: OnceLock<ContactBook> = OnceLock::new();
+    BOOK.get_or_init(|| {
+        ContactBook::default_path()
+            .and_then(|p| ContactBook::load(&p))
+            .unwrap_or_default()
+    })
+}
+
+/// Resolve `input` against an explicit book. Literal Solana base58
+/// pubkeys are tried first — a contact with the same name as a real
+/// address can never shadow that address. Factored out from
+/// `parse_address_or_name` so tests can pin the precedence rule
+/// without going through the process-wide `OnceLock`.
+pub fn resolve_with(book: &ContactBook, input: &str) -> Result<Pubkey> {
+    if let Ok(pk) = Pubkey::from_str(input) {
+        return Ok(pk);
+    }
+    match book.find_by_name(input) {
+        Some(c) => Ok(c.address),
+        None => bail!("'{input}' is not a known contact or a valid Solana address"),
+    }
+}
+
+/// clap value parser for any field that accepts either a literal Solana
+/// base58 pubkey or the name of a known contact. Delegates to
+/// `resolve_with` against the process-cached book.
+pub fn parse_address_or_name(input: &str) -> Result<Pubkey> {
+    resolve_with(cached(), input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn pk(seed: u8) -> Pubkey {
+        Pubkey::new_from_array([seed; 32])
+    }
+
+    #[test]
+    fn missing_file_loads_empty() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("contacts.json");
+        let book = ContactBook::load(&path).expect("load missing");
+        assert!(book.contacts.is_empty());
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("sub").join("contacts.json");
+        let mut book = ContactBook::default();
+        book.add(Contact {
+            name: "alice".to_string(),
+            address: pk(1),
+        })
+        .expect("add alice");
+        book.save(&path).expect("save");
+
+        let reloaded = ContactBook::load(&path).expect("reload");
+        assert_eq!(reloaded.contacts.len(), 1);
+        assert_eq!(reloaded.contacts[0].name, "alice");
+        assert_eq!(reloaded.contacts[0].address, pk(1));
+    }
+
+    #[test]
+    fn add_rejects_duplicate_name() {
+        let mut book = ContactBook::default();
+        book.add(Contact {
+            name: "alice".to_string(),
+            address: pk(1),
+        })
+        .expect("first add");
+        let err = book
+            .add(Contact {
+                name: "alice".to_string(),
+                address: pk(2),
+            })
+            .expect_err("duplicate must fail");
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    #[test]
+    fn add_rejects_pubkey_shaped_name() {
+        let mut book = ContactBook::default();
+        let err = book
+            .add(Contact {
+                name: pk(1).to_string(),
+                address: pk(2),
+            })
+            .expect_err("pubkey-name must fail");
+        assert!(err.to_string().contains("parses as a Solana address"));
+    }
+
+    #[test]
+    fn remove_returns_entry_and_errors_when_missing() {
+        let mut book = ContactBook::default();
+        book.add(Contact {
+            name: "alice".to_string(),
+            address: pk(1),
+        })
+        .expect("add alice");
+        let removed = book.remove("alice").expect("remove alice");
+        assert_eq!(removed.address, pk(1));
+        assert!(book.contacts.is_empty());
+        let err = book.remove("alice").expect_err("second remove must fail");
+        assert!(err.to_string().contains("no contact named"));
+    }
+
+    #[test]
+    fn find_by_name_and_address() {
+        let mut book = ContactBook::default();
+        book.add(Contact {
+            name: "alice".to_string(),
+            address: pk(1),
+        })
+        .expect("add");
+        assert!(book.find_by_name("alice").is_some());
+        assert!(book.find_by_name("bob").is_none());
+        assert!(book.find_by_address(&pk(1)).is_some());
+        assert!(book.find_by_address(&pk(2)).is_none());
+    }
+
+    #[test]
+    fn add_rejects_whitespace_in_name() {
+        let mut book = ContactBook::default();
+        let err = book
+            .add(Contact {
+                name: "alice bob".to_string(),
+                address: pk(1),
+            })
+            .expect_err("whitespace name must fail");
+        assert!(err.to_string().contains("whitespace"));
+    }
+
+    #[test]
+    fn add_rejects_empty_name() {
+        let mut book = ContactBook::default();
+        let err = book
+            .add(Contact {
+                name: String::new(),
+                address: pk(1),
+            })
+            .expect_err("empty name must fail");
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn resolve_with_prefers_literal_pubkey_over_same_named_contact() {
+        // Security invariant: even if a malicious contacts file binds a
+        // name that LOOKS like a base58 pubkey, the literal pubkey on the
+        // command line must resolve to itself, never to the contact's
+        // address. `add` prevents pubkey-shaped names at write time;
+        // this test pins the read-time guarantee too, so a hand-edited
+        // file can't override it.
+        let real_addr = pk(1);
+        let attacker_addr = pk(2);
+        let book = ContactBook {
+            contacts: vec![Contact {
+                name: real_addr.to_string(),
+                address: attacker_addr,
+            }],
+        };
+        let resolved = resolve_with(&book, &real_addr.to_string()).expect("resolve literal");
+        assert_eq!(resolved, real_addr);
+    }
+
+    #[test]
+    fn resolve_with_falls_back_to_contact_name() {
+        let mut book = ContactBook::default();
+        book.add(Contact {
+            name: "alice".to_string(),
+            address: pk(1),
+        })
+        .expect("add alice");
+        assert_eq!(resolve_with(&book, "alice").expect("resolve name"), pk(1));
+    }
+
+    #[test]
+    fn resolve_with_errors_on_unknown_input() {
+        let book = ContactBook::default();
+        let err = resolve_with(&book, "nobody").expect_err("unknown must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("not a known contact"));
+        assert!(msg.contains("nobody"));
+    }
+}

--- a/helium-wallet/src/contacts.rs
+++ b/helium-wallet/src/contacts.rs
@@ -148,6 +148,70 @@ pub fn parse_address_or_name(input: &str) -> Result<Pubkey> {
     resolve_with(cached(), input)
 }
 
+/// JSON keys that identify the *subject* of an object — the pubkey
+/// this object IS. A matching contact attaches as the sibling key
+/// `name`. Used by the JSON walker; see `enrich_pubkeys_in_place`.
+const IDENTITY_KEYS: &[&str] = &["pubkey", "key", "address"];
+
+/// JSON keys that name a related entity — the pubkey this object
+/// HAS-A. A matching contact attaches as the sibling key
+/// `<original>_name` (e.g. `multisig` → `multisig_name`). Kept
+/// narrow so unrelated string fields can't accidentally trigger a
+/// lookup.
+const RELATION_KEYS: &[&str] = &["multisig", "vault", "authority", "creator"];
+
+/// Walk `value` and annotate every recognized pubkey-bearing field
+/// with the contact name registered for it, when one exists. Two
+/// patterns are recognized — see `IDENTITY_KEYS` / `RELATION_KEYS`.
+///
+/// Purely additive: an object with no matching contacts is unchanged.
+/// An object that already has a `name` field is never overwritten —
+/// callers can pre-populate names for entities outside the contacts
+/// book.
+pub fn enrich_pubkeys_in_place(value: &mut serde_json::Value) {
+    enrich(value, cached());
+}
+
+fn enrich(value: &mut serde_json::Value, book: &ContactBook) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let relation_inserts: Vec<(String, String)> = RELATION_KEYS
+                .iter()
+                .filter_map(|key| {
+                    let addr = map.get(*key)?.as_str()?;
+                    let pk = Pubkey::from_str(addr).ok()?;
+                    let name = book.find_by_address(&pk)?.name.clone();
+                    Some((format!("{key}_name"), name))
+                })
+                .collect();
+            for (k, v) in relation_inserts {
+                map.insert(k, serde_json::Value::String(v));
+            }
+
+            if !map.contains_key("name") {
+                let identity_name = IDENTITY_KEYS.iter().find_map(|key| {
+                    let addr = map.get(*key)?.as_str()?;
+                    let pk = Pubkey::from_str(addr).ok()?;
+                    book.find_by_address(&pk).map(|c| c.name.clone())
+                });
+                if let Some(name) = identity_name {
+                    map.insert("name".to_string(), serde_json::Value::String(name));
+                }
+            }
+
+            for v in map.values_mut() {
+                enrich(v, book);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                enrich(v, book);
+            }
+        }
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -303,5 +367,119 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("not a known contact"));
         assert!(msg.contains("nobody"));
+    }
+
+    /// Walker tests use a private variant of `enrich_pubkeys_in_place`
+    /// that takes an explicit book — same path the public function
+    /// uses internally, just without the process-singleton dependency.
+    fn enrich_test(value: &mut serde_json::Value, book: &ContactBook) {
+        super::enrich(value, book);
+    }
+
+    fn book_with(entries: &[(&str, Pubkey)]) -> ContactBook {
+        let mut book = ContactBook::default();
+        for (name, address) in entries {
+            book.add(Contact {
+                name: (*name).to_string(),
+                address: *address,
+            })
+            .expect("add");
+        }
+        book
+    }
+
+    #[test]
+    fn walker_injects_name_next_to_identity_keys() {
+        let book = book_with(&[("alice", pk(1))]);
+        let cases = ["pubkey", "key", "address"];
+        for field in cases {
+            let mut value = serde_json::json!({ field: pk(1).to_string() });
+            enrich_test(&mut value, &book);
+            assert_eq!(value[field].as_str(), Some(pk(1).to_string().as_str()));
+            assert_eq!(value["name"].as_str(), Some("alice"), "field = {field}");
+        }
+    }
+
+    #[test]
+    fn walker_injects_suffixed_name_for_relation_keys() {
+        let book = book_with(&[
+            ("treasury", pk(1)),
+            ("alice", pk(2)),
+            ("vault-prod", pk(3)),
+            ("ops-vault", pk(4)),
+        ]);
+        let mut value = serde_json::json!({
+            "multisig": pk(1).to_string(),
+            "creator": pk(2).to_string(),
+            "vault": pk(3).to_string(),
+            "authority": pk(4).to_string(),
+        });
+        enrich_test(&mut value, &book);
+        assert_eq!(value["multisig_name"].as_str(), Some("treasury"));
+        assert_eq!(value["creator_name"].as_str(), Some("alice"));
+        assert_eq!(value["vault_name"].as_str(), Some("vault-prod"));
+        assert_eq!(value["authority_name"].as_str(), Some("ops-vault"));
+    }
+
+    #[test]
+    fn walker_recurses_into_arrays_and_nested_objects() {
+        let book = book_with(&[("alice", pk(1)), ("bob", pk(2))]);
+        let mut value = serde_json::json!({
+            "instructions": [
+                {
+                    "accounts": [
+                        { "pubkey": pk(1).to_string(), "writable": true },
+                        { "pubkey": pk(2).to_string(), "writable": false },
+                        { "pubkey": pk(3).to_string(), "writable": false },
+                    ]
+                }
+            ]
+        });
+        enrich_test(&mut value, &book);
+        let accounts = &value["instructions"][0]["accounts"];
+        assert_eq!(accounts[0]["name"].as_str(), Some("alice"));
+        assert_eq!(accounts[1]["name"].as_str(), Some("bob"));
+        assert!(
+            accounts[2].get("name").is_none(),
+            "unknown pubkey gets no name"
+        );
+    }
+
+    #[test]
+    fn walker_skips_unknown_addresses_silently() {
+        let book = book_with(&[("alice", pk(1))]);
+        let original = serde_json::json!({
+            "multisig": pk(99).to_string(),
+            "pubkey": pk(99).to_string(),
+        });
+        let mut value = original.clone();
+        enrich_test(&mut value, &book);
+        assert_eq!(value, original, "unknown addresses must not be annotated");
+    }
+
+    #[test]
+    fn walker_preserves_existing_name_field() {
+        let book = book_with(&[("alice", pk(1))]);
+        // Caller pre-populated `name` for a token / program / etc;
+        // the walker must not overwrite it with the contact name.
+        let mut value = serde_json::json!({
+            "pubkey": pk(1).to_string(),
+            "name": "HNT mint",
+        });
+        enrich_test(&mut value, &book);
+        assert_eq!(value["name"].as_str(), Some("HNT mint"));
+    }
+
+    #[test]
+    fn walker_ignores_non_pubkey_strings_in_known_keys() {
+        let book = book_with(&[("alice", pk(1))]);
+        // A field literally named "address" can hold a non-pubkey
+        // string (e.g. a hotspot's location string). The walker must
+        // not trip over it.
+        let mut value = serde_json::json!({
+            "address": "123 Main St",
+        });
+        enrich_test(&mut value, &book);
+        assert!(value.get("name").is_none());
     }
 }

--- a/helium-wallet/src/contacts.rs
+++ b/helium-wallet/src/contacts.rs
@@ -94,8 +94,17 @@ impl ContactBook {
         if name.chars().any(char::is_whitespace) {
             bail!("contact name '{name}' contains whitespace; names must be a single CLI argument");
         }
+        // Reject names that parse as a wallet address in any of the forms
+        // the CLI resolves. Otherwise a contact could shadow a real
+        // address — `info <name>` would return the contact instead of
+        // doing the Solana-or-helium → Pubkey conversion. The Solana
+        // case covers `transfer one`, `squads`, etc; the helium case
+        // covers `info`'s helium-base58 fallback path.
         if Pubkey::from_str(name).is_ok() {
             bail!("contact name '{name}' parses as a Solana address; pick a non-pubkey name");
+        }
+        if helium_crypto::PublicKey::from_str(name).is_ok() {
+            bail!("contact name '{name}' parses as a Helium pubkey; pick a non-pubkey name");
         }
         if self.find_by_name(name).is_some() {
             bail!("contact named '{name}' already exists");
@@ -115,14 +124,37 @@ impl ContactBook {
 }
 
 /// Process-wide cached read of the default book. Loads lazily on first
-/// use; a missing or malformed file degrades to an empty book so name
-/// resolution can never break commands that don't use the feature.
+/// use; a missing file degrades to an empty book so name resolution
+/// can never break commands that don't use the feature. A *malformed*
+/// file also degrades to empty, but emits a warning on stderr —
+/// otherwise a subsequent `contacts add` would atomically overwrite
+/// the broken (but recoverable) file with a fresh one containing only
+/// the new entry, destroying every other contact.
 pub fn cached() -> &'static ContactBook {
     static BOOK: OnceLock<ContactBook> = OnceLock::new();
     BOOK.get_or_init(|| {
-        ContactBook::default_path()
-            .and_then(|p| ContactBook::load(&p))
-            .unwrap_or_default()
+        let path = match ContactBook::default_path() {
+            Ok(p) => p,
+            Err(err) => {
+                eprintln!("warning: failed to resolve contacts file path: {err}");
+                return ContactBook::default();
+            }
+        };
+        match ContactBook::load(&path) {
+            Ok(book) => book,
+            Err(err) => {
+                eprintln!(
+                    "warning: failed to load contacts from {}: {err}",
+                    path.display()
+                );
+                eprintln!(
+                    "         continuing with an empty address book. \
+                     fix the file before running `contacts add` — \
+                     it will atomically overwrite the existing file."
+                );
+                ContactBook::default()
+            }
+        }
     })
 }
 
@@ -148,6 +180,29 @@ pub fn parse_address_or_name(input: &str) -> Result<Pubkey> {
     resolve_with(cached(), input)
 }
 
+/// Serde variant of `parse_address_or_name` for fields read from JSON
+/// input files (e.g. `transfer multi`'s payee list). Lets a contact
+/// name appear inside the JSON wherever a base58 pubkey is accepted,
+/// matching the CLI-arg behavior.
+pub mod serde_address_or_name {
+    use super::*;
+    use serde::de::{self, Deserialize};
+
+    pub fn serialize<S: serde::Serializer>(
+        value: &Pubkey,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        serde_pubkey::serialize(value, serializer)
+    }
+
+    pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Pubkey, D::Error> {
+        let input = String::deserialize(deserializer)?;
+        resolve_with(cached(), &input).map_err(de::Error::custom)
+    }
+}
+
 /// JSON keys that identify the *subject* of an object — the pubkey
 /// this object IS. A matching contact attaches as the sibling key
 /// `name`. Used by the JSON walker; see `enrich_pubkeys_in_place`.
@@ -158,7 +213,13 @@ const IDENTITY_KEYS: &[&str] = &["pubkey", "key", "address"];
 /// `<original>_name` (e.g. `multisig` → `multisig_name`). Kept
 /// narrow so unrelated string fields can't accidentally trigger a
 /// lookup.
-const RELATION_KEYS: &[&str] = &["multisig", "vault", "authority", "creator"];
+const RELATION_KEYS: &[&str] = &[
+    "multisig",
+    "vault",
+    "authority",
+    "creator",
+    "resolved_from_vault",
+];
 
 /// Walk `value` and annotate every recognized pubkey-bearing field
 /// with the contact name registered for it, when one exists. Two
@@ -175,13 +236,22 @@ pub fn enrich_pubkeys_in_place(value: &mut serde_json::Value) {
 fn enrich(value: &mut serde_json::Value, book: &ContactBook) {
     match value {
         serde_json::Value::Object(map) => {
+            // Relation pass: for each `<key>` in RELATION_KEYS, attach
+            // a `<key>_name` sibling only when the sibling isn't
+            // already set — symmetric with the identity-key guard
+            // below, so a caller pre-populating `vault_name` (say, to
+            // label a non-contact entity) isn't clobbered.
             let relation_inserts: Vec<(String, String)> = RELATION_KEYS
                 .iter()
                 .filter_map(|key| {
+                    let sibling = format!("{key}_name");
+                    if map.contains_key(&sibling) {
+                        return None;
+                    }
                     let addr = map.get(*key)?.as_str()?;
                     let pk = Pubkey::from_str(addr).ok()?;
                     let name = book.find_by_address(&pk)?.name.clone();
-                    Some((format!("{key}_name"), name))
+                    Some((sibling, name))
                 })
                 .collect();
             for (k, v) in relation_inserts {
@@ -277,6 +347,30 @@ mod tests {
     }
 
     #[test]
+    fn add_rejects_helium_pubkey_shaped_name() {
+        // info.rs's parse_address falls back to helium_crypto::PublicKey
+        // after the contact lookup. If a helium-shaped name were
+        // allowed, a contact could shadow the helium → solana
+        // conversion — same class of bug as the Solana case above.
+        // Round-trip a known Solana pubkey through the helium format
+        // to get a name string the helium parser accepts.
+        let helium = helium_lib::keypair::to_helium_pubkey(&pk(1))
+            .expect("convert test pubkey to helium format");
+        let helium_name = helium.to_string();
+        helium_crypto::PublicKey::from_str(&helium_name)
+            .expect("round-tripped string parses as helium pubkey");
+
+        let mut book = ContactBook::default();
+        let err = book
+            .add(Contact {
+                name: helium_name,
+                address: pk(2),
+            })
+            .expect_err("helium-pubkey-shaped name must fail");
+        assert!(err.to_string().contains("Helium pubkey"));
+    }
+
+    #[test]
     fn remove_returns_entry_and_errors_when_missing() {
         let mut book = ContactBook::default();
         book.add(Contact {
@@ -369,13 +463,6 @@ mod tests {
         assert!(msg.contains("nobody"));
     }
 
-    /// Walker tests use a private variant of `enrich_pubkeys_in_place`
-    /// that takes an explicit book — same path the public function
-    /// uses internally, just without the process-singleton dependency.
-    fn enrich_test(value: &mut serde_json::Value, book: &ContactBook) {
-        super::enrich(value, book);
-    }
-
     fn book_with(entries: &[(&str, Pubkey)]) -> ContactBook {
         let mut book = ContactBook::default();
         for (name, address) in entries {
@@ -394,7 +481,7 @@ mod tests {
         let cases = ["pubkey", "key", "address"];
         for field in cases {
             let mut value = serde_json::json!({ field: pk(1).to_string() });
-            enrich_test(&mut value, &book);
+            super::enrich(&mut value, &book);
             assert_eq!(value[field].as_str(), Some(pk(1).to_string().as_str()));
             assert_eq!(value["name"].as_str(), Some("alice"), "field = {field}");
         }
@@ -414,7 +501,7 @@ mod tests {
             "vault": pk(3).to_string(),
             "authority": pk(4).to_string(),
         });
-        enrich_test(&mut value, &book);
+        super::enrich(&mut value, &book);
         assert_eq!(value["multisig_name"].as_str(), Some("treasury"));
         assert_eq!(value["creator_name"].as_str(), Some("alice"));
         assert_eq!(value["vault_name"].as_str(), Some("vault-prod"));
@@ -435,7 +522,7 @@ mod tests {
                 }
             ]
         });
-        enrich_test(&mut value, &book);
+        super::enrich(&mut value, &book);
         let accounts = &value["instructions"][0]["accounts"];
         assert_eq!(accounts[0]["name"].as_str(), Some("alice"));
         assert_eq!(accounts[1]["name"].as_str(), Some("bob"));
@@ -453,7 +540,7 @@ mod tests {
             "pubkey": pk(99).to_string(),
         });
         let mut value = original.clone();
-        enrich_test(&mut value, &book);
+        super::enrich(&mut value, &book);
         assert_eq!(value, original, "unknown addresses must not be annotated");
     }
 
@@ -466,8 +553,42 @@ mod tests {
             "pubkey": pk(1).to_string(),
             "name": "HNT mint",
         });
-        enrich_test(&mut value, &book);
+        super::enrich(&mut value, &book);
         assert_eq!(value["name"].as_str(), Some("HNT mint"));
+    }
+
+    #[test]
+    fn walker_preserves_existing_relation_name_field() {
+        // Symmetric guard with the identity-key case above: a caller
+        // that pre-populated `multisig_name` (e.g. to label a non-
+        // contact entity with a specific reviewer-facing label) keeps
+        // it; the walker doesn't clobber.
+        let book = book_with(&[("treasury", pk(1))]);
+        let mut value = serde_json::json!({
+            "multisig": pk(1).to_string(),
+            "multisig_name": "operator-set-2025-q2",
+        });
+        super::enrich(&mut value, &book);
+        assert_eq!(
+            value["multisig_name"].as_str(),
+            Some("operator-set-2025-q2")
+        );
+    }
+
+    #[test]
+    fn walker_enriches_resolved_from_vault() {
+        // MultisigInfo carries `resolved_from_vault` when the input
+        // target was a vault PDA. It should be named in the same way
+        // `multisig` and `vault` are.
+        let book = book_with(&[("ops-vault", pk(1))]);
+        let mut value = serde_json::json!({
+            "resolved_from_vault": pk(1).to_string(),
+        });
+        super::enrich(&mut value, &book);
+        assert_eq!(
+            value["resolved_from_vault_name"].as_str(),
+            Some("ops-vault")
+        );
     }
 
     #[test]
@@ -479,7 +600,7 @@ mod tests {
         let mut value = serde_json::json!({
             "address": "123 Main St",
         });
-        enrich_test(&mut value, &book);
+        super::enrich(&mut value, &book);
         assert!(value.get("name").is_none());
     }
 }

--- a/helium-wallet/src/lib.rs
+++ b/helium-wallet/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 pub mod cmd;
+pub mod contacts;
 pub mod format;
 pub mod pwhash;
 pub mod read_write;

--- a/helium-wallet/src/main.rs
+++ b/helium-wallet/src/main.rs
@@ -4,8 +4,8 @@
 use clap::Parser;
 use helium_wallet::{
     cmd::{
-        assets, balance, burn, create, dc, export, hotspots, info, ledger, memo, price, router,
-        sign, squads, swap, transfer, upgrade, Opts,
+        assets, balance, burn, contacts, create, dc, export, hotspots, info, ledger, memo, price,
+        router, sign, squads, swap, transfer, upgrade, Opts,
     },
     result::Result,
 };
@@ -46,6 +46,7 @@ pub enum Cmd {
     Memo(memo::Cmd),
     Assets(assets::Cmd),
     Ledger(ledger::Cmd),
+    Contacts(contacts::Cmd),
 }
 
 #[allow(clippy::needless_return)]
@@ -78,6 +79,7 @@ impl Cli {
             Cmd::Memo(cmd) => cmd.run(self.opts).await,
             Cmd::Assets(cmd) => cmd.run(self.opts).await,
             Cmd::Ledger(cmd) => cmd.run(self.opts).await,
+            Cmd::Contacts(cmd) => cmd.run(self.opts).await,
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a small per-user address book so contact names can be used anywhere a Solana pubkey is accepted on the helium-wallet CLI, and surfaces those names in JSON output where they're most useful.

- **Storage**: `$XDG_CONFIG_HOME/helium-wallet/contacts.json` (overridable via `HELIUM_WALLET_CONTACTS`), schema is just `{name, address}` per entry, JSON to reuse the existing `serde_json` workspace dep — no new runtime crate.
- **Manage**: `helium-wallet contacts list | show <name> | add <name> <address> | remove <name>`. `add` requires a literal base58 pubkey so names never resolve to other names; rejects empty, whitespace-bearing, and pubkey-shaped names so a contact can never shadow a real address at resolve time.
- **Use anywhere an address is accepted**: every destination, owner, and `--squads` target across `transfer`, `hotspots {transfer,burn,list,rewards}`, `assets {transfer,burn,claim}`, `dc {mint,burn,delegate}`, `burn`, `balance`, and every squads subcommand.
- **Show names in output** (skip-if-none, so existing JSON consumers are unaffected): top-level `name` on `info`, `balance`, `hotspots list`; per-member `name` on `squads members list`; `multisig_name` / `vault_name` next to the existing `multisig`/`vault` fields on squads proposal-submit responses.

## Notes

- Literal pubkeys always win over a same-named contact (precedence pinned by unit test), so a malicious or hand-edited contacts file cannot redirect a hand-typed address.
- The contacts file degrades to empty when missing or malformed — commands that don't use the feature can never break on it.
- `info`'s `parse_address` now tries Solana → contact → helium-crypto in that order. Vanishingly rare collisions between contact names and base58-decoding helium pubkeys would now resolve to the contact; explicitly intentional given the use cases.