### PR TITLE
feat(cli): add shell tab-completion subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,6 +2631,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "clap",
+ "clap_complete",
  "dialoguer",
  "futures",
  "helium-crypto",

--- a/README.md
+++ b/README.md
@@ -380,6 +380,31 @@ helium-wallet memo <subcommand>
 helium-wallet router <subcommand>
 ```
 
+### `completion` -- Shell Tab-Completion
+
+Generate a completion script for the given shell. The supported shells are
+`bash`, `zsh`, `fish`, `powershell`, and `elvish`.
+
+```
+helium-wallet completion <SHELL>
+```
+
+Install it where your shell will pick it up. A few common one-liners:
+
+```bash
+# zsh — drop it into an fpath directory
+helium-wallet completion zsh > ~/.zfunc/_helium-wallet
+
+# bash
+helium-wallet completion bash | sudo tee /etc/bash_completion.d/helium-wallet
+
+# fish
+helium-wallet completion fish > ~/.config/fish/completions/helium-wallet.fish
+
+# Or eval at shell start (zsh shown):
+eval "$(helium-wallet completion zsh)"
+```
+
 ## Environment Variables
 
 ### Solana RPC

--- a/helium-wallet/Cargo.toml
+++ b/helium-wallet/Cargo.toml
@@ -29,6 +29,7 @@ shamirsecretsharing = { version = "0.1.5", features = ["have_libsodium"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 clap = { workspace = true }
+clap_complete = "4"
 qr2term = "0.2"
 rust_decimal = { workspace = true }
 tokio = { version = "1.0", features = ["full"] }

--- a/helium-wallet/src/cmd/completion.rs
+++ b/helium-wallet/src/cmd/completion.rs
@@ -1,0 +1,8 @@
+use clap_complete::Shell;
+
+#[derive(Debug, clap::Args)]
+pub struct Cmd {
+    /// Target shell (bash, zsh, fish, powershell, elvish).
+    #[arg(value_enum)]
+    pub shell: Shell,
+}

--- a/helium-wallet/src/cmd/completion.rs
+++ b/helium-wallet/src/cmd/completion.rs
@@ -1,8 +1,19 @@
+use crate::result::Result;
 use clap_complete::Shell;
 
+/// Generate a shell completion script for the given shell
 #[derive(Debug, clap::Args)]
 pub struct Cmd {
-    /// Target shell (bash, zsh, fish, powershell, elvish).
+    /// Target shell to generate completion for
     #[arg(value_enum)]
-    pub shell: Shell,
+    shell: Shell,
+}
+
+impl Cmd {
+    pub fn run<C: clap::CommandFactory>(&self) -> Result {
+        let mut cmd = C::command();
+        let bin = cmd.get_name().to_string();
+        clap_complete::generate(self.shell, &mut cmd, bin, &mut std::io::stdout());
+        Ok(())
+    }
 }

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -27,6 +27,7 @@ use std::{
 pub mod assets;
 pub mod balance;
 pub mod burn;
+pub mod completion;
 pub mod create;
 pub mod dc;
 pub mod export;

--- a/helium-wallet/src/main.rs
+++ b/helium-wallet/src/main.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
-use clap::{CommandFactory, Parser};
+use clap::Parser;
 use helium_wallet::{
     cmd::{
         assets, balance, burn, completion, create, dc, export, hotspots, info, ledger, memo, price,
@@ -46,7 +46,6 @@ pub enum Cmd {
     Memo(memo::Cmd),
     Assets(assets::Cmd),
     Ledger(ledger::Cmd),
-    /// Generate shell completion script for the given shell.
     Completion(completion::Cmd),
 }
 
@@ -61,10 +60,7 @@ async fn main() -> Result {
 impl Cli {
     async fn run(self) -> Result {
         if let Cmd::Completion(cmd) = &self.cmd {
-            let mut cli_cmd = Cli::command();
-            let bin = cli_cmd.get_name().to_string();
-            clap_complete::generate(cmd.shell, &mut cli_cmd, bin, &mut std::io::stdout());
-            return Ok(());
+            return cmd.run::<Cli>();
         }
         let client = self.opts.client()?;
         helium_lib::init(client.solana_client)?;

--- a/helium-wallet/src/main.rs
+++ b/helium-wallet/src/main.rs
@@ -1,11 +1,11 @@
 #![forbid(unsafe_code)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use helium_wallet::{
     cmd::{
-        assets, balance, burn, create, dc, export, hotspots, info, ledger, memo, price, router,
-        sign, squads, swap, transfer, upgrade, Opts,
+        assets, balance, burn, completion, create, dc, export, hotspots, info, ledger, memo, price,
+        router, sign, squads, swap, transfer, upgrade, Opts,
     },
     result::Result,
 };
@@ -46,6 +46,8 @@ pub enum Cmd {
     Memo(memo::Cmd),
     Assets(assets::Cmd),
     Ledger(ledger::Cmd),
+    /// Generate shell completion script for the given shell.
+    Completion(completion::Cmd),
 }
 
 #[allow(clippy::needless_return)]
@@ -58,6 +60,12 @@ async fn main() -> Result {
 
 impl Cli {
     async fn run(self) -> Result {
+        if let Cmd::Completion(cmd) = &self.cmd {
+            let mut cli_cmd = Cli::command();
+            let bin = cli_cmd.get_name().to_string();
+            clap_complete::generate(cmd.shell, &mut cli_cmd, bin, &mut std::io::stdout());
+            return Ok(());
+        }
         let client = self.opts.client()?;
         helium_lib::init(client.solana_client)?;
         match self.cmd {
@@ -78,6 +86,7 @@ impl Cli {
             Cmd::Memo(cmd) => cmd.run(self.opts).await,
             Cmd::Assets(cmd) => cmd.run(self.opts).await,
             Cmd::Ledger(cmd) => cmd.run(self.opts).await,
+            Cmd::Completion(_) => unreachable!("handled above"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds `helium-wallet completion <shell>` that emits a shell completion
script for `bash`, `zsh`, `fish`, `powershell`, or `elvish` via
`clap_complete`. The subcommand short-circuits in `Cli::run` before
`opts.client()` / `helium_lib::init`, so it works without a `wallet.key`
in cwd and without network access.

Install one-liners are documented in the README under
**`completion` -- Shell Tab-Completion**.

## Notes

- Layout mirrors the existing `cmd::*` modules: struct-level doc, private
  field, `pub fn run(&self) -> Result` on the cmd. The only divergence
  from siblings is that `run` is generic on `clap::CommandFactory` and
  not async — both justified by the work being IO-free CLI generation.
- New dependency: `clap_complete = "4"`, tracking the existing `clap` v4.