### PR TITLE
fix(wallet): stop leaking secrets in debug builds, zeroize key material, 0600 key files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,6 +2648,7 @@ dependencies = [
  "shamirsecretsharing",
  "sodiumoxide",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]

--- a/helium-lib/src/keypair.rs
+++ b/helium-lib/src/keypair.rs
@@ -132,8 +132,12 @@ impl Keypair {
     }
 
     /// Get the 64-byte secret key (secret bytes + public key bytes).
+    ///
+    /// Allocated up-front so the secret bytes are never copied through an
+    /// intermediate reallocation the caller can't scrub.
     pub fn secret(&self) -> Vec<u8> {
-        let mut result = self.0.secret_bytes().to_vec();
+        let mut result = Vec::with_capacity(64);
+        result.extend_from_slice(self.0.secret_bytes().as_slice());
         result.extend_from_slice(self.pubkey().as_ref());
         result
     }

--- a/helium-lib/src/token.rs
+++ b/helium-lib/src/token.rs
@@ -748,7 +748,7 @@ impl<'de> serde::Deserialize<'de> for TokenAmount {
                     let amount = amount_value
                         .as_f64()
                         .ok_or_else(|| de::Error::custom("expected float for decimal token"))?;
-                    TokenAmount::from_f64(token, amount)
+                    TokenAmount::from_f64(token, amount).map_err(de::Error::custom)?
                 };
 
                 Ok(token_amount)
@@ -770,11 +770,33 @@ impl Default for TokenAmount {
 }
 
 impl TokenAmount {
+    /// Largest integer an f64 represents exactly (2^53). Scaled amounts
+    /// past this would silently lose base units in the cast.
+    const MAX_F64_AMOUNT: f64 = (1u64 << f64::MANTISSA_DIGITS) as f64;
+
     /// Create a token amount from a human-readable decimal value (e.g. `1.5` HNT).
-    pub fn from_f64<T: Into<Token>>(token: T, amount: f64) -> Self {
+    ///
+    /// Rejects negative, NaN, and infinite values, and values whose
+    /// base-unit form exceeds f64's exact integer range, all of which
+    /// the previous unchecked cast silently turned into a different
+    /// on-chain amount.
+    pub fn from_f64<T: Into<Token>>(token: T, amount: f64) -> Result<Self, DecodeError> {
         let token = token.into();
-        let amount = (amount * 10_usize.pow(token.decimals().into()) as f64) as u64;
-        Self { token, amount }
+        if !amount.is_finite() || amount < 0.0 {
+            return Err(DecodeError::other(format!(
+                "invalid {token} amount: {amount}"
+            )));
+        }
+        let scaled = amount * 10_usize.pow(token.decimals().into()) as f64;
+        if scaled > Self::MAX_F64_AMOUNT {
+            return Err(DecodeError::other(format!(
+                "{token} amount {amount} is too large to represent exactly"
+            )));
+        }
+        Ok(Self {
+            token,
+            amount: scaled as u64,
+        })
     }
 
     /// Create a token amount from raw integer units (e.g. lamports, bones).
@@ -855,7 +877,7 @@ mod tests {
 
     #[test]
     fn test_token_amount_serde_roundtrip_with_decimals() {
-        let original = TokenAmount::from_f64(Token::Hnt, 1.5);
+        let original = TokenAmount::from_f64(Token::Hnt, 1.5).expect("hnt token amount");
         let json = serde_json::to_string(&original).unwrap();
         let deserialized: TokenAmount = serde_json::from_str(&json).unwrap();
         assert_eq!(original, deserialized);
@@ -863,10 +885,24 @@ mod tests {
     }
 
     #[test]
+    fn test_token_amount_from_f64_rejects_invalid() {
+        for bad in [-1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(
+                TokenAmount::from_f64(Token::Hnt, bad).is_err(),
+                "expected rejection of {bad}"
+            );
+        }
+        // 2^53 base units of HNT (8 decimals) is ~90M HNT; past that the
+        // f64 cast would silently lose base units.
+        assert!(TokenAmount::from_f64(Token::Hnt, 100_000_000.0).is_err());
+        assert!(TokenAmount::from_f64(Token::Hnt, 0.0).expect("zero").amount == 0);
+    }
+
+    #[test]
     fn test_token_balance_serialization() {
         let balance = TokenBalance {
             address: Pubkey::new_unique(),
-            amount: TokenAmount::from_f64(Token::Mobile, 10.5),
+            amount: TokenAmount::from_f64(Token::Mobile, 10.5).expect("mobile token amount"),
         };
         let json = serde_json::to_string(&balance).unwrap();
         assert!(json.contains("\"amount\":{\"token\":\"mobile\",\"amount\":10.5}"));

--- a/helium-wallet/Cargo.toml
+++ b/helium-wallet/Cargo.toml
@@ -38,3 +38,4 @@ helium-mnemonic = { path = "../helium-mnemonic" }
 helium-proto = { workspace = true }
 helium-crypto = { workspace = true, features = ["solana", "ledger"] }
 bs58 = "0.5"
+zeroize = "1"

--- a/helium-wallet/src/cmd/assets/claim/one.rs
+++ b/helium-wallet/src/cmd/assets/claim/one.rs
@@ -28,7 +28,8 @@ impl Cmd {
 
         let token_amount = self
             .amount
-            .map(|amount| TokenAmount::from_f64(self.token, amount).amount);
+            .map(|amount| TokenAmount::from_f64(self.token, amount).map(|ta| ta.amount))
+            .transpose()?;
         let Some((tx, _)) = reward::claim(
             &client,
             self.token,

--- a/helium-wallet/src/cmd/assets/claim/schedule.rs
+++ b/helium-wallet/src/cmd/assets/claim/schedule.rs
@@ -92,7 +92,10 @@ impl InitCmd {
         let signer = opts.load_signer()?;
         let fund = self
             .fund
-            .map(|amount| token::TokenAmount::from_f64(token::Token::Sol, amount).amount);
+            .map(|amount| {
+                token::TokenAmount::from_f64(token::Token::Sol, amount).map(|ta| ta.amount)
+            })
+            .transpose()?;
         let (tx, _) = schedule::init(
             &client,
             &queue::TASK_QUEUE_ID,

--- a/helium-wallet/src/cmd/burn.rs
+++ b/helium-wallet/src/cmd/burn.rs
@@ -25,7 +25,7 @@ impl Cmd {
         let client = opts.client()?;
         let txn_opts = self.commit.transaction_opts(&client);
 
-        let token_amount = token::TokenAmount::from_f64(self.subdao.token(), self.amount);
+        let token_amount = token::TokenAmount::from_f64(self.subdao.token(), self.amount)?;
 
         if let Some(squads_target) = self.squads {
             return cmd_squads::submit_proposal_with(

--- a/helium-wallet/src/cmd/dc/mint.rs
+++ b/helium-wallet/src/cmd/dc/mint.rs
@@ -44,7 +44,7 @@ impl Cmd {
 
         let client = opts.client()?;
         let amount = match (self.hnt, self.dc) {
-            (Some(hnt), None) => TokenAmount::from_f64(Token::Hnt, hnt),
+            (Some(hnt), None) => TokenAmount::from_f64(Token::Hnt, hnt)?,
             (None, Some(dc)) => TokenAmount::from_u64(Token::Dc, dc),
             _ => return Err(anyhow!("Must specify either HNT or DC")),
         };

--- a/helium-wallet/src/cmd/export.rs
+++ b/helium-wallet/src/cmd/export.rs
@@ -1,9 +1,9 @@
 use crate::{cmd::*, pwhash::*};
-use helium_lib::keypair::Signer;
 use qr2term::print_qr;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sodiumoxide::crypto::{pwhash::argon2id13 as pwhash, secretbox::xsalsa20poly1305 as secretbox};
+use zeroize::Zeroizing;
 
 //NOTE: The ops and memlimits are set lower than the CLI wallet uses for itself because
 //      initial testing on the mobile devices found SENSITIVE settings took too long.
@@ -53,11 +53,16 @@ impl Cmd {
                 Ok(())
             }
             OutputFormat::Key => {
-                println!("{}", &serde_json::to_string(&keypair.secret())?);
+                let secret = Zeroizing::new(keypair.secret());
+                let json = Zeroizing::new(serde_json::to_string(secret.as_slice())?);
+                let json = json.as_str();
+                println!("{json}");
                 Ok(())
             }
             OutputFormat::Seed => {
-                println!("{}", &keypair.phrase()?);
+                let phrase = Zeroizing::new(keypair.phrase()?);
+                let phrase = phrase.as_str();
+                println!("{phrase}");
                 Ok(())
             }
         }
@@ -71,8 +76,7 @@ impl Cmd {
 ///  3) base64 encode the salt, the nonce, and the encrypted result so it is easier to
 ///     render in JSON later.
 pub fn encrypt_seed_v1(keypair: &Keypair, password: &String) -> Result<EncryptedSeed> {
-    let address = keypair.pubkey().to_string();
-    let phrase = keypair.phrase()?;
+    let phrase = Zeroizing::new(keypair.phrase()?);
 
     let hasher = Argon2id13::with_limits(ARGON_OPS_LIMIT, ARGON_MEM_LIMIT);
     let mut key = secretbox::Key([0; secretbox::KEYBYTES]);
@@ -82,24 +86,12 @@ pub fn encrypt_seed_v1(keypair: &Keypair, password: &String) -> Result<Encrypted
     let nonce = secretbox::gen_nonce();
     let ciphertext = secretbox::seal(phrase.as_bytes(), &nonce, &key);
 
-    let result = EncryptedSeed {
+    Ok(EncryptedSeed {
         version: 1,
         salt: b64::encode(hasher.salt()),
         nonce: b64::encode(nonce),
         ciphertext: b64::encode(ciphertext),
-    };
-
-    if cfg!(debug_assertions) {
-        println!("DEBUG encrypt_seed_v1:  password: {password}");
-        println!("DEBUG encrypt_seed_v1:  key: {}", b64::encode(key));
-        let json_data = json!({
-            "address": address,
-            "seed": result,
-        });
-        print_json(&json_data)?;
-    };
-
-    Ok(result)
+    })
 }
 
 /// Decrypt an EncryptedSeed that was encrypted by encrypt_seed_v1
@@ -117,12 +109,6 @@ pub fn decrypt_seed_v1(es: &EncryptedSeed, password: &String) -> Result<String> 
 
     let nonce: [u8; secretbox::NONCEBYTES] = b64::decode(&es.nonce)?.as_slice().try_into()?;
     let ciphertext = b64::decode(&es.ciphertext)?;
-
-    if cfg!(debug_assertions) {
-        println!("DEBUG decrypt_seed_v1: password: {password}");
-        println!("DEBUG decrypt_seed_v1: es: {es:?}");
-        println!("DEBUG decrypt_seed_v1: nonce: {nonce:?}, salt: {salt:?}");
-    };
 
     if let Ok(decrypted_bytes) = secretbox::open(&ciphertext, &secretbox::Nonce(nonce), &key) {
         String::from_utf8(decrypted_bytes).map_err(anyhow::Error::from)

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -23,6 +23,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use zeroize::Zeroizing;
 
 pub mod assets;
 pub mod balance;
@@ -312,30 +313,38 @@ impl std::str::FromStr for Transaction {
     }
 }
 
-fn get_wallet_password(confirm: bool) -> std::io::Result<String> {
+fn get_wallet_password(confirm: bool) -> std::io::Result<Zeroizing<String>> {
     match env::var("HELIUM_WALLET_PASSWORD") {
-        Ok(str) => Ok(str),
+        Ok(str) => Ok(Zeroizing::new(str)),
         _ => get_password("Wallet Password", confirm),
     }
 }
 
-fn get_password(prompt: &str, confirm: bool) -> std::io::Result<String> {
+fn get_password(prompt: &str, confirm: bool) -> std::io::Result<Zeroizing<String>> {
     use dialoguer::Password;
     let mut builder = Password::new();
     builder.with_prompt(prompt);
     if confirm {
         builder.with_confirmation("Confirm password", "Passwords do not match");
     };
-    builder.interact()
+    builder.interact().map(Zeroizing::new)
 }
 
+/// Open `filename` for writing, restricting access to the owner on Unix.
+/// Used for outputs that may contain key material.
 pub fn open_output_file(filename: &Path, create: bool) -> io::Result<fs::File> {
-    fs::OpenOptions::new()
+    let mut options = fs::OpenOptions::new();
+    options
         .write(true)
         .create(true)
         .create_new(create)
-        .truncate(true)
-        .open(filename)
+        .truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(filename)
 }
 
 pub fn get_file_extension(filename: &Path) -> String {

--- a/helium-wallet/src/cmd/swap.rs
+++ b/helium-wallet/src/cmd/swap.rs
@@ -32,7 +32,7 @@ impl Cmd {
         let input_mint = self.input_token.mint();
         let output_mint = self.output_token.mint();
         let raw_amount =
-            helium_lib::token::TokenAmount::from_f64(self.input_token, self.amount).amount;
+            helium_lib::token::TokenAmount::from_f64(self.input_token, self.amount)?.amount;
 
         let (tx, _, order) = jupiter_client
             .swap(&client, input_mint, output_mint, raw_amount, &*signer)

--- a/helium-wallet/src/cmd/transfer.rs
+++ b/helium-wallet/src/cmd/transfer.rs
@@ -54,16 +54,14 @@ pub struct One {
     commit: CommitOpts,
 }
 
-/// Multiple playment descriptor file
+/// Multiple payment descriptor file
 ///
 /// The input file for multiple payments is expected to be json file with a list
-/// of payees, amounts, tokens, and optional memos.
+/// of payees, amounts, and tokens.
 /// Notes:
 ///   "address" is required.
-///   "amount" is required. It must be a number or the string "max". When "max"
-///            the entire balance (minus fees) will be sent.
-///   "token" is optional and defaults to "hnt".
-///   "memo" is optional.
+///   "amount" is required and must be a positive number.
+///   "token" is required.
 ///
 /// For example:
 ///
@@ -71,15 +69,10 @@ pub struct One {
 ///     {
 ///         "address": "<address1>",
 ///         "amount": 1.6,
-///         "memo": "AAAAAAAAAAA=",
 ///         "token": "hnt"
 ///     },
 ///     {
 ///         "address": "<address2>",
-///         "amount": "max"
-///     },
-///     {
-///         "address": "<address3>",
 ///         "amount": 3,
 ///         "token": "mobile"
 ///     }
@@ -143,15 +136,14 @@ impl PayCmd {
 
     fn collect_payments(&self) -> Result<Vec<(Pubkey, TokenAmount)>> {
         match &self {
-            Self::One(one) => Ok(vec![(one.payee.address, one.payee.token_amount())]),
+            Self::One(one) => Ok(vec![(one.payee.address, one.payee.token_amount()?)]),
             Self::Multi(multi) => {
                 let file = std::fs::File::open(multi.path.clone())?;
                 let payees: Vec<Payee> = serde_json::from_reader(file)?;
-                let payments = payees
+                payees
                     .iter()
-                    .map(|p| (p.address, p.token_amount()))
-                    .collect();
-                Ok(payments)
+                    .map(|p| Ok((p.address, p.token_amount()?)))
+                    .collect()
             }
         }
     }
@@ -164,7 +156,11 @@ impl PayCmd {
     }
 }
 
+// deny_unknown_fields so a typo'd or unsupported key in a multi-payment
+// file (e.g. "memo", which the old doc advertised but was silently
+// dropped) is an error instead of being ignored.
 #[derive(Debug, Deserialize, clap::Args)]
+#[serde(deny_unknown_fields)]
 pub struct Payee {
     /// Address to send the tokens to.
     #[serde(with = "serde_pubkey")]
@@ -177,8 +173,8 @@ pub struct Payee {
 }
 
 impl Payee {
-    pub fn token_amount(&self) -> TokenAmount {
-        TokenAmount::from_f64(self.token, self.amount)
+    pub fn token_amount(&self) -> Result<TokenAmount> {
+        Ok(TokenAmount::from_f64(self.token, self.amount)?)
     }
 }
 
@@ -200,7 +196,7 @@ mod tests {
                 amount: 160_000_000,
                 token: Token::Hnt
             },
-            payee.token_amount()
+            payee.token_amount().expect("token amount")
         );
     }
 
@@ -218,7 +214,7 @@ mod tests {
                 amount: 500_000,
                 token: Token::Mobile
             },
-            payee.token_amount()
+            payee.token_amount().expect("token amount")
         );
     }
 

--- a/helium-wallet/src/format.rs
+++ b/helium-wallet/src/format.rs
@@ -8,6 +8,7 @@ use sha2::Sha256;
 use shamirsecretsharing::hazmat::{combine_keyshares, create_keyshares};
 use sodiumoxide::randombytes;
 use std::{fmt, io};
+use zeroize::Zeroizing;
 
 #[derive(Clone)]
 pub enum Format {
@@ -135,13 +136,16 @@ impl Sharded {
     pub fn derive_key(&mut self, password: &[u8], key: &mut [u8]) -> Result {
         self.pwhash.pwhash(password, key)?;
 
-        let mut sss_key: [u8; 32] = [0; 32];
+        let mut sss_key: Zeroizing<[u8; 32]> = Zeroizing::new([0; 32]);
 
         if self.key_shares.is_empty() {
             // Generate the keyhares when we have none
-            randombytes::randombytes_into(&mut sss_key);
-            let key_share_vecs =
-                create_keyshares(&sss_key, self.key_share_count, self.recovery_threshold)?;
+            randombytes::randombytes_into(sss_key.as_mut());
+            let key_share_vecs = create_keyshares(
+                sss_key.as_ref(),
+                self.key_share_count,
+                self.recovery_threshold,
+            )?;
             let mut key_shares = vec![];
             for share_vec in key_share_vecs {
                 key_shares.push(KeyShare::from_slice(&share_vec));
@@ -154,7 +158,7 @@ impl Sharded {
             // Reconstruct shared key
             let key_share_vecs: Vec<Vec<u8>> =
                 self.key_shares.iter().map(|sh| sh.to_vec()).collect();
-            match combine_keyshares(&key_share_vecs) {
+            match combine_keyshares(&key_share_vecs).map(Zeroizing::new) {
                 Ok(k) => sss_key.copy_from_slice(&k),
                 Err(_) => bail!("Failed to combine keyshares"),
             }
@@ -162,7 +166,7 @@ impl Sharded {
 
         // Now go derive the encryption key from the sharded key
         // source and the stretched key
-        let mut hmac = match Hmac::<Sha256>::new_from_slice(&sss_key) {
+        let mut hmac = match Hmac::<Sha256>::new_from_slice(sss_key.as_ref()) {
             Err(_) => bail!("Failed to initialize hmac"),
             Ok(m) => m,
         };

--- a/helium-wallet/src/wallet.rs
+++ b/helium-wallet/src/wallet.rs
@@ -15,6 +15,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use zeroize::Zeroizing;
 
 pub type Tag = [u8; 16];
 pub type Iv = [u8; 12];
@@ -47,15 +48,15 @@ impl Wallet {
     }
 
     pub fn encrypt(keypair: &Keypair, password: &[u8], fmt: Format) -> Result<Wallet> {
-        let mut encryption_key = AesKey::default();
+        let mut encryption_key = Zeroizing::new(AesKey::default());
         let mut format = fmt;
         let public_key = keypair.pubkey();
-        format.derive_key(password, &mut encryption_key)?;
+        format.derive_key(password, encryption_key.as_mut())?;
 
         let mut iv = Iv::default();
         randombytes::randombytes_into(&mut iv);
 
-        let aead = Aes256Gcm::new(GenericArray::from_slice(&encryption_key));
+        let aead = Aes256Gcm::new(GenericArray::from_slice(encryption_key.as_ref()));
 
         let mut encrypted = vec![];
         keypair.write(&mut encrypted)?;
@@ -79,11 +80,11 @@ impl Wallet {
     }
 
     pub fn decrypt(&self, password: &[u8]) -> Result<Arc<Keypair>> {
-        let mut encryption_key = AesKey::default();
+        let mut encryption_key = Zeroizing::new(AesKey::default());
         let mut format = self.format.clone();
-        format.derive_key(password, &mut encryption_key)?;
+        format.derive_key(password, encryption_key.as_mut())?;
 
-        let aead = Aes256Gcm::new(GenericArray::from_slice(&encryption_key));
+        let aead = Aes256Gcm::new(GenericArray::from_slice(encryption_key.as_ref()));
         let pubkey_bytes: Vec<u8> = match self.kind {
             WALLET_KIND_BASIC_V1
             | WALLET_KIND_BASIC_V2
@@ -102,12 +103,12 @@ impl Wallet {
             _ => unreachable!(),
         };
 
-        let mut buffer = self.encrypted.to_owned();
+        let mut buffer = Zeroizing::new(self.encrypted.to_owned());
         if aead
             .decrypt_in_place_detached(
                 self.iv.as_ref().into(),
                 &pubkey_bytes,
-                &mut buffer,
+                buffer.as_mut(),
                 self.tag.as_ref().into(),
             )
             .is_err()
@@ -290,7 +291,7 @@ pub struct Builder {
     output: PathBuf,
 
     /// Password to access wallet
-    password: String,
+    password: Zeroizing<String>,
 
     pwhash: PwHash,
 
@@ -298,7 +299,7 @@ pub struct Builder {
     force: bool,
 
     /// The entropy used to create this wallet
-    entropy: Option<Vec<u8>>,
+    entropy: Option<Zeroizing<Vec<u8>>>,
 
     /// Optional shard config info to use in order to create a sharded wallet
     /// otherwise, creates a basic non-sharded wallet
@@ -331,6 +332,13 @@ impl Builder {
         self
     }
 
+    /// The entropy used to create this wallet
+    /// Defaults to None
+    pub fn entropy(mut self, entropy: Option<Vec<u8>>) -> Builder {
+        self.entropy = entropy.map(Zeroizing::new);
+        self
+    }
+
     /// Sets the wallet's password hasher
     /// Defaults to `PwHash::argon2id13_default()`
     pub fn pwhash(mut self, pwhash: PwHash) -> Builder {
@@ -342,13 +350,6 @@ impl Builder {
     /// Defaults to false
     pub fn force(mut self, overwrite: bool) -> Builder {
         self.force = overwrite;
-        self
-    }
-
-    /// The entropy used to create this wallet
-    /// Defaults to None
-    pub fn entropy(mut self, entropy: Option<Vec<u8>>) -> Builder {
-        self.entropy = entropy;
         self
     }
 
@@ -408,7 +409,7 @@ impl Default for Builder {
     }
 }
 
-fn gen_keypair(entropy: Option<Vec<u8>>) -> Result<Arc<Keypair>> {
+fn gen_keypair(entropy: Option<Zeroizing<Vec<u8>>>) -> Result<Arc<Keypair>> {
     // Callers of this function should either have Some of both or None of both.
     // Anything else is an error.
     match entropy {
@@ -417,13 +418,21 @@ fn gen_keypair(entropy: Option<Vec<u8>>) -> Result<Arc<Keypair>> {
     }
 }
 
+/// Open `filename` for writing, restricting access to the owner on Unix
+/// since the file holds (encrypted) key material.
 fn open_output_file(filename: &Path, create: bool) -> io::Result<fs::File> {
-    fs::OpenOptions::new()
+    let mut options = fs::OpenOptions::new();
+    options
         .write(true)
         .create(true)
         .truncate(true)
-        .create_new(create)
-        .open(filename)
+        .create_new(create);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(filename)
 }
 
 //


### PR DESCRIPTION
Security fixes from a review of key-material and amount handling.

## Debug builds printed secrets

`encrypt_seed_v1` / `decrypt_seed_v1` contained `if cfg!(debug_assertions)` blocks that printed the wallet password, the base64 of the derived encryption key, and the full address+seed JSON to stdout. Any plain `cargo build` / `cargo run` hit these. Both blocks are deleted.

## Zeroization

No buffer holding key material was scrubbed before drop. Now wrapped in `Zeroizing`:

- derived AES key and the decrypted keypair buffer in `Wallet::encrypt` / `Wallet::decrypt`
- the Shamir `sss_key`, both when generated and when recombined from shares
- wallet passwords returned by the password prompts (env var and interactive)
- the wallet builder's password and entropy fields
- the exported secret key / seed phrase strings in `export`

`Keypair::secret()` also previously built its result via `to_vec()` + `extend_from_slice`, which can reallocate and leave the first copy of the secret bytes unscrubbed; it now allocates the full 64 bytes up-front. No API change.

The inner ed25519-dalek `SecretKey` and sodiumoxide types already zeroize on drop; this covers the copies this codebase makes around them.

## File permissions

Wallet key files (and the hotspot cert private-key output) were written with umask-default permissions, typically `0644`. Both `open_output_file` helpers now set `mode(0o600)` on Unix.

## Token amount validation

`TokenAmount::from_f64` cast `amount * 10^decimals` straight to `u64`: negative and NaN inputs became 0, infinities saturated to `u64::MAX`, and values past f64's exact integer range silently lost base units — so a malformed multi-payment file could sign a different amount than written. `from_f64` now returns a `Result` rejecting all of those, and every caller propagates the error.

The multi-payment file doc/parser also matched reality poorly: the doc advertised `"amount": "max"` (never accepted by the `f64` field) and an optional `"memo"` that serde silently dropped. The doc now describes the actual format, and `Payee` denies unknown fields so a typo'd key errors instead of producing a silently wrong payment.

## Verification

- CI-exact commands pass locally: `cargo fmt -- --check`, `cargo clippy --all-features --locked -- -D clippy::all`, `cargo test --locked`, `cargo build --all --locked --release`
- Functional checks: created a wallet (file is `-rw-------`); `export --output seed` from a debug build prints no DEBUG output; multi-payment files with a negative amount, an unknown `memo` field, and `"amount": "max"` are each rejected with a clear error
- New unit test covers `from_f64` rejection of negative/NaN/infinite/oversized amounts