### PR TITLE
chore: dedupe transaction framing, squads options, and twin commands

### DIFF
--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -8,11 +8,10 @@ use crate::{
     helium_entity_manager,
     keypair::{serde_opt_pubkey, serde_pubkey, Pubkey},
     kta, message,
-    priority_fee::{compute_budget_instruction, compute_price_instruction_for_accounts},
     programs::{SPL_NOOP_PROGRAM_ID, TOKEN_METADATA_PROGRAM_ID},
     solana_sdk::{account::Account, instruction::Instruction},
     spl_account_compression,
-    transaction::{mk_transaction, VersionedTransaction},
+    transaction::{mk_signed_transaction, mk_transaction, VersionedTransaction},
     TransactionOpts,
 };
 use futures::{stream, StreamExt, TryStreamExt};
@@ -523,14 +522,8 @@ pub async fn transfer_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     let (asset, asset_proof) = get_with_proof(client, pubkey).await?;
     let ix = transfer_instruction(recipient, &asset, &asset_proof)?;
 
-    let ixs = &[
-        compute_budget_instruction(200_000),
-        compute_price_instruction_for_accounts(client, &ix.accounts, opts.fee_range()).await?,
-        ix,
-    ];
-
     let (msg, block_height) =
-        message::mk_message(client, ixs, &opts.lut_addresses, &asset.ownership.owner).await?;
+        message::mk_budgeted_message(client, 200_000, &[ix], &asset.ownership.owner, opts).await?;
     let txn = mk_transaction(msg, &[&NullSigner::new(&asset.ownership.owner)])?;
     Ok((txn, block_height))
 }
@@ -605,12 +598,11 @@ pub async fn fetch_burn_instruction<C: AsRef<SolanaRpcClient> + AsRef<DasClient>
 /// so the user can compare against the Squads UI.
 fn check_owner(asset_id: &Pubkey, asset: &Asset, expected: &Pubkey) -> Result<(), Error> {
     if asset.ownership.owner != *expected {
-        return Err(crate::squads::SquadsError::WrongAssetOwner {
+        return Err(Error::WrongAssetOwner {
             asset: *asset_id,
             actual: asset.ownership.owner,
             expected: *expected,
-        }
-        .into());
+        });
     }
     Ok(())
 }
@@ -624,13 +616,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     let (asset, asset_proof) = get_with_proof(client, pubkey).await?;
     let ix = burn_instruction(&asset, &asset_proof)?;
 
-    let ixs = &[
-        compute_budget_instruction(100_000),
-        compute_price_instruction_for_accounts(client, &ix.accounts, opts.fee_range()).await?,
-        ix,
-    ];
-
-    message::mk_message(client, ixs, &opts.lut_addresses, &asset.ownership.owner).await
+    message::mk_budgeted_message(client, 100_000, &[ix], &asset.ownership.owner, opts).await
 }
 
 /// Signs and returns a transaction to permanently burn (destroy) a compressed NFT.
@@ -640,9 +626,8 @@ pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
-    let (msg, block_height) = burn_message(client, pubkey, opts).await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = burn_message(client, pubkey, opts).await?;
+    mk_signed_transaction(msg, &[keypair])
 }
 
 /// A paginated list of compressed NFT assets returned from a DAS search.

--- a/helium-lib/src/boosting.rs
+++ b/helium-lib/src/boosting.rs
@@ -4,7 +4,7 @@ use crate::{
     error::Error,
     hexboosting,
     keypair::Pubkey,
-    message, priority_fee,
+    message,
     solana_sdk::{instruction::Instruction, signer::Signer},
     transaction, TransactionOpts,
 };
@@ -41,7 +41,6 @@ pub async fn start_boost_message<C: AsRef<SolanaRpcClient>>(
         }
     }
 
-    let mut ix_accounts = vec![];
     let mut start_ixs = vec![];
     for update in updates {
         let accounts = mk_accounts(
@@ -49,11 +48,9 @@ pub async fn start_boost_message<C: AsRef<SolanaRpcClient>>(
             update.boost_config(),
             update.boosted_hex(),
         );
-        let accounts = accounts.to_account_metas(None);
-        ix_accounts.extend_from_slice(&accounts);
         let ix = Instruction {
             program_id: hexboosting::ID,
-            accounts,
+            accounts: accounts.to_account_metas(None),
             data: hexboosting::client::args::StartBoostV0 {
                 args: hexboosting::types::StartBoostArgsV0 {
                     start_ts: update.activation_ts().timestamp(),
@@ -63,20 +60,7 @@ pub async fn start_boost_message<C: AsRef<SolanaRpcClient>>(
         };
         start_ixs.push(ix);
     }
-    let ixs = [
-        &[
-            priority_fee::compute_budget_instruction(150_000),
-            priority_fee::compute_price_instruction_for_accounts(
-                client,
-                &ix_accounts,
-                opts.fee_range(),
-            )
-            .await?,
-        ],
-        start_ixs.as_slice(),
-    ]
-    .concat();
-    message::mk_message(client, &ixs, &opts.lut_addresses, &keypair.pubkey()).await
+    message::mk_budgeted_message(client, 150_000, &start_ixs, &keypair.pubkey(), opts).await
 }
 
 /// Activate hex boosting and return a signed transaction.
@@ -86,7 +70,6 @@ pub async fn start_boost<C: AsRef<SolanaRpcClient>>(
     keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(transaction::VersionedTransaction, u64), Error> {
-    let (msg, block_height) = start_boost_message(client, keypair, updates, opts).await?;
-    let txn = transaction::mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = start_boost_message(client, keypair, updates, opts).await?;
+    transaction::mk_signed_transaction(msg, &[keypair])
 }

--- a/helium-lib/src/dc.rs
+++ b/helium-lib/src/dc.rs
@@ -8,10 +8,10 @@ use crate::{
     error::{DecodeError, Error},
     helium_sub_daos,
     keypair::Pubkey,
-    message, priority_fee,
+    message,
     solana_sdk::{instruction::Instruction, signer::Signer},
     token::{Token, TokenAmount},
-    transaction::{mk_transaction, VersionedTransaction},
+    transaction::{mk_signed_transaction, VersionedTransaction},
     TransactionOpts,
 };
 
@@ -72,17 +72,7 @@ pub async fn mint_message<C: AsRef<SolanaRpcClient>>(
     opts: &TransactionOpts,
 ) -> Result<(message::VersionedMessage, u64), Error> {
     let ix = mint_instruction(client, amount, payee, payer).await?;
-    let ixs = &[
-        priority_fee::compute_budget_instruction(300_000),
-        priority_fee::compute_price_instruction_for_accounts(
-            client,
-            &ix.accounts,
-            opts.fee_range(),
-        )
-        .await?,
-        ix,
-    ];
-    message::mk_message(client, ixs, &opts.lut_addresses, payer).await
+    message::mk_budgeted_message(client, 300_000, &[ix], payer, opts).await
 }
 
 /// Mints data credits by burning HNT and returns a signed transaction.
@@ -93,9 +83,8 @@ pub async fn mint<C: AsRef<SolanaRpcClient>>(
     keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
-    let (msg, block_height) = mint_message(client, amount, payee, &keypair.pubkey(), opts).await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = mint_message(client, amount, payee, &keypair.pubkey(), opts).await?;
+    mk_signed_transaction(msg, &[keypair])
 }
 
 /// Build the bare DC-delegate instruction (no compute-budget framing).
@@ -144,18 +133,7 @@ pub async fn delegate_message<C: AsRef<SolanaRpcClient>>(
     opts: &TransactionOpts,
 ) -> Result<(message::VersionedMessage, u64), Error> {
     let ix = delegate_instruction(subdao, payer_key, amount, owner);
-
-    let ixs = &[
-        priority_fee::compute_budget_instruction(150_000),
-        priority_fee::compute_price_instruction_for_accounts(
-            client,
-            &ix.accounts,
-            opts.fee_range(),
-        )
-        .await?,
-        ix,
-    ];
-    message::mk_message(client, ixs, &opts.lut_addresses, owner).await
+    message::mk_budgeted_message(client, 150_000, &[ix], owner, opts).await
 }
 
 /// Delegates data credits to a router/OUI and returns a signed transaction.
@@ -167,10 +145,8 @@ pub async fn delegate<C: AsRef<SolanaRpcClient>>(
     keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
-    let (msg, block_height) =
-        delegate_message(client, subdao, payer_key, amount, &keypair.pubkey(), opts).await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = delegate_message(client, subdao, payer_key, amount, &keypair.pubkey(), opts).await?;
+    mk_signed_transaction(msg, &[keypair])
 }
 
 /// Build the bare DC-burn instruction (no compute-budget framing).
@@ -205,18 +181,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
     opts: &TransactionOpts,
 ) -> Result<(message::VersionedMessage, u64), Error> {
     let ix = burn_instruction(amount, owner);
-
-    let ixs = &[
-        priority_fee::compute_budget_instruction(150_000),
-        priority_fee::compute_price_instruction_for_accounts(
-            client,
-            &ix.accounts,
-            opts.fee_range(),
-        )
-        .await?,
-        ix,
-    ];
-    message::mk_message(client, ixs, &opts.lut_addresses, owner).await
+    message::mk_budgeted_message(client, 150_000, &[ix], owner, opts).await
 }
 
 /// Burns data credits and returns a signed transaction.
@@ -226,9 +191,8 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
     keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
-    let (msg, block_height) = burn_message(client, amount, &keypair.pubkey(), opts).await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = burn_message(client, amount, &keypair.pubkey(), opts).await?;
+    mk_signed_transaction(msg, &[keypair])
 }
 
 /// Builds a message that burns delegated data credits for a router.
@@ -290,17 +254,7 @@ pub async fn burn_delegated_message<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
         .data(),
     };
 
-    let ixs = &[
-        priority_fee::compute_budget_instruction(150_000),
-        priority_fee::compute_price_instruction_for_accounts(
-            client,
-            &burn_ix.accounts,
-            opts.fee_range(),
-        )
-        .await?,
-        burn_ix,
-    ];
-    message::mk_message(client, ixs, &opts.lut_addresses, payer).await
+    message::mk_budgeted_message(client, 150_000, &[burn_ix], payer, opts).await
 }
 
 /// Burns delegated data credits and returns a signed transaction.
@@ -312,9 +266,7 @@ pub async fn burn_delegated<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     router_key: &E,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
-    let (msg, block_height) =
-        burn_delegated_message(client, sub_dao, amount, router_key, &keypair.pubkey(), opts)
-            .await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = burn_delegated_message(client, sub_dao, amount, router_key, &keypair.pubkey(), opts)
+        .await?;
+    mk_signed_transaction(msg, &[keypair])
 }

--- a/helium-lib/src/error.rs
+++ b/helium-lib/src/error.rs
@@ -45,7 +45,7 @@ pub enum Error {
     #[error("confirmation: {0}")]
     Confirmation(#[from] ConfirmationError),
     #[error("message: {0}")]
-    Cmopile(#[from] solana_sdk::message::CompileError),
+    Compile(#[from] solana_sdk::message::CompileError),
     #[error("signing: {0}")]
     Signing(#[from] solana_sdk::signer::SignerError),
     #[error("crypto: {0}")]
@@ -60,6 +60,17 @@ pub enum Error {
     Jupiter(#[from] jupiter::JupiterError),
     #[error("squads: {0}")]
     Squads(#[from] squads::SquadsError),
+    /// Asset owner doesn't match the caller's expectation. Surfaced by
+    /// owner pre-checks (e.g. the Squads-mode asset/hotspot wrappers,
+    /// which enforce this so a proposer can't ship an un-executable
+    /// proposal whose `leaf_owner` the vault can't satisfy at execute
+    /// time) with both addresses so the user can compare.
+    #[error("asset {asset} is owned by {actual}, expected {expected}")]
+    WrongAssetOwner {
+        asset: solana_sdk::pubkey::Pubkey,
+        actual: solana_sdk::pubkey::Pubkey,
+        expected: solana_sdk::pubkey::Pubkey,
+    },
 }
 
 impl From<solana_client::client_error::ClientError> for Error {

--- a/helium-lib/src/hotspot/dataonly.rs
+++ b/helium-lib/src/hotspot/dataonly.rs
@@ -9,7 +9,7 @@ use crate::{
     helium_entity_manager, helium_sub_daos, hotspot,
     hotspot::{HotspotInfoUpdate, ECC_VERIFIER},
     keypair::Pubkey,
-    kta, message, priority_fee,
+    kta, message,
     programs::{SPL_NOOP_PROGRAM_ID, TOKEN_METADATA_PROGRAM_ID},
     solana_sdk::{
         instruction::Instruction,
@@ -273,18 +273,8 @@ async fn build_onboard_transaction<
         assertion,
         owner,
     )?;
-    let ixs = &[
-        priority_fee::compute_budget_instruction(300_000),
-        priority_fee::compute_price_instruction_for_accounts(
-            client,
-            &ix.accounts,
-            opts.fee_range(),
-        )
-        .await?,
-        ix,
-    ];
     let (msg, block_height) =
-        message::mk_message(client, ixs, &opts.lut_addresses, &asset.ownership.owner).await?;
+        message::mk_budgeted_message(client, 300_000, &[ix], &asset.ownership.owner, opts).await?;
     let txn = mk_transaction(msg, &[&NullSigner::new(&asset.ownership.owner)])?;
     Ok((txn, block_height))
 }
@@ -398,14 +388,8 @@ pub async fn issue_transaction<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
         .data(),
     };
 
-    let ixs = &[
-        priority_fee::compute_budget_instruction(300_000),
-        priority_fee::compute_price_instruction_for_accounts(client, &accounts, opts.fee_range())
-            .await?,
-        issue_ix,
-    ];
-
-    let (msg, block_height) = message::mk_message(client, ixs, &opts.lut_addresses, &owner).await?;
+    let (msg, block_height) =
+        message::mk_budgeted_message(client, 300_000, &[issue_ix], &owner, opts).await?;
     let txn = mk_transaction(
         msg,
         &[

--- a/helium-lib/src/hotspot/mod.rs
+++ b/helium-lib/src/hotspot/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{DecodeError, EncodeError, Error},
     helium_entity_manager, is_zero,
     keypair::{pubkey, serde_opt_pubkey, serde_pubkey, Pubkey},
-    kta, message, onboarding, priority_fee,
+    kta, message, onboarding,
     solana_sdk::{
         instruction::{AccountMeta, Instruction},
         signer::Signer,
@@ -230,18 +230,8 @@ pub async fn direct_update_transaction<C: AsRef<SolanaRpcClient> + AsRef<DasClie
     let (asset, asset_proof) = asset::for_kta_with_proof(&client, &kta).await?;
     let ix = direct_update_instruction(&kta, &asset, &asset_proof, update, owner)?;
 
-    let ixs = &[
-        priority_fee::compute_budget_instruction(200_000),
-        priority_fee::compute_price_instruction_for_accounts(
-            client,
-            &ix.accounts,
-            opts.fee_range(),
-        )
-        .await?,
-        ix,
-    ];
-
-    let (msg, block_height) = message::mk_message(client, ixs, &opts.lut_addresses, owner).await?;
+    let (msg, block_height) =
+        message::mk_budgeted_message(client, 200_000, &[ix], owner, opts).await?;
     let txn = mk_transaction(msg, &[&NullSigner::new(owner)])?;
     Ok((txn, block_height))
 }

--- a/helium-lib/src/memo.rs
+++ b/helium-lib/src/memo.rs
@@ -1,6 +1,6 @@
 use crate::{
-    client::SolanaRpcClient, error::Error, keypair::Pubkey, message, priority_fee,
-    solana_sdk::signer::Signer, transaction, TransactionOpts,
+    client::SolanaRpcClient, error::Error, keypair::Pubkey, message, solana_sdk::signer::Signer,
+    transaction, TransactionOpts,
 };
 
 /// Builds a message that records an on-chain memo.
@@ -11,18 +11,7 @@ pub async fn memo_message<C: AsRef<SolanaRpcClient>>(
     opts: &TransactionOpts,
 ) -> Result<(message::VersionedMessage, u64), Error> {
     let ix = spl_memo::build_memo(data.as_bytes(), &[pubkey]);
-    let ixs = &[
-        priority_fee::compute_budget_instruction(200_000),
-        priority_fee::compute_price_instruction_for_accounts(
-            client,
-            &ix.accounts,
-            opts.fee_range(),
-        )
-        .await?,
-        ix,
-    ];
-
-    message::mk_message(client, ixs, &opts.lut_addresses, pubkey).await
+    message::mk_budgeted_message(client, 200_000, &[ix], pubkey, opts).await
 }
 
 /// Records an on-chain memo and returns a signed transaction.
@@ -32,7 +21,6 @@ pub async fn memo<C: AsRef<SolanaRpcClient>>(
     keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(transaction::VersionedTransaction, u64), Error> {
-    let (msg, block_height) = memo_message(client, data, &keypair.pubkey(), opts).await?;
-    let txn = transaction::mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = memo_message(client, data, &keypair.pubkey(), opts).await?;
+    transaction::mk_signed_transaction(msg, &[keypair])
 }

--- a/helium-lib/src/message.rs
+++ b/helium-lib/src/message.rs
@@ -1,12 +1,13 @@
 use crate::{
     client::SolanaRpcClient,
     keypair::pubkey,
+    priority_fee,
     solana_sdk::{
         address_lookup_table::{state::AddressLookupTable, AddressLookupTableAccount},
         instruction::Instruction,
         message::v0,
     },
-    Error, Pubkey,
+    Error, Pubkey, TransactionOpts,
 };
 use itertools::Itertools;
 
@@ -69,4 +70,24 @@ pub async fn mk_message<C: AsRef<SolanaRpcClient>>(
     let mut msg = mk_raw_message(ixs, &lut_accounts, payer)?;
     msg.set_recent_blockhash(recent_blockhash);
     Ok((msg, recent_blockheight))
+}
+
+/// Builds a versioned message like [`mk_message`], prepending a
+/// compute-budget instruction with the given compute unit limit and a
+/// compute-price instruction with a priority fee estimated from the
+/// writable accounts of `ixs`, clamped to the fee range in `opts`.
+pub async fn mk_budgeted_message<C: AsRef<SolanaRpcClient>>(
+    client: &C,
+    compute_limit: u32,
+    ixs: &[Instruction],
+    payer: &Pubkey,
+    opts: &TransactionOpts,
+) -> Result<(VersionedMessage, u64), Error> {
+    let budget_ixs = [
+        priority_fee::compute_budget_instruction(compute_limit),
+        priority_fee::compute_price_instruction_for_instructions(client, ixs, opts.fee_range())
+            .await?,
+    ];
+    let all_ixs = [&budget_ixs[..], ixs].concat();
+    mk_message(client, &all_ixs, &opts.lut_addresses, payer).await
 }

--- a/helium-lib/src/queue.rs
+++ b/helium-lib/src/queue.rs
@@ -1,10 +1,10 @@
 use crate::{
     client::{DasClient, GetAnchorAccount, SolanaRpcClient},
     error::Error,
-    message, priority_fee,
+    message,
     programs::hpl_crons,
     solana_sdk::{instruction::Instruction, pubkey},
-    transaction::{mk_transaction, VersionedTransaction},
+    transaction::{mk_signed_transaction, VersionedTransaction},
     Pubkey, TransactionOpts,
 };
 use anchor_lang::{InstructionData, ToAccountMetas};
@@ -78,19 +78,6 @@ pub async fn claim_wallet<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnch
     let task_queue = client.anchor_account(task_queue_key).await?;
 
     let ix = claim_wallet_instruction(task_queue_key, &task_queue, wallet, &keypair.pubkey())?;
-    let ixs = &[
-        priority_fee::compute_budget_instruction(100_000),
-        priority_fee::compute_price_instruction_for_accounts(
-            client,
-            &ix.accounts,
-            opts.fee_range(),
-        )
-        .await?,
-        ix,
-    ];
-
-    let (msg, block_height) =
-        message::mk_message(client, ixs, &opts.lut_addresses, &keypair.pubkey()).await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = message::mk_budgeted_message(client, 100_000, &[ix], &keypair.pubkey(), opts).await?;
+    mk_signed_transaction(msg, &[keypair])
 }

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -10,11 +10,11 @@ use crate::{
     keypair::Pubkey,
     kta, lazy_distributor,
     message::{self, mk_message},
-    priority_fee, rewards_oracle,
+    rewards_oracle,
     solana_sdk::{instruction::Instruction, signer::Signer, sysvar},
     spl_account_compression,
     token::{Token, TokenAmount},
-    transaction::{mk_transaction, VersionedTransaction},
+    transaction::{mk_signed_transaction, mk_transaction, VersionedTransaction},
     TransactionOpts,
 };
 use chrono::Utc;
@@ -921,17 +921,7 @@ pub mod recipient {
         let asset_with_proof = asset::for_kta_with_proof(client, &kta).await?;
 
         let ix = init_instruction(token, &kta, &asset_with_proof, payer)?;
-        let ixs = &[
-            priority_fee::compute_budget_instruction(INIT_INSTRUCTION_BUDGET),
-            priority_fee::compute_price_instruction_for_accounts(
-                client,
-                &ix.accounts,
-                opts.fee_range(),
-            )
-            .await?,
-            ix,
-        ];
-        message::mk_message(client, ixs, &opts.lut_addresses, payer).await
+        message::mk_budgeted_message(client, INIT_INSTRUCTION_BUDGET, &[ix], payer, opts).await
     }
 
     /// Signs and returns a transaction to initialize a recipient account.
@@ -942,10 +932,8 @@ pub mod recipient {
         keypair: &dyn Signer,
         opts: &TransactionOpts,
     ) -> Result<(VersionedTransaction, u64), Error> {
-        let (msg, block_height) =
-            init_message(client, token, entity_key, &keypair.pubkey(), opts).await?;
-        let txn = mk_transaction(msg, &[keypair])?;
-        Ok((txn, block_height))
+        let msg = init_message(client, token, entity_key, &keypair.pubkey(), opts).await?;
+        mk_signed_transaction(msg, &[keypair])
     }
 
     /// Resolves the actual reward destination for entities (custom destination or asset owner).
@@ -1101,33 +1089,17 @@ pub mod recipient {
             let kta = kta::for_entity_key(entity_key).await?;
             let asset_with_proof = asset::for_kta_with_proof(client, &kta).await?;
 
-            let mut ix_accounts = vec![];
             let init_ix = if recipient::for_kta(client, token, &kta).await?.is_none() {
-                let init_ix = init_instruction(token, &kta, &asset_with_proof, owner)?;
-                ix_accounts.extend_from_slice(&init_ix.accounts);
-                Some(init_ix)
+                Some(init_instruction(token, &kta, &asset_with_proof, owner)?)
             } else {
                 None
             };
             let update_ix = update_instruction(token, &kta, &asset_with_proof, destination)?;
-            ix_accounts.extend_from_slice(&update_ix.accounts);
-            let ixs = [
-                Some(priority_fee::compute_budget_instruction(200_000)),
-                Some(
-                    priority_fee::compute_price_instruction_for_accounts(
-                        client,
-                        &ix_accounts,
-                        opts.fee_range(),
-                    )
-                    .await?,
-                ),
-                init_ix,
-                Some(update_ix),
-            ]
-            .into_iter()
-            .flatten()
-            .collect_vec();
-            message::mk_message(client, &ixs, &opts.lut_addresses, owner).await
+            let ixs = [init_ix, Some(update_ix)]
+                .into_iter()
+                .flatten()
+                .collect_vec();
+            message::mk_budgeted_message(client, 200_000, &ixs, owner, opts).await
         }
 
         /// Signs and returns a transaction to update the reward destination.
@@ -1142,7 +1114,7 @@ pub mod recipient {
             keypair: &dyn Signer,
             opts: &TransactionOpts,
         ) -> Result<(VersionedTransaction, u64), Error> {
-            let (msg, block_height) = update_message(
+            let msg = update_message(
                 client,
                 token,
                 entity_key,
@@ -1151,9 +1123,7 @@ pub mod recipient {
                 opts,
             )
             .await?;
-
-            let txn = mk_transaction(msg, &[keypair])?;
-            Ok((txn, block_height))
+            mk_signed_transaction(msg, &[keypair])
         }
     }
 }

--- a/helium-lib/src/schedule.rs
+++ b/helium-lib/src/schedule.rs
@@ -4,11 +4,11 @@ use crate::{
     dao::Dao,
     entity_key::EncodedEntityKey,
     error::Error,
-    message, priority_fee,
+    message,
     programs::hpl_crons::{self, accounts::CronJobV0, types::RemoveEntityFromCronArgsV0},
     queue,
     solana_sdk::{instruction::Instruction, signer::Signer},
-    transaction::{mk_transaction, VersionedTransaction},
+    transaction::{mk_signed_transaction, VersionedTransaction},
     tuktuk_sdk::{
         tuktuk,
         tuktuk_program::{self, TaskQueueV0},
@@ -122,27 +122,10 @@ pub async fn init<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccoun
         solana_system_interface::instruction::transfer(&payer, &cron_job_key, amount)
     });
 
-    let ixs = [
-        Some(priority_fee::compute_budget_instruction(500_000)),
-        Some(
-            priority_fee::compute_price_instruction_for_accounts(
-                client,
-                &ix.accounts,
-                opts.fee_range(),
-            )
-            .await?,
-        ),
-        Some(ix),
-        fund_ix,
-    ]
-    .into_iter()
-    .flatten()
-    .collect_vec();
+    let ixs = [Some(ix), fund_ix].into_iter().flatten().collect_vec();
 
-    let (msg, block_height) =
-        message::mk_message(client, &ixs, &opts.lut_addresses, &keypair.pubkey()).await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = message::mk_budgeted_message(client, 500_000, &ixs, &keypair.pubkey(), opts).await?;
+    mk_signed_transaction(msg, &[keypair])
 }
 
 /// Builds an instruction to requeue an existing entity claim cron job.
@@ -214,21 +197,8 @@ pub async fn requeue<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAcc
         &keypair.pubkey(),
     )?;
 
-    let ixs = [
-        priority_fee::compute_budget_instruction(100_000),
-        priority_fee::compute_price_instruction_for_accounts(
-            client,
-            &ix.accounts,
-            opts.fee_range(),
-        )
-        .await?,
-        ix,
-    ];
-
-    let (msg, block_height) =
-        message::mk_message(client, &ixs, &opts.lut_addresses, &keypair.pubkey()).await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = message::mk_budgeted_message(client, 100_000, &[ix], &keypair.pubkey(), opts).await?;
+    mk_signed_transaction(msg, &[keypair])
 }
 
 /// Compute units needed to close a cron job.
@@ -318,45 +288,22 @@ pub async fn close<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccou
     let cron_job: CronJobV0 = client.anchor_account(cron_job_key).await?;
 
     let payer = keypair.pubkey();
-    let mut ix_accounts = vec![];
     let mut compute_budget = 0;
     let close_claim_ixs: Vec<Instruction> = (0..cron_job.next_transaction_id)
         .map(|cron_job_index| {
-            close_entity_claim_instruction(cron_job_key, cron_job_index, &payer).inspect(|ix| {
-                ix_accounts.extend_from_slice(&ix.accounts);
-                compute_budget += CU_CLOSE_ENTITY_CLAIM;
-            })
+            close_entity_claim_instruction(cron_job_key, cron_job_index, &payer)
+                .inspect(|_ix| compute_budget += CU_CLOSE_ENTITY_CLAIM)
         })
         .try_collect()?;
 
     let close_ix = close_instruction(cron_id, name, &keypair.pubkey())?;
-    ix_accounts.extend_from_slice(&close_ix.accounts);
     compute_budget += CU_CLOSE;
 
-    let ixs = &[
-        &[
-            priority_fee::compute_budget_instruction(compute_budget),
-            priority_fee::compute_price_instruction_for_accounts(
-                client,
-                &ix_accounts,
-                opts.fee_range(),
-            )
-            .await?,
-        ],
-        close_claim_ixs.as_slice(),
-        &[close_ix],
-    ]
-    .concat();
+    let ixs = [close_claim_ixs.as_slice(), &[close_ix]].concat();
 
-    let (msg, block_height) = message::mk_message(
-        client,
-        ixs.as_slice(),
-        &opts.lut_addresses,
-        &keypair.pubkey(),
-    )
-    .await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg =
+        message::mk_budgeted_message(client, compute_budget, &ixs, &keypair.pubkey(), opts).await?;
+    mk_signed_transaction(msg, &[keypair])
 }
 
 /// Builds an instruction to add a wallet claim to a cron job.
@@ -411,21 +358,8 @@ pub async fn claim_wallet<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnch
 ) -> Result<(VersionedTransaction, u64), Error> {
     let cron_job = client.anchor_account(cron_job_key).await?;
     let ix = claim_wallet_instruction(cron_job_key, &cron_job, wallet, &keypair.pubkey())?;
-    let ixs = &[
-        priority_fee::compute_budget_instruction(100_000),
-        priority_fee::compute_price_instruction_for_accounts(
-            client,
-            &ix.accounts,
-            opts.fee_range(),
-        )
-        .await?,
-        ix,
-    ];
-
-    let (msg, block_height) =
-        message::mk_message(client, ixs, &opts.lut_addresses, &keypair.pubkey()).await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = message::mk_budgeted_message(client, 100_000, &[ix], &keypair.pubkey(), opts).await?;
+    mk_signed_transaction(msg, &[keypair])
 }
 
 /// Builds an instruction to add an entity asset claim to a cron job.
@@ -482,19 +416,6 @@ pub async fn claim_asset<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAncho
     let entity_key = encoded_entity_key.as_entity_key()?;
     let kta_key = Dao::Hnt.entity_key_to_kta_key(&entity_key);
     let ix = claim_asset_instruction(cron_job_key, &cron_job, &kta_key, &keypair.pubkey())?;
-    let ixs = &[
-        priority_fee::compute_budget_instruction(100_000),
-        priority_fee::compute_price_instruction_for_accounts(
-            client,
-            &ix.accounts,
-            opts.fee_range(),
-        )
-        .await?,
-        ix,
-    ];
-
-    let (msg, block_height) =
-        message::mk_message(client, ixs, &opts.lut_addresses, &keypair.pubkey()).await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = message::mk_budgeted_message(client, 100_000, &[ix], &keypair.pubkey(), opts).await?;
+    mk_signed_transaction(msg, &[keypair])
 }

--- a/helium-lib/src/squads/error.rs
+++ b/helium-lib/src/squads/error.rs
@@ -103,17 +103,6 @@ pub enum SquadsError {
     Membership(#[from] SquadsMembershipError),
     #[error("encoding: {0}")]
     Encoding(#[from] SquadsEncodingError),
-    /// Asset owner doesn't match the expected vault. The Squads-mode
-    /// asset/hotspot wrappers enforce this so a proposer can't ship
-    /// an un-executable proposal whose `leaf_owner` the vault can't
-    /// satisfy at execute time. Single-variant outlier — kept directly
-    /// on `SquadsError` rather than carved into a one-variant sub-enum.
-    #[error("asset {asset} is owned by {actual}, expected {expected}")]
-    WrongAssetOwner {
-        asset: solana_sdk::pubkey::Pubkey,
-        actual: solana_sdk::pubkey::Pubkey,
-        expected: solana_sdk::pubkey::Pubkey,
-    },
 }
 
 /// JSON-RPC failure modes the squads module surfaces from raw

--- a/helium-lib/src/squads/v4.rs
+++ b/helium-lib/src/squads/v4.rs
@@ -2220,7 +2220,8 @@ mod tests {
             data: vec![9, 9, 9],
         };
         let bytes =
-            compile_transaction_message_with_luts(&vault, &[ix], &[lut.clone()]).expect("compact");
+            compile_transaction_message_with_luts(&vault, &[ix], std::slice::from_ref(&lut))
+                .expect("compact");
 
         // Header.
         assert_eq!(bytes[0], 1, "num_signers");
@@ -2324,13 +2325,21 @@ mod tests {
             ],
             data: vec![7; 16],
         };
-        let first = compile_transaction_message_with_luts(&vault, &[ix.clone()], &[lut.clone()])
-            .expect("compact");
+        let first = compile_transaction_message_with_luts(
+            &vault,
+            std::slice::from_ref(&ix),
+            std::slice::from_ref(&lut),
+        )
+        .expect("compact");
         for _ in 0..16 {
             assert_eq!(
                 first,
-                compile_transaction_message_with_luts(&vault, &[ix.clone()], &[lut.clone()])
-                    .expect("compact"),
+                compile_transaction_message_with_luts(
+                    &vault,
+                    std::slice::from_ref(&ix),
+                    std::slice::from_ref(&lut)
+                )
+                .expect("compact"),
                 "compactor output must be deterministic"
             );
         }
@@ -2351,7 +2360,8 @@ mod tests {
             ],
             data: vec![1, 2, 3, 4],
         };
-        let static_only = compile_transaction_message(&vault, &[ix.clone()]).expect("compact");
+        let static_only =
+            compile_transaction_message(&vault, std::slice::from_ref(&ix)).expect("compact");
         let with_empty_luts =
             compile_transaction_message_with_luts(&vault, &[ix], &[]).expect("compact");
         assert_eq!(static_only, with_empty_luts);
@@ -2474,7 +2484,8 @@ mod tests {
             data: vec![],
         };
         let bytes =
-            compile_transaction_message_with_luts(&vault, &[ix], &[lut.clone()]).expect("compact");
+            compile_transaction_message_with_luts(&vault, &[ix], std::slice::from_ref(&lut))
+                .expect("compact");
 
         // Static count = 2 (vault + program); both LUT keys are resolved.
         let static_count = bytes[3] as usize;
@@ -2604,13 +2615,13 @@ mod tests {
                 account_keys: static_keys.clone(),
                 instructions: vec![MultisigCompiledInstruction {
                     program_id_index: 2, // program
-                    account_indexes: vec![0, 3].try_into().unwrap(),
-                    data: vec![].try_into().unwrap(),
+                    account_indexes: vec![0, 3],
+                    data: vec![],
                 }],
                 address_table_lookups: vec![MultisigMessageAddressTableLookup {
                     account_key: lut_addr,
-                    writable_indexes: vec![0u8, 1u8].try_into().unwrap(),
-                    readonly_indexes: vec![2u8].try_into().unwrap(),
+                    writable_indexes: vec![0u8, 1u8],
+                    readonly_indexes: vec![2u8],
                 }],
             },
         };

--- a/helium-lib/src/token.rs
+++ b/helium-lib/src/token.rs
@@ -4,9 +4,9 @@ use crate::{
     client::SolanaRpcClient,
     error::{DecodeError, Error},
     keypair::{serde_pubkey, Pubkey},
-    message, priority_fee,
+    message,
     solana_sdk::{account::Account, signer::Signer},
-    transaction::{mk_transaction, VersionedTransaction},
+    transaction::{mk_signed_transaction, VersionedTransaction},
     TransactionOpts,
 };
 use chrono::{DateTime, Duration, Utc};
@@ -105,9 +105,8 @@ pub async fn burn<C: AsRef<SolanaRpcClient>>(
     keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
-    let (msg, block_height) = burn_message(client, token_amount, &keypair.pubkey(), opts).await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = burn_message(client, token_amount, &keypair.pubkey(), opts).await?;
+    mk_signed_transaction(msg, &[keypair])
 }
 
 /// Build the bare transfer instructions (no compute-budget framing) for
@@ -175,21 +174,7 @@ pub async fn transfer_message<C: AsRef<SolanaRpcClient>>(
                 }
             })
             .sum::<u32>();
-    let ixs_accounts: Vec<_> = ixs.iter().flat_map(|i| i.accounts.clone()).collect();
-    let final_ixs = &[
-        &[
-            priority_fee::compute_budget_instruction(cu_budget),
-            priority_fee::compute_price_instruction_for_accounts(
-                client,
-                &ixs_accounts,
-                opts.fee_range(),
-            )
-            .await?,
-        ],
-        ixs.as_slice(),
-    ]
-    .concat();
-    message::mk_message(client, final_ixs, &opts.lut_addresses, payer).await
+    message::mk_budgeted_message(client, cu_budget, &ixs, payer, opts).await
 }
 
 /// Transfer tokens to one or more recipients, returning a signed transaction.
@@ -199,9 +184,8 @@ pub async fn transfer<C: AsRef<SolanaRpcClient>>(
     keypair: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
-    let (msg, block_height) = transfer_message(client, transfers, &keypair.pubkey(), opts).await?;
-    let txn = mk_transaction(msg, &[keypair])?;
-    Ok((txn, block_height))
+    let msg = transfer_message(client, transfers, &keypair.pubkey(), opts).await?;
+    mk_signed_transaction(msg, &[keypair])
 }
 
 /// Builds a message to close multiple accounts and return funds to destination.
@@ -262,21 +246,7 @@ pub async fn close_accounts_message<C: AsRef<SolanaRpcClient>>(
         + system_ix.as_ref().map_or(0, |_| SYS_PROGRAM_TRANSFER_CU);
     let ixs = spl_ixs.into_iter().chain(system_ix).collect_vec();
 
-    let final_ixs = &[
-        &[
-            priority_fee::compute_budget_instruction(cu_budget),
-            priority_fee::compute_price_instruction_for_instructions(
-                client,
-                &ixs,
-                opts.fee_range(),
-            )
-            .await?,
-        ],
-        ixs.as_slice(),
-    ]
-    .concat();
-
-    message::mk_message(client, final_ixs, &opts.lut_addresses, fee_payer).await
+    message::mk_budgeted_message(client, cu_budget, &ixs, fee_payer, opts).await
 }
 
 /// Close multiple accounts in a single transaction.
@@ -293,7 +263,7 @@ pub async fn close_accounts<C: AsRef<SolanaRpcClient>>(
     fee_payer: &dyn Signer,
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
-    let (msg, block_height) = close_accounts_message(
+    let msg = close_accounts_message(
         client,
         accounts,
         destination,
@@ -307,8 +277,7 @@ pub async fn close_accounts<C: AsRef<SolanaRpcClient>>(
     } else {
         vec![fee_payer, owner]
     };
-    let txn = mk_transaction(msg, &signers)?;
-    Ok((txn, block_height))
+    mk_signed_transaction(msg, &signers)
 }
 
 /// Close a single account and return funds to destination.
@@ -878,7 +847,7 @@ mod tests {
         let mut map = TokenBalanceMap::default();
         map.as_mut().insert(
             Token::Hnt,
-            Token::Hnt.to_balance(address, 1_50_000_000), // 1.5 HNT (8 decimals)
+            Token::Hnt.to_balance(address, 150_000_000), // 1.5 HNT (8 decimals)
         );
         map.as_mut().insert(
             Token::Dc,

--- a/helium-lib/src/transaction.rs
+++ b/helium-lib/src/transaction.rs
@@ -64,6 +64,16 @@ pub fn mk_transaction<T: Signers + ?Sized>(
     VersionedTransaction::try_new(msg, signers).map_err(Error::from)
 }
 
+/// Signs a `(message, block_height)` pair as returned by the `*_message`
+/// builders, preserving the block height for confirmation tracking.
+pub fn mk_signed_transaction<T: Signers + ?Sized>(
+    (msg, block_height): (message::VersionedMessage, u64),
+    signers: &T,
+) -> Result<(VersionedTransaction, u64), Error> {
+    let txn = mk_transaction(msg, signers)?;
+    Ok((txn, block_height))
+}
+
 /// Pack multiple instruction groups into size-limited transactions.
 pub fn pack_instructions(
     instructions: &[&[Instruction]],

--- a/helium-wallet/src/cmd/assets/burn.rs
+++ b/helium-wallet/src/cmd/assets/burn.rs
@@ -1,24 +1,22 @@
-use crate::cmd::{squads as cmd_squads, *};
-use helium_lib::{asset, dao, entity_key, keypair::Pubkey};
+use crate::cmd::{
+    squads::{self as cmd_squads, SquadsOpts},
+    *,
+};
+use helium_lib::{asset, entity_key};
 
 #[derive(Clone, Debug, clap::Args)]
 /// Burn a given asset (NFT)
 pub struct Cmd {
-    /// Subdao for command
-    subdao: dao::SubDao,
     /// Entity key of asset to burn
     #[clap(flatten)]
-    entity_key: entity_key::EncodedEntityKey,
-    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    pub entity_key: entity_key::EncodedEntityKey,
+    /// Submit as a Squads v4 proposal.
     /// The asset's current owner must be the resolved vault.
-    #[arg(long)]
-    squads: Option<Pubkey>,
-    /// Memo recorded on the v4 proposal (`--squads` only).
-    #[arg(long)]
-    memo: Option<String>,
+    #[command(flatten)]
+    pub squads: SquadsOpts,
     /// Commit the transaction
     #[command(flatten)]
-    commit: CommitOpts,
+    pub commit: CommitOpts,
 }
 
 impl Cmd {
@@ -28,13 +26,13 @@ impl Cmd {
         let transaction_opts = self.commit.transaction_opts(&client);
         let asset = asset::for_entity_key(&client, &self.entity_key.as_entity_key()?).await?;
 
-        if let Some(squads_target) = self.squads {
+        if let Some(squads_target) = self.squads.squads {
             let client_ref = &client;
             let asset_id = asset.id;
             return cmd_squads::submit_proposal_with(
                 client_ref,
                 squads_target,
-                self.memo.clone(),
+                self.squads.memo.clone(),
                 &*signer,
                 &self.commit,
                 &transaction_opts,

--- a/helium-wallet/src/cmd/assets/transfer.rs
+++ b/helium-wallet/src/cmd/assets/transfer.rs
@@ -1,4 +1,7 @@
-use crate::cmd::{squads as cmd_squads, *};
+use crate::cmd::{
+    squads::{self as cmd_squads, SquadsOpts},
+    *,
+};
 use helium_lib::{
     asset, entity_key,
     keypair::{Pubkey, Signer},
@@ -6,23 +9,20 @@ use helium_lib::{
 };
 
 #[derive(Clone, Debug, clap::Args)]
-/// Transfer a Hotspot to another owner
+/// Transfer an asset (NFT) to another owner
 pub struct Cmd {
     #[clap(flatten)]
     pub entity_key: entity_key::EncodedEntityKey,
 
-    /// Solana address of Recipient of Hotspot
-    recipient: Pubkey,
-    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    /// Solana address of the recipient of the asset
+    pub recipient: Pubkey,
+    /// Submit as a Squads v4 proposal.
     /// The asset's current owner must be the resolved vault.
-    #[arg(long)]
-    squads: Option<Pubkey>,
-    /// Memo recorded on the v4 proposal (`--squads` only).
-    #[arg(long)]
-    memo: Option<String>,
+    #[command(flatten)]
+    pub squads: SquadsOpts,
     /// Commit the transfer
     #[command(flatten)]
-    commit: CommitOpts,
+    pub commit: CommitOpts,
 }
 
 impl Cmd {
@@ -32,14 +32,14 @@ impl Cmd {
         let transaction_opts = self.commit.transaction_opts(&client);
         let kta = kta::for_entity_key(&self.entity_key.as_entity_key()?).await?;
 
-        if let Some(squads_target) = self.squads {
+        if let Some(squads_target) = self.squads.squads {
             let client_ref = &client;
             let recipient = self.recipient;
             let asset_id = kta.asset;
             return cmd_squads::submit_proposal_with(
                 client_ref,
                 squads_target,
-                self.memo.clone(),
+                self.squads.memo.clone(),
                 &*signer,
                 &self.commit,
                 &transaction_opts,
@@ -62,7 +62,7 @@ impl Cmd {
         }
 
         if signer.pubkey() == self.recipient {
-            bail!("recipient already owner of hotspot");
+            bail!("recipient already owner of asset");
         }
         let (tx, _) = asset::transfer(
             &client,

--- a/helium-wallet/src/cmd/burn.rs
+++ b/helium-wallet/src/cmd/burn.rs
@@ -1,5 +1,8 @@
-use crate::cmd::{squads as cmd_squads, *};
-use helium_lib::{dao::SubDao, keypair::Pubkey, token};
+use crate::cmd::{
+    squads::{self as cmd_squads, SquadsOpts},
+    *,
+};
+use helium_lib::{dao::SubDao, token};
 
 #[derive(Debug, Clone, clap::Args)]
 /// Burn tokens
@@ -8,12 +11,8 @@ pub struct Cmd {
     subdao: SubDao,
     /// Amount to burn
     amount: f64,
-    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
-    #[arg(long)]
-    squads: Option<Pubkey>,
-    /// Memo recorded on the v4 proposal (`--squads` only).
-    #[arg(long)]
-    memo: Option<String>,
+    #[command(flatten)]
+    squads: SquadsOpts,
     /// Commit the burn
     #[command(flatten)]
     commit: CommitOpts,
@@ -27,11 +26,11 @@ impl Cmd {
 
         let token_amount = token::TokenAmount::from_f64(self.subdao.token(), self.amount);
 
-        if let Some(squads_target) = self.squads {
+        if let Some(squads_target) = self.squads.squads {
             return cmd_squads::submit_proposal_with(
                 &client,
                 squads_target,
-                self.memo.clone(),
+                self.squads.memo.clone(),
                 &*signer,
                 &self.commit,
                 &txn_opts,

--- a/helium-wallet/src/cmd/dc/burn.rs
+++ b/helium-wallet/src/cmd/dc/burn.rs
@@ -1,5 +1,8 @@
-use crate::cmd::{squads as cmd_squads, *};
-use helium_lib::{dao, dc, keypair::Pubkey};
+use crate::cmd::{
+    squads::{self as cmd_squads, SquadsOpts},
+    *,
+};
+use helium_lib::{dao, dc};
 
 #[derive(Debug, Clone, clap::Args)]
 /// Burn Data Credits (DC) from this wallet or delegated for the given router into oblivion.
@@ -13,14 +16,10 @@ pub struct Cmd {
     /// Note that the wallet keypair must be the burn authority for the router key
     /// for the burn to succeed
     router: Option<String>,
-    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
     /// Only supported for the non-delegated (no router) burn path; the
     /// DC is sourced from the resolved vault's DC ATA.
-    #[arg(long)]
-    squads: Option<Pubkey>,
-    /// Memo recorded on the v4 proposal (`--squads` only).
-    #[arg(long)]
-    memo: Option<String>,
+    #[command(flatten)]
+    squads: SquadsOpts,
     /// Commit the burn
     #[command(flatten)]
     commit: CommitOpts,
@@ -32,14 +31,14 @@ impl Cmd {
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
 
-        if let Some(squads_target) = self.squads {
+        if let Some(squads_target) = self.squads.squads {
             if self.router.is_some() || self.subdao.is_some() {
                 bail!("--squads only supports the non-delegated burn path");
             }
             return cmd_squads::submit_proposal_with(
                 &client,
                 squads_target,
-                self.memo.clone(),
+                self.squads.memo.clone(),
                 &*signer,
                 &self.commit,
                 &transaction_opts,

--- a/helium-wallet/src/cmd/dc/delegate.rs
+++ b/helium-wallet/src/cmd/dc/delegate.rs
@@ -1,5 +1,8 @@
-use crate::cmd::{squads as cmd_squads, *};
-use helium_lib::{dao::SubDao, dc, keypair::Pubkey};
+use crate::cmd::{
+    squads::{self as cmd_squads, SquadsOpts},
+    *,
+};
+use helium_lib::{dao::SubDao, dc};
 
 #[derive(Debug, Clone, clap::Args)]
 /// Delegate DC from this wallet to a given router
@@ -13,13 +16,9 @@ pub struct Cmd {
     /// Amount of DC to delegate
     dc: u64,
 
-    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
     /// The DC is sourced from the resolved vault's DC ATA.
-    #[arg(long)]
-    squads: Option<Pubkey>,
-    /// Memo recorded on the v4 proposal (`--squads` only).
-    #[arg(long)]
-    memo: Option<String>,
+    #[command(flatten)]
+    squads: SquadsOpts,
 
     /// Commit the delegation
     #[command(flatten)]
@@ -33,11 +32,11 @@ impl Cmd {
         let client = opts.client()?;
         let transaction_opts = self.commit.transaction_opts(&client);
 
-        if let Some(squads_target) = self.squads {
+        if let Some(squads_target) = self.squads.squads {
             return cmd_squads::submit_proposal_with(
                 &client,
                 squads_target,
-                self.memo.clone(),
+                self.squads.memo.clone(),
                 &*signer,
                 &self.commit,
                 &transaction_opts,

--- a/helium-wallet/src/cmd/dc/mint.rs
+++ b/helium-wallet/src/cmd/dc/mint.rs
@@ -1,4 +1,7 @@
-use crate::cmd::{squads as cmd_squads, *};
+use crate::cmd::{
+    squads::{self as cmd_squads, SquadsOpts},
+    *,
+};
 use helium_lib::{
     dc,
     keypair::{Pubkey, Signer},
@@ -24,14 +27,10 @@ pub struct Cmd {
     #[arg(long, conflicts_with = "hnt")]
     dc: Option<u64>,
 
-    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
     /// HNT is sourced from the resolved vault; the wallet only signs as
     /// proposer.
-    #[arg(long)]
-    squads: Option<Pubkey>,
-    /// Memo recorded on the v4 proposal (`--squads` only).
-    #[arg(long)]
-    memo: Option<String>,
+    #[command(flatten)]
+    squads: SquadsOpts,
 
     /// Commit the burn
     #[command(flatten)]
@@ -50,13 +49,13 @@ impl Cmd {
         };
         let transaction_opts = self.commit.transaction_opts(&client);
 
-        if let Some(squads_target) = self.squads {
+        if let Some(squads_target) = self.squads.squads {
             let client_ref = &client;
             let payee_override = self.payee;
             return cmd_squads::submit_proposal_with(
                 client_ref,
                 squads_target,
-                self.memo.clone(),
+                self.squads.memo.clone(),
                 &*signer,
                 &self.commit,
                 &transaction_opts,

--- a/helium-wallet/src/cmd/hotspots/burn.rs
+++ b/helium-wallet/src/cmd/hotspots/burn.rs
@@ -1,53 +1,32 @@
-use crate::cmd::{squads as cmd_squads, *};
-use helium_lib::{dao, hotspot, keypair::Pubkey};
+use crate::cmd::{squads::SquadsOpts, *};
+use helium_lib::entity_key::EncodedEntityKey;
 
 #[derive(Clone, Debug, clap::Args)]
 /// Burn a given Hotspot NFT
 pub struct Cmd {
-    /// Subdao for command
-    subdao: dao::SubDao,
     /// Key for the Hotspot NFT to burn
     address: helium_crypto::PublicKey,
-    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    /// Submit as a Squads v4 proposal.
     /// The hotspot's current owner must be the resolved vault.
-    #[arg(long)]
-    squads: Option<Pubkey>,
-    /// Memo recorded on the v4 proposal (`--squads` only).
-    #[arg(long)]
-    memo: Option<String>,
+    #[command(flatten)]
+    squads: SquadsOpts,
     /// Commit the transaction
     #[command(flatten)]
     commit: CommitOpts,
 }
 
+impl From<&Cmd> for crate::cmd::assets::burn::Cmd {
+    fn from(value: &Cmd) -> Self {
+        Self {
+            entity_key: EncodedEntityKey::from(&value.address),
+            squads: value.squads.clone(),
+            commit: value.commit.clone(),
+        }
+    }
+}
+
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let client = opts.client()?;
-        let signer = opts.load_signer()?;
-        let transaction_opts = self.commit.transaction_opts(&client);
-
-        if let Some(squads_target) = self.squads {
-            let client_ref = &client;
-            let address = self.address.clone();
-            return cmd_squads::submit_proposal_with(
-                client_ref,
-                squads_target,
-                self.memo.clone(),
-                &*signer,
-                &self.commit,
-                &transaction_opts,
-                |vault| async move {
-                    Ok(vec![
-                        hotspot::fetch_burn_instruction(client_ref, &address, vault.as_pubkey())
-                            .await?,
-                    ])
-                },
-            )
-            .await;
-        }
-
-        let (tx, _) = hotspot::burn(&client, &self.address, &*signer, &transaction_opts).await?;
-
-        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
+        crate::cmd::assets::burn::Cmd::from(self).run(opts).await
     }
 }

--- a/helium-wallet/src/cmd/hotspots/transfer.rs
+++ b/helium-wallet/src/cmd/hotspots/transfer.rs
@@ -1,8 +1,5 @@
-use crate::cmd::{squads as cmd_squads, *};
-use helium_lib::{
-    hotspot,
-    keypair::{Pubkey, Signer},
-};
+use crate::cmd::{squads::SquadsOpts, *};
+use helium_lib::{entity_key::EncodedEntityKey, keypair::Pubkey};
 
 #[derive(Clone, Debug, clap::Args)]
 /// Transfer a Hotspot to another owner
@@ -11,64 +8,30 @@ pub struct Cmd {
     address: helium_crypto::PublicKey,
     /// Solana address of Recipient of Hotspot
     recipient: Pubkey,
-    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
+    /// Submit as a Squads v4 proposal.
     /// The hotspot's current owner must be the resolved vault.
-    #[arg(long)]
-    squads: Option<Pubkey>,
-    /// Memo recorded on the v4 proposal (`--squads` only).
-    #[arg(long)]
-    memo: Option<String>,
+    #[command(flatten)]
+    squads: SquadsOpts,
     /// Commit the transfer
     #[command(flatten)]
     commit: CommitOpts,
 }
 
+impl From<&Cmd> for crate::cmd::assets::transfer::Cmd {
+    fn from(value: &Cmd) -> Self {
+        Self {
+            entity_key: EncodedEntityKey::from(&value.address),
+            recipient: value.recipient,
+            squads: value.squads.clone(),
+            commit: value.commit.clone(),
+        }
+    }
+}
+
 impl Cmd {
     pub async fn run(&self, opts: Opts) -> Result {
-        let signer = opts.load_signer()?;
-        let client = opts.client()?;
-        let transaction_opts = self.commit.transaction_opts(&client);
-
-        if let Some(squads_target) = self.squads {
-            let client_ref = &client;
-            let address = self.address.clone();
-            let recipient = self.recipient;
-            return cmd_squads::submit_proposal_with(
-                client_ref,
-                squads_target,
-                self.memo.clone(),
-                &*signer,
-                &self.commit,
-                &transaction_opts,
-                |vault| async move {
-                    if vault.as_pubkey() == &recipient {
-                        bail!("recipient already owner of hotspot");
-                    }
-                    Ok(vec![
-                        hotspot::fetch_transfer_instruction(
-                            client_ref,
-                            &address,
-                            &recipient,
-                            vault.as_pubkey(),
-                        )
-                        .await?,
-                    ])
-                },
-            )
-            .await;
-        }
-
-        if signer.pubkey() == self.recipient {
-            bail!("recipient already owner of hotspot");
-        }
-        let (tx, _) = hotspot::transfer(
-            &client,
-            &self.address,
-            &self.recipient,
-            &*signer,
-            &transaction_opts,
-        )
-        .await?;
-        print_json(&self.commit.maybe_commit(tx, &client).await?.to_json())
+        crate::cmd::assets::transfer::Cmd::from(self)
+            .run(opts)
+            .await
     }
 }

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -448,7 +448,7 @@ mod tests {
 
     #[test]
     fn commit_response_error_keeps_existing_shape() {
-        let err: Result<CommitResponse> = Err(anyhow!("boom").into());
+        let err: Result<CommitResponse> = Err(anyhow!("boom"));
         let value = err.to_json();
         assert_eq!(value["result"], json!("error"));
         assert!(value.get("committed").is_none());

--- a/helium-wallet/src/cmd/squads/mod.rs
+++ b/helium-wallet/src/cmd/squads/mod.rs
@@ -15,6 +15,23 @@ mod members;
 mod threshold;
 mod vote;
 
+/// Shared `--squads`/`--memo` options for commands that can submit their
+/// transaction as a Squads v4 proposal instead of executing directly.
+/// Flatten with `#[command(flatten)]`.
+#[derive(Debug, Clone, clap::Args)]
+pub struct SquadsOpts {
+    /// Submit as a Squads v4 proposal instead of executing directly.
+    /// Accepts a multisig PDA or a vault PDA — when a vault is given the
+    /// multisig is resolved through the local cache. The transaction's
+    /// authority becomes the resolved vault (not the wallet), and the
+    /// wallet just signs as proposer.
+    #[arg(long)]
+    pub squads: Option<Pubkey>,
+    /// Memo recorded on the v4 proposal (`--squads` only).
+    #[arg(long)]
+    pub memo: Option<String>,
+}
+
 /// Resolve a `--squads <addr>` value into the (multisig, vault PDA,
 /// vault_index) triple every proposer-side wallet command needs.
 /// Helium multisigs use vault index 0; non-zero vaults aren't surfaced

--- a/helium-wallet/src/cmd/transfer.rs
+++ b/helium-wallet/src/cmd/transfer.rs
@@ -1,5 +1,8 @@
 use crate::{
-    cmd::{squads as cmd_squads, *},
+    cmd::{
+        squads::{self as cmd_squads, SquadsOpts},
+        *,
+    },
     result::Result,
 };
 use helium_lib::{
@@ -39,16 +42,8 @@ pub enum PayCmd {
 pub struct One {
     #[command(flatten)]
     payee: Payee,
-    /// Submit as a Squads v4 proposal instead of executing directly.
-    /// Accepts a multisig PDA or a vault PDA — when a vault is given the
-    /// multisig is resolved through the local cache. The transfer's
-    /// source becomes the vault's ATA (not the wallet's), and the wallet
-    /// just signs as proposer.
-    #[arg(long)]
-    squads: Option<Pubkey>,
-    /// Memo recorded on the v4 proposal (`--squads` only).
-    #[arg(long)]
-    memo: Option<String>,
+    #[command(flatten)]
+    squads: SquadsOpts,
     /// Commit the payment to the API
     #[command(flatten)]
     commit: CommitOpts,
@@ -89,12 +84,8 @@ pub struct One {
 pub struct Multi {
     /// File to read multiple payments from.
     path: PathBuf,
-    /// Submit as a Squads v4 proposal — see `transfer one --squads`.
-    #[arg(long)]
-    squads: Option<Pubkey>,
-    /// Memo recorded on the v4 proposal (`--squads` only).
-    #[arg(long)]
-    memo: Option<String>,
+    #[command(flatten)]
+    squads: SquadsOpts,
     /// Commit the payments
     #[command(flatten)]
     commit: CommitOpts,
@@ -107,11 +98,11 @@ impl PayCmd {
         let client = opts.client()?;
         let txn_opts = self.commit().transaction_opts(&client);
 
-        if let Some(squads_target) = self.squads_target() {
+        if let Some(squads_target) = self.squads().squads {
             return cmd_squads::submit_proposal_with(
                 &client,
                 squads_target,
-                self.squads_memo().cloned(),
+                self.squads().memo.clone(),
                 &*signer,
                 self.commit(),
                 &txn_opts,
@@ -127,17 +118,10 @@ impl PayCmd {
         print_json(&self.commit().maybe_commit(tx, &client).await?.to_json())
     }
 
-    fn squads_target(&self) -> Option<Pubkey> {
+    fn squads(&self) -> &SquadsOpts {
         match &self {
-            Self::One(one) => one.squads,
-            Self::Multi(multi) => multi.squads,
-        }
-    }
-
-    fn squads_memo(&self) -> Option<&String> {
-        match &self {
-            Self::One(one) => one.memo.as_ref(),
-            Self::Multi(multi) => multi.memo.as_ref(),
+            Self::One(one) => &one.squads,
+            Self::Multi(multi) => &multi.squads,
         }
     }
 


### PR DESCRIPTION
Cleanup pass from a repo review: ~290 lines of duplication removed across helium-lib and the CLI, plus one layering fix. Two commits, lib and CLI.

## helium-lib

**`message::mk_budgeted_message`** — the compute-budget + priority-fee + `mk_message` envelope was hand-rolled at 19 sites across dc, token, asset, schedule, reward, queue, hotspot, boosting, and memo. One helper now owns it; each site keeps its compute-unit limit. Behavior note: fee estimation now uniformly considers all instructions' writable accounts. A few single-instruction sites previously estimated from only the primary instruction's accounts; they now match the multi-instruction sites.

**`transaction::mk_signed_transaction`** — collapses 18 identical "sign message, return with block height" tails. NullSigner/re-sign paths untouched.

**Layering fix** — `asset::check_owner` returned `SquadsError::WrongAssetOwner`, the only upward dependency from the DAS layer to the multisig integration. The variant moved to the top-level `Error`; `SquadsError` loses its self-described "single-variant outlier".

**API breaking (pre-1.0)** — `Error::Cmopile` renamed to `Compile`; `SquadsError::WrongAssetOwner` removed (now on `Error`). Also fixed the clippy `--all-targets` lints in test code that CI's lint step (no `--all-targets`) doesn't catch.

## CLI

**Shared `SquadsOpts`** — the `--squads`/`--memo` pair was re-declared in 10 command structs with drifting help text. Now one flattened clap struct with the canonical description.

**Hotspot burn/transfer delegate to the asset commands** — `hotspots burn`/`hotspots transfer` were ~90% copies of the assets variants. They are now thin `From`-conversions, the same pattern `hotspots rewards` already uses. This also fixes drift in the copies: `assets transfer` described itself as transferring "a Hotspot" and errored with "recipient already owner of hotspot".

**Removed dead `subdao` positional from `assets burn` and `hotspots burn`** — declared since the commands were added in #426 but never read. This is a CLI syntax change: `hotspots burn <subdao> <address>` becomes `hotspots burn <address>`. The README has always documented the syntax *without* the subdao argument, so the documented invocation now actually parses; anyone scripting the old form gets a clear clap error.

## Verification

- CI-exact commands pass locally: `cargo fmt -- --check`, `cargo clippy --all-features --locked -- -D clippy::all`, `cargo test --locked`, `cargo build --all --locked --release`
- Stricter than CI: `RUSTFLAGS="-D warnings" cargo clippy --locked --all-targets --workspace` is clean
- Functional check: `hotspots burn --help` and `transfer one --help` from the release binary show the expected arguments and unified `--squads` help
- Swept for leftovers: no remaining hand-rolled `compute_budget_instruction` framing outside `priority_fee`/`message`, no remaining `squads: Option<Pubkey>` declarations, no `Cmopile`/`SquadsError::WrongAssetOwner` references