### PR TITLE
ci: run apt-get update before install in the build job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,7 @@ jobs:
         shell: bash
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
+              sudo apt-get update
               sudo apt-get install -y protobuf-compiler libudev-dev
           elif [ "$RUNNER_OS" == "macOS" ]; then
               brew install protobuf


### PR DESCRIPTION
The build job's `Setup | Tools` step runs `apt-get install` without `apt-get update`, so it installs against the package index baked into the runner image. When a pinned package version rotates out of the mirror, the fetch 404s — currently failing every PR on `libudev-dev`:

```
E: Failed to fetch https://security.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_255.4-1ubuntu8.15_amd64.deb  404  Not Found
```

The macOS build "failures" on those runs are just fail-fast cancellations of the matrix sibling.

The hygiene job (rust.yml) and geiger job already run `apt-get update` first; this aligns the build job with them.