### PR TITLE
fix(lib): cluster-aware lookup-table selection for TransactionOpts

### DIFF
--- a/helium-lib/src/lib.rs
+++ b/helium-lib/src/lib.rs
@@ -124,7 +124,22 @@ pub struct TransactionOpts {
     pub lut_addresses: Vec<Pubkey>,
 }
 
+/// Returns the default LUT addresses for the cluster identified by `url`,
+/// selecting the devnet common LUT for devnet URLs and the mainnet common
+/// LUT otherwise. See [`client::is_devnet`] for how the cluster is detected.
+fn default_lut_addresses_for_url(url: &str) -> Vec<Pubkey> {
+    if client::is_devnet(url) {
+        vec![message::COMMON_LUT_DEVNET]
+    } else {
+        vec![message::COMMON_LUT]
+    }
+}
+
 impl Default for TransactionOpts {
+    /// Default options assuming the **mainnet** cluster. When the target
+    /// cluster is not known to be mainnet, build options with
+    /// [`TransactionOpts::for_url`] or [`TransactionOpts::for_client`] so the
+    /// correct (devnet vs mainnet) common lookup table is selected.
     fn default() -> Self {
         Self {
             min_priority_fee: priority_fee::MIN_PRIORITY_FEE,
@@ -135,6 +150,23 @@ impl Default for TransactionOpts {
 }
 
 impl TransactionOpts {
+    /// Builds options for the cluster identified by `url`, selecting the
+    /// devnet or mainnet common lookup table accordingly. Priority fees use
+    /// the same defaults as [`TransactionOpts::default`].
+    pub fn for_url(url: &str) -> Self {
+        Self {
+            lut_addresses: default_lut_addresses_for_url(url),
+            ..Self::default()
+        }
+    }
+
+    /// Builds options for the cluster `client` is connected to, selecting the
+    /// devnet or mainnet common lookup table accordingly. Priority fees use
+    /// the same defaults as [`TransactionOpts::default`].
+    pub fn for_client<C: AsRef<SolanaRpcClient>>(client: &C) -> Self {
+        Self::for_url(&client.as_ref().url())
+    }
+
     fn fee_range(&self) -> RangeInclusive<u64> {
         RangeInclusive::new(self.min_priority_fee, self.max_priority_fee)
     }
@@ -153,4 +185,21 @@ pub async fn mk_transaction_with_blockhash<C: AsRef<SolanaRpcClient>>(
         .await?;
     txn.message.recent_blockhash = latest_blockhash;
     Ok((txn, latest_block_height))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transaction_opts_selects_devnet_lut_for_devnet_url() {
+        let opts = TransactionOpts::for_url(client::SOLANA_URL_DEVNET);
+        assert_eq!(opts.lut_addresses, vec![message::COMMON_LUT_DEVNET]);
+    }
+
+    #[test]
+    fn transaction_opts_selects_mainnet_lut_for_mainnet_url() {
+        let opts = TransactionOpts::for_url(client::SOLANA_URL_MAINNET);
+        assert_eq!(opts.lut_addresses, vec![message::COMMON_LUT]);
+    }
 }

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -6,7 +6,7 @@ use helium_lib::{
     b64,
     client::{self, SolanaRpcClient},
     keypair::{to_pubkey, Keypair, Pubkey, Signer},
-    message, priority_fee,
+    priority_fee,
     solana_client::{
         self, rpc_config::RpcSendTransactionConfig, rpc_request::RpcResponseErrorData,
         rpc_response::RpcSimulateTransactionResult,
@@ -286,11 +286,7 @@ impl CommitOpts {
         TransactionOpts {
             min_priority_fee: self.min_priority_fee,
             max_priority_fee: self.max_priority_fee,
-            lut_addresses: if client::is_devnet(&client.as_ref().url()) {
-                vec![message::COMMON_LUT_DEVNET]
-            } else {
-                vec![message::COMMON_LUT]
-            },
+            ..TransactionOpts::for_client(client)
         }
     }
 }


### PR DESCRIPTION
Closes #544.

`TransactionOpts::default()` hardcoded the mainnet common LUT; the devnet correction lived only in the CLI, so an external helium-lib consumer pointed at devnet silently got the mainnet table.

- New `TransactionOpts::for_url(&str)` / `for_client(&client)` select `COMMON_LUT_DEVNET` vs `COMMON_LUT` using the existing `client::is_devnet` detection.
- `Default` is unchanged (mainnet) but its doc now states the assumption and points to the new constructors.
- The CLI's `CommitOpts::transaction_opts` builds on `for_client`, so the selection logic exists in exactly one place — swept `COMMON_LUT` references to confirm no call site hand-rolls the choice anymore.
- Unit tests cover devnet URL → devnet LUT and mainnet URL → mainnet LUT.

CI-exact commands plus `RUSTFLAGS="-D warnings" cargo clippy --locked --all-targets --workspace` pass.