### PR TITLE
fix(error): keep TransactionError typed in ConfirmationError

### DIFF
--- a/helium-lib/src/error.rs
+++ b/helium-lib/src/error.rs
@@ -2,7 +2,7 @@ use crate::{
     anchor_client, anchor_lang, client, hotspot::cert, jupiter, onboarding, solana_client, squads,
     token,
 };
-use solana_sdk::signature::Signature;
+use solana_sdk::{signature::Signature, transaction::TransactionError};
 use std::{array::TryFromSliceError, num::TryFromIntError, time::Duration};
 use thiserror::Error;
 
@@ -229,7 +229,10 @@ pub enum ConfirmationError {
 
     /// Transaction failed on-chain with a program error
     #[error("transaction {signature} failed: {error}")]
-    Failed { signature: Signature, error: String },
+    Failed {
+        signature: Signature,
+        error: TransactionError,
+    },
 
     /// Confirmation polling timed out before reaching finalized status
     #[error("timeout after {duration:?} waiting for {count} signatures")]
@@ -256,11 +259,8 @@ impl ConfirmationError {
     }
 
     /// Create a Failed error for a transaction that failed on-chain
-    pub fn failed(signature: Signature, error: impl Into<String>) -> Self {
-        Self::Failed {
-            signature,
-            error: error.into(),
-        }
+    pub fn failed(signature: Signature, error: TransactionError) -> Self {
+        Self::Failed { signature, error }
     }
 
     /// Create a Timeout error when confirmation polling exceeded the deadline
@@ -285,7 +285,7 @@ impl Error {
     }
 
     /// Helper to create a confirmation failed error
-    pub fn confirmation_failed(signature: Signature, error: impl Into<String>) -> Self {
+    pub fn confirmation_failed(signature: Signature, error: TransactionError) -> Self {
         ConfirmationError::failed(signature, error).into()
     }
 

--- a/helium-lib/src/transaction.rs
+++ b/helium-lib/src/transaction.rs
@@ -4,6 +4,7 @@ use crate::{
     solana_sdk::{
         address_lookup_table::AddressLookupTableAccount, commitment_config::CommitmentConfig,
         instruction::Instruction, signature::Signature, signers::Signers,
+        transaction::TransactionError,
     },
     Error,
 };
@@ -19,7 +20,7 @@ pub enum SignatureStatus {
     /// Transaction confirmed at the requested commitment level
     Confirmed,
     /// Transaction failed on-chain (not retriable)
-    Failed(String),
+    Failed(TransactionError),
     /// Signature not found (may be pending or dropped)
     NotFound,
 }
@@ -101,7 +102,7 @@ pub async fn get_signature_statuses<C: AsRef<SolanaRpcClient>>(
             Some(status) => {
                 // Check for transaction error first
                 if let Some(err) = status.err {
-                    return SignatureStatus::Failed(err.to_string());
+                    return SignatureStatus::Failed(err);
                 }
                 // Check if confirmed at the required commitment level
                 let confirmed = match commitment.commitment {


### PR DESCRIPTION
`ConfirmationError::Failed` stored the on-chain error as a `String` (`SignatureStatus::Failed` stringified the `TransactionError` before it ever reached the error type), so callers could only string-match to tell why a transaction failed.

Carry the `TransactionError` through `SignatureStatus::Failed` and store it typed on `ConfirmationError::Failed` so callers can match on the actual variant. The existing CLI consumer formats it via `Display`, so user-facing output is unchanged.

Builds clean, `helium-lib` tests pass.

Addresses #546 (the typed `ConfirmationError` item).