### PR TITLE
refactor(client): expose explicit-URL Client constructor

### DIFF
--- a/helium-lib/src/client.rs
+++ b/helium-lib/src/client.rs
@@ -131,33 +131,43 @@ impl GetAnchorAccount for Client {
     }
 }
 
-impl TryFrom<&str> for Client {
-    type Error = Error;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        fn maybe_env(key: &str) -> Option<String> {
-            std::env::var(key).ok()
-        }
-        fn env_or(key: &str, default: &str) -> String {
-            maybe_env(key).unwrap_or_else(|| default.to_string())
-        }
-        let rpc_url = match value {
-            "m" | "mainnet-beta" => env_or(SOLANA_URL_MAINNET_ENV, SOLANA_URL_MAINNET),
-            "d" | "devnet" => env_or(SOLANA_URL_DEVNET_ENV, SOLANA_URL_DEVNET),
-            url => url.to_string(),
-        };
-        let cert_url = match value {
-            "d" | "devnet" => env_or(CERT_URL_DEVNET_ENV, CERT_URL_DEVNET),
-            url if is_devnet(url) => env_or(CERT_URL_DEVNET_ENV, CERT_URL_DEVNET),
-            _url => env_or(CERT_URL_MAINNET_ENV, CERT_URL_MAINNET),
-        };
-        let das_client = Arc::new(DasClient::with_base_url(&rpc_url)?);
-        let solana_client = Arc::new(SolanaRpcClient::new(rpc_url));
-        let cert_client = Arc::new(CertClient::new(&cert_url, None)?);
+impl Client {
+    /// Build a client from explicit RPC and certificate-service URLs.
+    ///
+    /// No environment or moniker resolution happens here: turning user input
+    /// (monikers, `*_MAINNET_URL` / `*_DEVNET_URL` env overrides) into concrete
+    /// URLs is the consuming application's responsibility. `TryFrom<&str>`
+    /// offers a moniker shorthand against the built-in defaults, but
+    /// environment overrides belong in the binary.
+    pub fn new(rpc_url: &str, cert_url: &str) -> Result<Self, Error> {
+        let das_client = Arc::new(DasClient::with_base_url(rpc_url)?);
+        let solana_client = Arc::new(SolanaRpcClient::new(rpc_url.to_string()));
+        let cert_client = Arc::new(CertClient::new(cert_url, None)?);
         Ok(Self {
             solana_client,
             das_client,
             cert_client,
         })
+    }
+}
+
+impl TryFrom<&str> for Client {
+    type Error = Error;
+    /// Resolve a moniker (`"m"`, `"mainnet-beta"`, `"d"`, `"devnet"`) or a raw
+    /// URL to the built-in default endpoints and build a client. Environment
+    /// overrides are intentionally not read here — see [`Client::new`].
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let rpc_url = match value {
+            "m" | "mainnet-beta" => SOLANA_URL_MAINNET,
+            "d" | "devnet" => SOLANA_URL_DEVNET,
+            url => url,
+        };
+        let cert_url = match value {
+            "d" | "devnet" => CERT_URL_DEVNET,
+            url if is_devnet(url) => CERT_URL_DEVNET,
+            _ => CERT_URL_MAINNET,
+        };
+        Self::new(rpc_url, cert_url)
     }
 }
 

--- a/helium-wallet/src/cmd/mod.rs
+++ b/helium-wallet/src/cmd/mod.rs
@@ -180,7 +180,8 @@ impl Opts {
         if let Some(client) = self.client.get() {
             return Ok(client.clone());
         }
-        let client = client::Client::try_from(self.url.as_str())?;
+        let (rpc_url, cert_url) = resolve_endpoints(self.url.as_str());
+        let client = client::Client::new(&rpc_url, &cert_url)?;
         // Ignore the Err: a concurrent caller may have set it first, in which
         // case `get()` below returns that instance and ours is dropped.
         let _ = self.client.set(client);
@@ -190,6 +191,29 @@ impl Opts {
             .expect("client set above or by a concurrent caller")
             .clone())
     }
+}
+
+/// Resolve a `--url` value (a moniker or a raw URL) into concrete RPC and
+/// certificate-service endpoints, honoring the `*_MAINNET_URL` / `*_DEVNET_URL`
+/// environment overrides. Environment policy lives in the binary, not in
+/// `helium-lib`; the library takes explicit URLs via [`client::Client::new`].
+fn resolve_endpoints(url: &str) -> (String, String) {
+    fn env_or(key: &str, default: &str) -> String {
+        std::env::var(key).unwrap_or_else(|_| default.to_string())
+    }
+    let rpc_url = match url {
+        "m" | "mainnet-beta" => env_or(client::SOLANA_URL_MAINNET_ENV, client::SOLANA_URL_MAINNET),
+        "d" | "devnet" => env_or(client::SOLANA_URL_DEVNET_ENV, client::SOLANA_URL_DEVNET),
+        url => url.to_string(),
+    };
+    let cert_url = match url {
+        "d" | "devnet" => env_or(client::CERT_URL_DEVNET_ENV, client::CERT_URL_DEVNET),
+        url if client::is_devnet(url) => {
+            env_or(client::CERT_URL_DEVNET_ENV, client::CERT_URL_DEVNET)
+        }
+        _ => env_or(client::CERT_URL_MAINNET_ENV, client::CERT_URL_MAINNET),
+    };
+    (rpc_url, cert_url)
 }
 
 /// Blind-sign hook installed on every Ledger keypair we hand out. Fires


### PR DESCRIPTION
## Summary

Addresses the first item in #546: `client::Client::try_from` read `SOLANA_MAINNET_URL` / `CERT_MAINNET_URL` (and the devnet variants) from the process environment *inside* `helium-lib`. That puts the CLI's environment policy in the library, so an external consumer of `helium-lib` inherits env-based URL overrides whether it wants them or not.

## Changes

- Add `Client::new(rpc_url, cert_url)` to `helium-lib`. It builds the Solana / DAS / cert sub-clients from explicit URLs and does no environment or moniker resolution.
- `TryFrom<&str>` keeps the moniker shorthand (`"m"`, `"mainnet-beta"`, `"d"`, `"devnet"`, or a raw URL) but now resolves against the built-in default endpoints only — it no longer touches `std::env`.
- Move the environment-override handling into the CLI: `Opts::client()` resolves the user's `--url` plus the `*_MAINNET_URL` / `*_DEVNET_URL` env vars into concrete endpoints and then calls `Client::new`.

The binary's behavior is unchanged — the same env vars are honored, just resolved in the binary instead of the library. The default endpoint constants and `is_devnet` stay public so the CLI (or any consumer) can reuse them.

The remaining items in #546 (squads cache path, v4.rs split, KTA cache on `Client`) are left for separate PRs, so this does not close the issue.

## Verification

```
cargo build --workspace        # clean
cargo fmt --all --check        # clean
cargo clippy -p helium-lib -p helium-wallet --all-targets   # no warnings
cargo test -p helium-lib       # 60 passed
```
