### PR TITLE
fix(reward): include ticket key in claim invariant panic messages

### DIFF
--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -562,15 +562,16 @@ pub async fn claim_instructions<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + G
                 return Ok(None);
             };
             // Should be safe because all ktas were fetched as part of the asset fetch
-            let kta = kta::get_cached(&ticket.kta_key).expect("kta for {ticket_key}");
+            let kta = kta::get_cached(&ticket.kta_key)
+                .unwrap_or_else(|err| panic!("kta for {}: {err}", ticket.key_str()));
             // Safe to unwrap since asset::get_many will fail for any not found asset
             let asset = asset_map
                 .remove(ticket.key_str())
-                .expect("asset for {ticket_key}");
+                .unwrap_or_else(|| panic!("asset for {}", ticket.key_str()));
             // Safe to unwrap since an oracle ixn must exist for every reward
             let oracle_ixn = oracle_ixns
                 .remove(ticket.key_str())
-                .expect("oracle instruction for {ticket_key}");
+                .unwrap_or_else(|| panic!("oracle instruction for {}", ticket.key_str()));
             let claim_common = ClaimCommon {
                 token,
                 ld_account: &ld_account,


### PR DESCRIPTION
While reading `claim_instructions` I noticed the three invariant guards pass a literal format-looking string to `.expect()`:

```rust
let kta = kta::get_cached(&ticket.kta_key).expect("kta for {ticket_key}");
let asset = asset_map.remove(ticket.key_str()).expect("asset for {ticket_key}");
let oracle_ixn = oracle_ixns.remove(ticket.key_str()).expect("oracle instruction for {ticket_key}");
```

`.expect()` takes a plain `&str`, so `{ticket_key}` is printed verbatim rather than interpolated — and there is no `ticket_key` binding in scope anyway (the key is `ticket.key_str()`). If one of these invariants is ever violated, the panic names no specific ticket, which defeats the purpose of the message.

This switches the three guards to `unwrap_or_else(|| panic!(...))` and interpolates `ticket.key_str()` (and, for the `get_cached` Result, the underlying error too), so a violated invariant points at the offending ticket. `unwrap_or_else` keeps the message lazy, avoiding the eager allocation `expect(&format!(...))` would add on the hot path.

No behavior change on the success path. `cargo build`/`fmt --check`/`clippy -p helium-lib --all-targets` clean, `cargo test -p helium-lib` 60 pass.