### PR TITLE
fix(signer): keep async signer futures Send via `dyn Signer + Sync`

### DIFF
--- a/helium-lib/src/asset.rs
+++ b/helium-lib/src/asset.rs
@@ -583,7 +583,7 @@ pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     pubkey: &Pubkey,
     recipient: &Pubkey,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (mut txn, block_height) = transfer_transaction(client, pubkey, recipient, opts).await?;
@@ -673,7 +673,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
 pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     pubkey: &Pubkey,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let msg = burn_message(client, pubkey, opts).await?;

--- a/helium-lib/src/boosting.rs
+++ b/helium-lib/src/boosting.rs
@@ -25,7 +25,7 @@ pub trait StartBoostingHex {
 /// Builds a message that activates hex boosting for a set of hexes.
 pub async fn start_boost_message<C: AsRef<SolanaRpcClient>>(
     client: &C,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     updates: impl IntoIterator<Item = impl StartBoostingHex>,
     opts: &TransactionOpts,
 ) -> Result<(message::VersionedMessage, u64), Error> {
@@ -67,7 +67,7 @@ pub async fn start_boost_message<C: AsRef<SolanaRpcClient>>(
 pub async fn start_boost<C: AsRef<SolanaRpcClient>>(
     client: &C,
     updates: impl IntoIterator<Item = impl StartBoostingHex>,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(transaction::VersionedTransaction, u64), Error> {
     let msg = start_boost_message(client, keypair, updates, opts).await?;

--- a/helium-lib/src/dc.rs
+++ b/helium-lib/src/dc.rs
@@ -80,7 +80,7 @@ pub async fn mint<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: TokenAmount,
     payee: &Pubkey,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let msg = mint_message(client, amount, payee, &keypair.pubkey(), opts).await?;
@@ -142,7 +142,7 @@ pub async fn delegate<C: AsRef<SolanaRpcClient>>(
     subdao: SubDao,
     payer_key: &str,
     amount: u64,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let msg = delegate_message(client, subdao, payer_key, amount, &keypair.pubkey(), opts).await?;
@@ -188,7 +188,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
 pub async fn burn<C: AsRef<SolanaRpcClient>>(
     client: &C,
     amount: u64,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let msg = burn_message(client, amount, &keypair.pubkey(), opts).await?;
@@ -261,7 +261,7 @@ pub async fn burn_delegated_message<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
 pub async fn burn_delegated<C: AsRef<SolanaRpcClient>, E: AsEntityKey>(
     client: &C,
     sub_dao: SubDao,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     amount: u64,
     router_key: &E,
     opts: &TransactionOpts,

--- a/helium-lib/src/hotspot/dataonly.rs
+++ b/helium-lib/src/hotspot/dataonly.rs
@@ -285,7 +285,7 @@ pub async fn onboard<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAcc
     subdao: SubDao,
     hotspot_key: &helium_crypto::PublicKey,
     assertion: &HotspotInfoUpdate,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (mut txn, block_height) = onboard_transaction(
@@ -311,7 +311,7 @@ pub async fn onboard_with_asset<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + G
     hotspot_key: &helium_crypto::PublicKey,
     asset: &asset::Asset,
     assertion: &HotspotInfoUpdate,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (mut txn, block_height) = onboard_transaction_with_asset(
@@ -466,7 +466,7 @@ pub async fn issue<C: AsRef<SolanaRpcClient> + GetAnchorAccount>(
     client: &C,
     verifier: &str,
     add_tx: &mut BlockchainTxnAddGatewayV1,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (mut txn, block_height) =

--- a/helium-lib/src/hotspot/mod.rs
+++ b/helium-lib/src/hotspot/mod.rs
@@ -243,7 +243,7 @@ pub async fn direct_update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot: &helium_crypto::PublicKey,
     update: &HotspotInfoUpdate,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let (mut txn, block_height) =
@@ -263,7 +263,7 @@ pub async fn update<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     onboarding_server: Option<String>,
     hotspot: &helium_crypto::PublicKey,
     update: &HotspotInfoUpdate,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<VersionedTransaction, Error> {
     let public_key = keypair.pubkey();
@@ -326,7 +326,7 @@ pub async fn transfer<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot_key: &helium_crypto::PublicKey,
     recipient: &Pubkey,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let kta = kta::for_entity_key(hotspot_key).await?;
@@ -347,7 +347,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
 pub async fn burn<C: AsRef<SolanaRpcClient> + AsRef<DasClient>>(
     client: &C,
     hotspot_key: &helium_crypto::PublicKey,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let kta = kta::for_entity_key(hotspot_key).await?;

--- a/helium-lib/src/jupiter.rs
+++ b/helium-lib/src/jupiter.rs
@@ -244,7 +244,7 @@ impl Client {
         input_mint: &Pubkey,
         output_mint: &Pubkey,
         amount: u64,
-        keypair: &dyn Signer,
+        keypair: &(dyn Signer + Sync),
     ) -> Result<(VersionedTransaction, u64, OrderResponse), JupiterError> {
         let order = self
             .order(input_mint, output_mint, amount, &keypair.pubkey())

--- a/helium-lib/src/memo.rs
+++ b/helium-lib/src/memo.rs
@@ -18,7 +18,7 @@ pub async fn memo_message<C: AsRef<SolanaRpcClient>>(
 pub async fn memo<C: AsRef<SolanaRpcClient>>(
     client: &C,
     data: &str,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(transaction::VersionedTransaction, u64), Error> {
     let msg = memo_message(client, data, &keypair.pubkey(), opts).await?;

--- a/helium-lib/src/queue.rs
+++ b/helium-lib/src/queue.rs
@@ -72,7 +72,7 @@ pub async fn claim_wallet<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnch
     client: &C,
     task_queue_key: &Pubkey,
     wallet: &Pubkey,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let task_queue = client.anchor_account(task_queue_key).await?;

--- a/helium-lib/src/reward.rs
+++ b/helium-lib/src/reward.rs
@@ -318,7 +318,7 @@ pub async fn claim<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccou
     token: ClaimableToken,
     amount: Option<u64>,
     encoded_entity_key: &entity_key::EncodedEntityKey,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<Option<(VersionedTransaction, u64)>, Error> {
     let ticket = ClaimTicket::new(encoded_entity_key.to_owned(), amount)?;
@@ -929,7 +929,7 @@ pub mod recipient {
         client: &C,
         token: ClaimableToken,
         entity_key: &E,
-        keypair: &dyn Signer,
+        keypair: &(dyn Signer + Sync),
         opts: &TransactionOpts,
     ) -> Result<(VersionedTransaction, u64), Error> {
         let msg = init_message(client, token, entity_key, &keypair.pubkey(), opts).await?;
@@ -1111,7 +1111,7 @@ pub mod recipient {
             token: ClaimableToken,
             entity_key: &E,
             destination: &Pubkey,
-            keypair: &dyn Signer,
+            keypair: &(dyn Signer + Sync),
             opts: &TransactionOpts,
         ) -> Result<(VersionedTransaction, u64), Error> {
             let msg = update_message(

--- a/helium-lib/src/schedule.rs
+++ b/helium-lib/src/schedule.rs
@@ -102,7 +102,7 @@ pub async fn init<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccoun
     cron_id: u32,
     (schedule, name): (&str, &str),
     fund: Option<u64>,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let task_queue = client.anchor_account(task_queue_key).await?;
@@ -184,7 +184,7 @@ pub async fn requeue<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAcc
     task_queue_key: &Pubkey,
     cron_id: u32,
     name: &str,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let task_queue = client.anchor_account(task_queue_key).await?;
@@ -282,7 +282,7 @@ pub async fn close<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnchorAccou
     cron_job_key: &Pubkey,
     cron_id: u32,
     name: &str,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let cron_job: CronJobV0 = client.anchor_account(cron_job_key).await?;
@@ -353,7 +353,7 @@ pub async fn claim_wallet<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAnch
     client: &C,
     cron_job_key: &Pubkey,
     wallet: &Pubkey,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let cron_job = client.anchor_account(cron_job_key).await?;
@@ -409,7 +409,7 @@ pub async fn claim_asset<C: AsRef<DasClient> + AsRef<SolanaRpcClient> + GetAncho
     client: &C,
     cron_job_key: &Pubkey,
     encoded_entity_key: &EncodedEntityKey,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let cron_job = client.anchor_account(cron_job_key).await?;

--- a/helium-lib/src/token.rs
+++ b/helium-lib/src/token.rs
@@ -102,7 +102,7 @@ pub async fn burn_message<C: AsRef<SolanaRpcClient>>(
 pub async fn burn<C: AsRef<SolanaRpcClient>>(
     client: &C,
     token_amount: &TokenAmount,
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let msg = burn_message(client, token_amount, &keypair.pubkey(), opts).await?;
@@ -181,7 +181,7 @@ pub async fn transfer_message<C: AsRef<SolanaRpcClient>>(
 pub async fn transfer<C: AsRef<SolanaRpcClient>>(
     client: &C,
     transfers: &[(Pubkey, TokenAmount)],
-    keypair: &dyn Signer,
+    keypair: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let msg = transfer_message(client, transfers, &keypair.pubkey(), opts).await?;
@@ -259,8 +259,8 @@ pub async fn close_accounts<C: AsRef<SolanaRpcClient>>(
     client: &C,
     accounts: &[Pubkey],
     destination: &Pubkey,
-    owner: &dyn Signer,
-    fee_payer: &dyn Signer,
+    owner: &(dyn Signer + Sync),
+    fee_payer: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     let msg = close_accounts_message(
@@ -272,7 +272,7 @@ pub async fn close_accounts<C: AsRef<SolanaRpcClient>>(
         opts,
     )
     .await?;
-    let signers: Vec<&dyn Signer> = if fee_payer.pubkey() == owner.pubkey() {
+    let signers: Vec<&(dyn Signer + Sync)> = if fee_payer.pubkey() == owner.pubkey() {
         vec![owner]
     } else {
         vec![fee_payer, owner]
@@ -286,8 +286,8 @@ pub async fn close_account<C: AsRef<SolanaRpcClient>>(
     client: &C,
     account: &Pubkey,
     destination: &Pubkey,
-    owner: &dyn Signer,
-    fee_payer: &dyn Signer,
+    owner: &(dyn Signer + Sync),
+    fee_payer: &(dyn Signer + Sync),
     opts: &TransactionOpts,
 ) -> Result<(VersionedTransaction, u64), Error> {
     close_accounts(client, &[*account], destination, owner, fee_payer, opts).await


### PR DESCRIPTION
## Problem

The async transaction-building functions take `keypair: &dyn Signer`. `dyn Signer` is not `Sync`, so `&dyn Signer` is not `Send`, and any future that holds the reference across an `.await` is itself not `Send`.

That breaks callers driving these futures on a multi-threaded async runtime. A server that `tokio::spawn`s a claim / transfer / swap as a detached task fails to compile:

```
error[E0277]: `dyn helium_lib::keypair::Signer` cannot be shared between threads safely
   = help: the trait `Sync` is not implemented for `dyn ...Signer`
   = note: required for `&dyn ...Signer` to implement `Send`
```

The CLI doesn't hit this because it doesn't spawn the futures onto a multi-threaded executor.

## Fix

Bound the trait-object signer parameters as `&(dyn Signer + Sync)` across the crate (`token`, `reward`, `queue`, `schedule`, `hotspot`, `dc`, `boosting`, `asset`, `memo`, `jupiter`). Concrete signers such as `Keypair` are already `Sync`, so they coerce unchanged and every existing caller is unaffected — the change only restores `Send` on the returned futures.

No behavior change; build, clippy (`--all-features --locked -D warnings`), and `cargo test --locked` all pass.