### PR TITLE
fix(jupiter): exclude RFQ via excludeRouters, not excludeRfq

### DIFF
--- a/helium-lib/src/jupiter.rs
+++ b/helium-lib/src/jupiter.rs
@@ -194,14 +194,19 @@ impl Client {
             ("amount", amount.to_string()),
             ("slippageBps", self.slippage_bps.to_string()),
             ("taker", taker.to_string()),
-            // Exclude RFQ (JupiterZ) routes. Those return maker-co-signed
-            // transactions that must be submitted through Jupiter's execute
-            // endpoint; this client signs only as the taker and broadcasts
-            // via Solana RPC, so it can only complete single-signer
-            // aggregator routes. Measured price difference vs RFQ on
-            // HNT→USDC is within quote noise (≤0.01%), so excluding it
+            // Exclude RFQ (JupiterZ) routes. Those return maker-co-signed,
+            // two-signer transactions that must be submitted through
+            // Jupiter's execute endpoint; this client signs only as the
+            // taker and broadcasts via Solana RPC, so it needs a
+            // single-signer aggregator route. The price difference vs RFQ
+            // on HNT→USDC is within quote noise (≤0.01%), so excluding it
             // costs effectively nothing.
-            ("excludeRfq", "true".to_string()),
+            //
+            // NOTE: the keyed `api.jup.ag` endpoint honors
+            // `excludeRouters=jupiterz` but silently ignores `excludeRfq`;
+            // only the keyless `lite-api` host respects `excludeRfq`. Use
+            // the router exclusion so this works on both.
+            ("excludeRouters", "jupiterz".to_string()),
         ]);
         let resp = self.apply_auth(req).send().await?;
 
@@ -265,7 +270,7 @@ impl Client {
         let mut txn: VersionedTransaction =
             bincode::deserialize(&tx_bytes).map_err(JupiterError::transaction_decode)?;
 
-        // Belt-and-suspenders: `order()` already passes `excludeRfq=true`,
+        // Belt-and-suspenders: `order()` already excludes the RFQ router,
         // but reject any transaction that still needs more than the taker's
         // signature so the failure names the offending signer instead of
         // surfacing an opaque "not enough signers" from `try_new` below.


### PR DESCRIPTION
## Problem

The previous fix passed `excludeRfq=true`, verified only against the keyless `lite-api` host. The keyed `api.jup.ag` endpoint (what production uses) **silently ignores `excludeRfq`** and still returns RFQ (JupiterZ) maker-co-signed, two-signer transactions. So swaps kept drawing RFQ routes and failing the single-signer guard with `swap transaction requires 2 signers, extra: …`.

## Fix

Use `excludeRouters=jupiterz`, which the keyed endpoint honors. Verified against `api.jup.ag` for a ~3,300 HNT order: `router=metis`, `swapType=aggregator`, decoded `numRequiredSignatures=1` — a single-signer (taker-only) transaction the sign-and-send path can complete.

The `MultipleSigners` guard stays as the backstop for any future multi-signer route.

Rate-limit (429) handling is being addressed on the consumer side (the swap orchestration), where a shutdown signal exists to keep any backoff cancellable — a library `order()` call has no signal to honor.