### PR TITLE
fix(format): correct "key shares" typo in shard write error

### DIFF
--- a/helium-wallet/src/format.rs
+++ b/helium-wallet/src/format.rs
@@ -216,7 +216,7 @@ impl Sharded {
 
     pub fn write(&self, writer: &mut dyn io::Write) -> Result {
         if self.key_shares.len() != 1 {
-            bail!("Invalid number of ksy shares in shard");
+            bail!("Invalid number of key shares in shard");
         }
         writer.write_u8(self.key_share_count)?;
         writer.write_u8(self.recovery_threshold)?;


### PR DESCRIPTION
The error raised when a shard carries the wrong number of key shares reads "Invalid number of ksy shares in shard". Corrected "ksy" to "key".

Surfaced from `Sharded::write` in `helium-wallet/src/format.rs`; message-only change, no behavior difference.